### PR TITLE
Potential fix for code scanning alert no. 30: Client-side cross-site scripting

### DIFF
--- a/src/frontend/script.js
+++ b/src/frontend/script.js
@@ -878,15 +878,16 @@ document.addEventListener('DOMContentLoaded', () => {
                 const leadingSpaces = line.match(/^(\s+)/)[1];
                 const trimmed = line.trimStart();
                 
+                const escapedLeadingSpaces = escapeHtml(leadingSpaces);
                 if (trimmed.startsWith('${')) {
                     const varMatch = trimmed.match(/^(\$\{[^}]+\})(\s+)(.+)$/);
                     if (varMatch) {
                         const varName = varMatch[1];
                         const separator = varMatch[2];
                         const varValue = varMatch[3];
-                        highlightedLine = `${leadingSpaces}<span class="rf-variable">${escapeHtml(varName)}</span>${separator}${escapeHtml(varValue)}`;
+                        highlightedLine = `${escapedLeadingSpaces}<span class="rf-variable">${escapeHtml(varName)}</span>${escapeHtml(separator)}${escapeHtml(varValue)}`;
                     } else {
-                        highlightedLine = `${leadingSpaces}<span class="rf-variable">${escapeHtml(trimmed)}</span>`;
+                        highlightedLine = `${escapedLeadingSpaces}<span class="rf-variable">${escapeHtml(trimmed)}</span>`;
                     }
                 } else {
                     const keywordMatch = trimmed.match(/^([^\s]+(?:\s+[^\s]+)*?)(\s{2,}|\t)/);
@@ -896,9 +897,9 @@ document.addEventListener('DOMContentLoaded', () => {
                         const separator = keywordMatch[2];
                         const rest = trimmed.substring(keyword.length + separator.length);
                         const restHighlighted = escapeHtml(rest).replace(/(\$\{[^}]+\})/g, '<span class="rf-variable">$1</span>');
-                        highlightedLine = `${leadingSpaces}<span class="rf-builtin">${escapeHtml(keyword)}</span>${separator}${restHighlighted}`;
+                        highlightedLine = `${escapedLeadingSpaces}<span class="rf-builtin">${escapeHtml(keyword)}</span>${escapeHtml(separator)}${restHighlighted}`;
                     } else {
-                        highlightedLine = `${leadingSpaces}<span class="rf-builtin">${escapeHtml(trimmed)}</span>`;
+                        highlightedLine = `${escapedLeadingSpaces}<span class="rf-builtin">${escapeHtml(trimmed)}</span>`;
                     }
                 }
             } else if (line.includes('${') && !line.match(/^\s+\$/)) {


### PR DESCRIPTION
Potential fix for [https://github.com/monkscode/Natural-Language-to-Robot-Framework/security/code-scanning/30](https://github.com/monkscode/Natural-Language-to-Robot-Framework/security/code-scanning/30)

The code must ensure that any content derived from the user's clipboard, including whitespace (`leadingSpaces`), is safely encoded before insertion into HTML (whether via `innerHTML` or string concatenation in template literals). The correct approach is to explicitly escape all values that are inserted as part of an HTML string, including whitespace, variable names, values, and any other code fragments. Concretely, in `applySyntaxHighlighting`, any time a value originates from user input and is used in a string that will be inserted as HTML, it should be run through the `escapeHtml` function before inclusion.  
Update the handling for `leadingSpaces` and any similar code constructs.  
All changes occur in the file `src/frontend/script.js`:  
- In `applySyntaxHighlighting`, ensure that every variable—especially `leadingSpaces`—which can contain user input, is escaped via `escapeHtml` before including in the HTML string.  
- No new methods/imports are required, as `escapeHtml` exists.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced security for code snippet rendering by improving how whitespace and special characters are displayed in syntax highlighting, ensuring code snippets render safely without display issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->