### PR TITLE
Potential fix for code scanning alert no. 24: Information exposure through an exception

### DIFF
--- a/src/backend/api/endpoints.py
+++ b/src/backend/api/endpoints.py
@@ -88,7 +88,8 @@ async def docker_status_endpoint():
         status = get_docker_status(client)
         return status
     except ConnectionError as e:
-        return {"status": "error", "docker_available": False, "error": str(e)}
+        logging.error(f"Docker connection error: {e}")
+        return {"status": "error", "docker_available": False, "error": "Docker is unavailable."}
     except Exception as e:
         logging.error("Unexpected error in /docker-status endpoint", exc_info=True)
         return {"status": "error", "docker_available": False, "error": "An unexpected error occurred."}


### PR DESCRIPTION
Potential fix for [https://github.com/monkscode/Natural-Language-to-Robot-Framework/security/code-scanning/24](https://github.com/monkscode/Natural-Language-to-Robot-Framework/security/code-scanning/24)

To fix the problem, the endpoint should avoid returning the exception message to the user. Instead, it should log the detailed error on the server and return a generic error message in the response. Specifically, change line 91 in the `/docker-status` endpoint so that the `"error"` field does not include `str(e)` but rather a standard string like `"Docker is unavailable"`, ensuring users do not receive potentially sensitive information. Additionally, keep sufficient logging on the backend for debugging purposes. No changes to imports are necessary as `logging` is already present.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved error messaging for Docker connection failures. The system now displays a user-friendly generic message instead of exposing technical error details, enhancing usability and security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->