### PR TITLE
feat: Update model provider options and add Vertex AI setup guide

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,4 @@ docs/tasks/
 tasks/*
 logs/crewai.log.txt
 CLAUDE.md
+credentials.json

--- a/docker-compose.vertex.yml
+++ b/docker-compose.vertex.yml
@@ -1,0 +1,46 @@
+# Docker Compose override for Google Cloud Vertex AI authentication.
+#
+# Use this file alongside the base docker-compose.yml when MODEL_PROVIDER=vertex
+# is set in src/backend/.env. It mounts the service account JSON key into the
+# container and sets VERTEXAI_CREDENTIALS, which is the env var LiteLLM reads
+# to locate the key file. This passes the file path directly into LiteLLM's
+# vertex auth layer, which then uses google.oauth2.service_account to load it
+# — bypassing google.auth.default() and GOOGLE_APPLICATION_CREDENTIALS entirely.
+#
+# Usage:
+#   docker compose -f docker-compose.yml -f docker-compose.vertex.yml up -d
+#
+# Prerequisites:
+#   1. Place your service account key at ./credentials.json (repo root)
+#   2. Ensure credentials.json is in .gitignore (it already is)
+#   3. Set MODEL_PROVIDER=vertex in src/backend/.env
+#   4. Set VERTEXAI_PROJECT and VERTEXAI_LOCATION in src/backend/.env
+#
+# See docs/VERTEX_AI_SETUP_GUIDE.md for full setup instructions.
+
+services:
+  fastapi:
+    volumes:
+      - ./credentials.json:/app/credentials.json:ro
+    environment:
+      # LiteLLM reads VERTEXAI_CREDENTIALS to pass the key path directly to its
+      # vertex auth layer (load_auth → _credentials_from_service_account).
+      # GOOGLE_APPLICATION_CREDENTIALS is NOT needed here — that var is only
+      # used by google.auth.default(), which is never called when this is set.
+      - VERTEXAI_CREDENTIALS=/app/credentials.json
+
+  browser-service:
+    volumes:
+      - ./credentials.json:/app/credentials.json:ro
+    environment:
+      # browser-service reads VERTEXAI_CREDENTIALS at startup and loads it via
+      # google.oauth2.service_account.Credentials.from_service_account_file().
+      # The resulting Credentials object is cached on config.llm.vertexai_credentials
+      # and passed to ChatGoogle(credentials=...) for each workflow — no file I/O
+      # per request. Token refresh is handled automatically by google-auth.
+      #
+      # MODEL_PROVIDER, VERTEXAI_PROJECT, and VERTEXAI_LOCATION reach this container
+      # via env_file: ./src/backend/.env in docker-compose.yml (line 64).
+      # Only VERTEXAI_CREDENTIALS needs to be overridden here because the .env value
+      # is a relative path (credentials.json) that is invalid inside the container.
+      - VERTEXAI_CREDENTIALS=/app/credentials.json

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -386,11 +386,12 @@ webui --> user : 33. Display results\n+ report links
 
 7. **LLM Integration** ✅
    - ✅ **Supported Providers**:
-     - Google Gemini: `gemini/gemini-2.5-flash` (default)
+     - Google Gemini (AI Studio): `gemini/gemini-2.5-flash` (default)
+     - Google Vertex AI: `vertex_ai/gemini-2.5-flash`
      - Ollama: Local models (e.g., `llama3`)
    - ✅ **Configuration**: 
-     - `MODEL_PROVIDER` ("online" or "local")
-     - `GEMINI_API_KEY` (for online)
+     - `MODEL_PROVIDER` ("gemini", "vertex", or "local")
+     - `GEMINI_API_KEY` (for gemini provider)
      - `ONLINE_MODEL` / `LOCAL_MODEL`
    - ✅ **Rate Limiting**: REMOVED - Gemini API has sufficient limits (1500 RPM)
    - ✅ **Output Cleaning**: `get_cleaned_llm()` wrapper for robust parsing

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -23,18 +23,19 @@ nano src/backend/.env  # or use your preferred editor
 Controls which AI provider to use.
 
 ```env
-MODEL_PROVIDER=online  # or 'local'
+MODEL_PROVIDER=gemini  # or 'vertex' or 'local'
 ```
 
 **Options:**
-- `online` - Use cloud-based models (Google Gemini)
-- `local` - Use locally hosted models (Ollama)
+- `gemini` - Google AI Studio (requires `GEMINI_API_KEY`)
+- `vertex` - Google Cloud Vertex AI (requires service account credentials)
+- `local` - Locally hosted models via Ollama
 
-**Recommendation:** Use `online` for best results and performance.
+**Recommendation:** Use `gemini` for development, `vertex` for production/Docker.
 
 ### GEMINI_API_KEY
 
-Your Google Gemini API key (required for online mode).
+Your Google Gemini API key (required for `MODEL_PROVIDER=gemini`).
 
 ```env
 GEMINI_API_KEY=your-actual-api-key-here
@@ -50,7 +51,7 @@ GEMINI_API_KEY=your-actual-api-key-here
 
 ### ONLINE_MODEL
 
-Which Gemini model to use.
+Which model to use (bare name — the provider prefix is added automatically based on `MODEL_PROVIDER`).
 
 ```env
 ONLINE_MODEL=gemini-2.5-flash
@@ -58,8 +59,8 @@ ONLINE_MODEL=gemini-2.5-flash
 
 **Available Models:**
 - `gemini-2.5-flash` - Fast, accurate (recommended)
-- `gemini-1.5-pro-latest` - More powerful, slower
-- `gemini-1.5-flash` - Balanced performance
+- `gemini-2.0-flash` - Faster, slightly less capable
+- `gemini-1.5-pro` - More powerful, slower
 
 **Recommendation:** Use `gemini-2.5-flash` for best speed/accuracy balance.
 
@@ -302,7 +303,7 @@ TEMPERATURE=0.1
 
 ```env
 # AI Provider
-MODEL_PROVIDER=online
+MODEL_PROVIDER=gemini
 GEMINI_API_KEY=your-production-key
 ONLINE_MODEL=gemini-2.5-flash
 
@@ -363,7 +364,7 @@ LOG_LEVEL=INFO
 
 ```env
 # AI Provider
-MODEL_PROVIDER=online
+MODEL_PROVIDER=gemini
 GEMINI_API_KEY=your-key
 ONLINE_MODEL=gemini-2.5-flash
 
@@ -394,7 +395,8 @@ Mark 1 validates configuration on startup. Common validation errors:
 - Recommended: Use 'browser' for best performance
 
 ### "Invalid MODEL_PROVIDER"
-- Must be 'online' or 'local'
+- Must be `gemini`, `vertex`, or `local` (lowercase)
+- The old value `online` is no longer accepted — use `gemini` instead
 - Check spelling
 
 ## Environment-Specific Configuration
@@ -426,7 +428,7 @@ Set environment variables in your CI/CD platform:
 **GitHub Actions:**
 ```yaml
 env:
-  MODEL_PROVIDER: online
+  MODEL_PROVIDER: gemini
   GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
   ONLINE_MODEL: gemini-2.5-flash
 ```
@@ -434,7 +436,7 @@ env:
 **GitLab CI:**
 ```yaml
 variables:
-  MODEL_PROVIDER: "online"
+  MODEL_PROVIDER: "gemini"
   ONLINE_MODEL: "gemini-2.5-flash"
 ```
 

--- a/docs/DOCKER-GUIDE.md
+++ b/docs/DOCKER-GUIDE.md
@@ -150,8 +150,8 @@ GEMINI_API_KEY=your_api_key_here
 
 # Everything below has sensible defaults — you don't need to change these to get started.
 
-MODEL_PROVIDER=online
-ONLINE_MODEL=gemini/gemini-2.5-flash
+MODEL_PROVIDER=gemini
+ONLINE_MODEL=gemini-2.5-flash
 
 ROBOT_LIBRARY=browser       # Use Playwright-based tests (recommended)
 BROWSER_HEADLESS=true       # Run browser in background (no visible window)
@@ -337,9 +337,9 @@ All settings below go in `src/backend/.env`. Only `GEMINI_API_KEY` is required t
 
 | Variable | Default | Description |
 |---|---|---|
-| `MODEL_PROVIDER` | `online` | `online` to use Gemini, `local` to use Ollama |
-| `ONLINE_MODEL` | `gemini/gemini-2.5-flash` | Which Gemini model to use |
-| `GEMINI_API_KEY` | — | **Required for online mode.** Your Google AI Studio key |
+| `MODEL_PROVIDER` | `gemini` | `gemini` (Google AI Studio), `vertex` (Vertex AI), or `local` (Ollama) |
+| `ONLINE_MODEL` | `gemini-2.5-flash` | Bare model name — provider prefix added automatically |
+| `GEMINI_API_KEY` | — | **Required for `MODEL_PROVIDER=gemini`.** Your Google AI Studio key |
 | `LOCAL_MODEL` | `qwen2.5-coder:14b` | Which Ollama model to use (local mode only) |
 | `OLLAMA_API_BASE` | `http://localhost:11434` | URL of your Ollama server |
 

--- a/docs/LIBRARY_SWITCHING_GUIDE.md
+++ b/docs/LIBRARY_SWITCHING_GUIDE.md
@@ -71,7 +71,7 @@ Close Browser
 
 ```env
 # AI Provider
-MODEL_PROVIDER=online              # or "local"
+MODEL_PROVIDER=gemini              # or "vertex" or "local"
 GEMINI_API_KEY=your-key-here      # Get from https://aistudio.google.com/app/apikey
 ONLINE_MODEL=gemini-2.5-flash     # Fast and accurate
 

--- a/docs/VERTEX_AI_SETUP_GUIDE.md
+++ b/docs/VERTEX_AI_SETUP_GUIDE.md
@@ -1,0 +1,168 @@
+# Google Cloud Vertex AI: Authentication & Setup Guide
+
+This guide explains how to authenticate and use Google Cloud Vertex AI (Gemini) locally and within Docker containers. It also covers how to bypass the "Secure by Default" Organization Policy that blocks Service Account JSON key creation.
+
+---
+
+## 1. Initial Setup (Local Machine)
+
+Before interacting with Vertex AI, you need the Google Cloud CLI installed:
+
+1. **Install gcloud CLI:** [Download link](https://cloud.google.com/sdk/docs/install)
+2. **Initialize gcloud:** Open a terminal and run:
+   ```bash
+   gcloud init
+   ```
+   *Log in with your Google account and select your active project (e.g., `project-1434b01c-dc17-4123-ba3`).*
+3. **Enable Vertex AI API:** Ensure the API is active for your project:
+   ```bash
+   gcloud services enable aiplatform.googleapis.com --project=project-1434b01c-dc17-4123-ba3
+   ```
+
+---
+
+## 2. Local Development Login (ADC)
+
+For quick local development (running scripts directly on your machine without Docker), use **Application Default Credentials (ADC)**. 
+
+Run this command to authenticate:
+```bash
+gcloud auth application-default login
+```
+* **How it works:** This downloads a local JSON file (usually to `%APPDATA%\gcloud\application_default_credentials.json` on Windows) containing a refresh token.
+* **Limitations for Docker/Production:** The access tokens expire every 60 minutes (the SDK auto-refreshes them), but the underlying refresh token itself can expire depending on your Workspace session controls (e.g., every 14 days), requiring manual re-login.
+
+---
+
+## 3. Creating a Permanent Service Account (For Docker)
+
+To avoid manual logins inside Docker containers, you need a dedicated **Service Account** with a long-lived JSON key that never expires.
+
+**Step 3.1: Create the Service Account**
+```bash
+gcloud iam service-accounts create vertex-ai-sa \
+    --display-name="Vertex AI Service Account" \
+    --project=project-1434b01c-dc17-4123-ba3
+```
+
+**Step 3.2: Grant Permissions**
+Give the account the required `roles/aiplatform.user` role:
+```bash
+gcloud projects add-iam-policy-binding project-1434b01c-dc17-4123-ba3 \
+    --member="serviceAccount:vertex-ai-sa@project-1434b01c-dc17-4123-ba3.iam.gserviceaccount.com" \
+    --role="roles/aiplatform.user"
+```
+
+---
+
+## 4. Overcoming the "Secure by Default" JSON Key Block
+
+Google Workspace automatically locks down Organization security, preventing even Project Owners from generating Service Account JSON keys. This policy is called `constraints/iam.disableServiceAccountKeyCreation`.
+
+**The Symptom (Console "View Policy" Issue):** 
+If your `gcloud iam service-accounts keys create` command fails with a **FAILED_PRECONDITION** error, you might try to go to the Google Cloud Console -> Organization Policies to turn it off. However, you might find that you only see a **"View policy"** option without an "Edit" or "Manage" button. 
+
+This happens because being a "Project Owner" or even an "Organization Admin" does not automatically grant you the rights to edit security policies. You specifically need the `roles/orgpolicy.policyAdmin` role.
+
+Follow these exact terminal commands to investigate and fix this issue:
+
+**Step 4.1: Identify your Organization ID and Active Account**
+First, find out the Organization ID your project belongs to, and verify your current logged-in email.
+```bash
+# Get your active account email
+gcloud config get-value account
+
+# Find the parent Organization ID of your project
+gcloud projects describe project-1434b01c-dc17-4123-ba3
+# Look for the 'parent.id' value in the output (e.g., 396743985220)
+```
+
+**Step 4.2: Verify your Current Organization Permissions (Optional)**
+You can verify why you are blocked in the console by listing the IAM policy of the organization and seeing that `roles/orgpolicy.policyAdmin` is missing for your email:
+```bash
+gcloud organizations get-iam-policy 396743985220
+```
+
+**Step 4.3: Grant Yourself Organization Policy Admin Role**
+Elevate your own user account so you have the authority to edit the policy. Replace the email and Org ID with yours. *(Note: You must be an Organization Admin/Owner at the top level to assign this role to yourself).*
+```bash
+gcloud organizations add-iam-policy-binding 396743985220 \
+    --member="user:YOUR_EMAIL@gmail.com" \
+    --role="roles/orgpolicy.policyAdmin"
+```
+
+**Step 4.4: Disable the Blocking Constraint**
+Now that you have the correct permissions, use the CLI to turn off the security lock at both the Organization and Project levels:
+```bash
+# Disable at Org Level
+gcloud resource-manager org-policies disable-enforce constraints/iam.disableServiceAccountKeyCreation --organization=396743985220
+
+# Disable at Project Level
+gcloud resource-manager org-policies disable-enforce constraints/iam.disableServiceAccountKeyCreation --project=project-1434b01c-dc17-4123-ba3
+```
+*Note: Wait 2-3 minutes for the policy change to propagate across Google's global servers before proceeding.*
+
+---
+
+## 5. Download the Infinite JSON Key
+
+Once the policy block is removed, generate your permanent `credentials.json` file:
+```bash
+gcloud iam service-accounts keys create credentials.json \
+    --iam-account=vertex-ai-sa@project-1434b01c-dc17-4123-ba3.iam.gserviceaccount.com \
+    --project=project-1434b01c-dc17-4123-ba3
+```
+* **Lifespan:** This JSON key will work indefinitely ("until infinity"). It never requires a manual refresh or re-login.
+* **⚠️ MASSIVE SECURITY WARNING:** Do not **EVER** commit this file to Git. Malicious bots scrape GitHub for these JSON files to steal compute resources. **Immediately add `credentials.json` to your `.gitignore`.**
+
+---
+
+## 6. Using the JSON Key in Docker
+
+This project uses LiteLLM as its LLM transport layer. LiteLLM reads `VERTEXAI_CREDENTIALS` (not `GOOGLE_APPLICATION_CREDENTIALS`) to locate the service account key file. When set, it passes the file path directly to `google.oauth2.service_account` — bypassing `google.auth.default()` entirely.
+
+**Standard Docker Run:**
+```bash
+docker run -d \
+  -e VERTEXAI_CREDENTIALS=/app/credentials.json \
+  -v $(pwd)/credentials.json:/app/credentials.json:ro \
+  my-docker-image
+```
+
+**Docker Compose (recommended approach):**
+
+This project ships a dedicated override file for Vertex AI. Instead of editing `docker-compose.yml`, use the override file — no commenting/uncommenting required:
+
+```bash
+# Place credentials.json in the repo root, then:
+docker compose -f docker-compose.yml -f docker-compose.vertex.yml up -d
+```
+
+`docker-compose.vertex.yml` mounts the credentials file and sets `VERTEXAI_CREDENTIALS` only when you explicitly include it. The base `docker-compose.yml` stays clean for users on other providers.
+
+---
+
+## 7. Python Implementation Example
+
+When using the `google-genai` SDK, specify `vertexai=True` and provide the exact project IDs and geographic location. Do **not** hardcode passwords or paths here; the SDK will automatically pick up the credentials from the `VERTEXAI_CREDENTIALS` environment variable read by LiteLLM, or from `GOOGLE_APPLICATION_CREDENTIALS` if using the Google SDK directly.
+
+```python
+from google import genai
+
+# Initialize the Vertex AI client
+# Authentication is handled automatically via VERTEXAI_CREDENTIALS (LiteLLM) or ADC
+client = genai.Client(
+    vertexai=True,
+    project="project-1434b01c-dc17-4123-ba3",
+    location="asia-south1"  # "asia-south1" maps to Mumbai, India
+)
+
+try:
+    response = client.models.generate_content(
+        model="gemini-2.5-flash",
+        contents="Explain how Service Accounts work in Google Cloud.",
+    )
+    print(response.text)
+except Exception as e:
+    print(f"Vertex AI Error: {e}")
+```

--- a/src/backend/.env.example
+++ b/src/backend/.env.example
@@ -1,10 +1,14 @@
-# The model provider to use. Can be "online" or "local".
-MODEL_PROVIDER=online
+# The model provider to use.
+#   "gemini"  — Google AI Studio API key (recommended for development)
+#   "vertex"  — Google Cloud Vertex AI service account (recommended for production/Docker)
+#   "local"   — Ollama local model server
+MODEL_PROVIDER=vertex
 
-# The online model to use (e.g., "gemini-1.5-flash", "gemini-2.0-flash-exp").
-# This is only used if MODEL_PROVIDER is "online".
-# Note: Use model name WITHOUT "gemini/" prefix for LiteLLM
-ONLINE_MODEL=gemini/gemini-2.5-flash
+# The online model to use (e.g., "gemini-2.5-flash", "gemini-2.0-flash").
+# This is only used if MODEL_PROVIDER is "gemini" or "vertex".
+# Use the bare model name — the provider prefix (gemini/ or vertex_ai/) is
+# added automatically based on MODEL_PROVIDER.
+ONLINE_MODEL=gemini-2.5-flash
 
 # The local model to use with Ollama (e.g., "qwen2.5-coder:14b").
 # This is only used if MODEL_PROVIDER is "local".
@@ -24,9 +28,24 @@ BROWSER_USE_SERVICE_URL=http://localhost:4999
 # Default: true
 BROWSER_HEADLESS=true
 
-# --- Gemini Configuration ---
-# Your Google Gemini API key. This is required if MODEL_PROVIDER is "online".
+# --- Gemini Configuration (only used if MODEL_PROVIDER=gemini) ---
+# Your Google Gemini API key.
 GEMINI_API_KEY=
+
+# --- Vertex AI Configuration (only used if MODEL_PROVIDER=vertex) ---
+# Google Cloud project ID (e.g., my-gcp-project-123)
+VERTEXAI_PROJECT=
+
+# Google Cloud region where your Vertex AI endpoint is deployed
+# Examples: us-central1, asia-south1 (Mumbai), europe-west1
+VERTEXAI_LOCATION=
+
+# Path to your Google Cloud service account JSON key file.
+# This is the env var LiteLLM reads to locate the key and authenticate with Vertex AI.
+# Local dev:  relative path from repo root (e.g., credentials.json)
+# Docker:     set to the container path via docker-compose.vertex.yml (do not set here for Docker)
+# NEVER commit this file to Git — credentials.json is already in .gitignore
+VERTEXAI_CREDENTIALS=credentials.json
 
 # --- Ollama Configuration (only used if MODEL_PROVIDER is "local") ---
 # URL of the Ollama HTTP API server.

--- a/src/backend/api/endpoints.py
+++ b/src/backend/api/endpoints.py
@@ -33,9 +33,9 @@ async def generate_test_only(query: Query):
         raise HTTPException(status_code=400, detail="Query not provided")
 
     model_provider = settings.MODEL_PROVIDER
-    model_name = settings.ONLINE_MODEL if model_provider == "online" else settings.LOCAL_MODEL
+    model_name = settings.ONLINE_MODEL if model_provider in ("gemini", "vertex") else settings.LOCAL_MODEL
 
-    if model_provider == "online" and not settings.GEMINI_API_KEY:
+    if model_provider == "gemini" and not settings.GEMINI_API_KEY:
         raise HTTPException(status_code=500, detail="GEMINI_API_KEY environment variable is not set.")
 
     logging.info(f"[GENERATE ONLY] Using {model_provider} model provider: {model_name}")
@@ -84,9 +84,9 @@ async def generate_and_run_streaming(query: Query):
         raise HTTPException(status_code=400, detail="Query not provided")
 
     model_provider = settings.MODEL_PROVIDER
-    model_name = settings.ONLINE_MODEL if model_provider == "online" else settings.LOCAL_MODEL
+    model_name = settings.ONLINE_MODEL if model_provider in ("gemini", "vertex") else settings.LOCAL_MODEL
 
-    if model_provider == "online" and not settings.GEMINI_API_KEY:
+    if model_provider == "gemini" and not settings.GEMINI_API_KEY:
         raise HTTPException(status_code=500, detail="GEMINI_API_KEY environment variable is not set.")
 
     logging.info(f"[GENERATE AND RUN] Using {model_provider} model provider: {model_name}")

--- a/src/backend/core/config.py
+++ b/src/backend/core/config.py
@@ -10,10 +10,21 @@ load_dotenv("src/backend/.env")
 
 class Settings(BaseSettings):
     # LLM Configuration
-    MODEL_PROVIDER: str = "online"  # "online" for Gemini, "local" for Ollama
+    # MODEL_PROVIDER controls which LLM backend is used:
+    #   "vertex"  — Google Cloud Vertex AI (requires VERTEXAI_CREDENTIALS,
+    #               VERTEXAI_PROJECT, VERTEXAI_LOCATION)
+    #   "gemini"  — Google AI Studio (requires GEMINI_API_KEY)
+    #   "local"   — Ollama (requires a running Ollama server)
+    MODEL_PROVIDER: str = "vertex"
     GEMINI_API_KEY: str | None = None
-    ONLINE_MODEL: str = "gemini/gemini-2.5-flash"
+    ONLINE_MODEL: str = "gemini-2.5-flash"
     LOCAL_MODEL: str = "llama3"
+
+    # Vertex AI Configuration (only required when MODEL_PROVIDER=vertex)
+    # VERTEXAI_CREDENTIALS is the env var LiteLLM reads to locate the service account
+    # key file. Set it in .env (local dev) or via docker-compose.vertex.yml (Docker).
+    VERTEXAI_PROJECT: str | None = None
+    VERTEXAI_LOCATION: str | None = None
     
     # Note: SECONDS_BETWEEN_API_CALLS was removed during Phase 2 of codebase cleanup.
     # Rate limiting is no longer implemented as Google Gemini API has sufficient
@@ -50,6 +61,13 @@ class Settings(BaseSettings):
     
     # Learning System Configuration (Adaptive Learning — Phase 1+)
     EXECUTION_MEMORY_DB: str = Field(default="./data/execution_memory.db", description="Path to execution memory SQLite database for the learning system")
+
+    @validator('MODEL_PROVIDER')
+    def validate_model_provider(cls, v):
+        """Validate that MODEL_PROVIDER is one of the supported providers."""
+        if v.lower() not in ['gemini', 'vertex', 'local']:
+            raise ValueError(f"MODEL_PROVIDER must be 'gemini', 'vertex', or 'local', got '{v}'")
+        return v.lower()
 
     @validator('ROBOT_LIBRARY')
     def validate_robot_library(cls, v):

--- a/src/backend/crew_ai/agents.py
+++ b/src/backend/crew_ai/agents.py
@@ -28,7 +28,7 @@ class RobotAgents:
         Initialize Robot Framework agents.
 
         Args:
-            model_provider: "local" or "online"
+            model_provider: "local", "gemini", or "vertex"
             model_name: Model identifier
             library_context: LibraryContext instance (optional, for dynamic keyword knowledge)
             keyword_search_tool: KeywordSearchTool instance (optional, added to code assembler tools)

--- a/src/backend/crew_ai/cleaned_llm_wrapper.py
+++ b/src/backend/crew_ai/cleaned_llm_wrapper.py
@@ -2,8 +2,12 @@
 LLM Wrapper - LLM instantiation with output cleaning for CrewAI agents.
 
 This module provides a single CleanedLLMWrapper that works for all providers:
-- Online models (Gemini): model="gemini/gemini-2.5-flash"
-- Local  models (Ollama): model="ollama/<model_name>"
+- Gemini  models (Google AI Studio): model="gemini/gemini-2.5-flash"   (prefix added by get_llm())
+- Vertex  models (Google Cloud):     model="vertex_ai/gemini-2.5-flash" (prefix added by get_llm())
+- Local   models (Ollama):           model="ollama/<model_name>"         (prefix added by get_llm())
+
+Callers always pass bare model names (e.g. "gemini-2.5-flash") via ONLINE_MODEL.
+get_llm() derives the LiteLLM-routable string based on MODEL_PROVIDER.
 
 The wrapper intercepts every LLM call via call() to apply Action/ActionInput
 cleaning and rate-limit retry logic, then delegates to LiteLLM for the actual
@@ -217,8 +221,15 @@ def get_llm(model_provider: str, model_name: str, api_key: Optional[str] = None)
     Get a CleanedLLMWrapper instance for the given provider and model.
 
     Works for all LiteLLM-supported providers via a single wrapper class:
-    - Online (Gemini):  model_provider="online", model_name="gemini/gemini-2.5-flash"
-    - Local  (Ollama):  model_provider="local",  model_name="qwen2.5-coder:14b"
+    - Gemini  (Google AI Studio):  model_provider="gemini", model_name="gemini-2.5-flash"
+    - Vertex  (Google Cloud):      model_provider="vertex", model_name="gemini-2.5-flash"
+    - Local   (Ollama):            model_provider="local",  model_name="qwen2.5-coder:14b"
+
+    model_name is always the bare model name (no provider prefix). This function
+    derives the correct LiteLLM-routable string automatically:
+        gemini  → "gemini/gemini-2.5-flash"
+        vertex  → "vertex_ai/gemini-2.5-flash"
+        local   → "ollama/qwen2.5-coder:14b"
 
     The returned instance:
     - Calls LiteLLM under the hood (__new__ override bypasses CrewAI's native
@@ -229,13 +240,12 @@ def get_llm(model_provider: str, model_name: str, api_key: Optional[str] = None)
     - Tracks all responses via formatting_monitor
 
     Args:
-        model_provider: "local" for Ollama, "online" for Gemini/other API models
-        model_name: Model identifier.
-                    Online: include provider prefix (e.g. "gemini/gemini-2.5-flash")
-                    Local:  bare model name (e.g. "qwen2.5-coder:14b") — "ollama/"
-                            is prepended here so callers stay provider-agnostic.
-        api_key: API key for online models (optional, falls back to GEMINI_API_KEY
-                 env var). Not used for local Ollama models.
+        model_provider: "gemini" for Google AI Studio, "vertex" for Vertex AI,
+                        "local" for Ollama.
+        model_name: Bare model name without provider prefix (e.g. "gemini-2.5-flash",
+                    "qwen2.5-coder:14b"). The provider prefix is prepended here.
+        api_key: API key for Gemini models (optional, falls back to GEMINI_API_KEY
+                 env var). Not used for Vertex AI or local Ollama models.
 
     Returns:
         CleanedLLMWrapper instance ready for use with CrewAI agents
@@ -259,13 +269,31 @@ def get_llm(model_provider: str, model_name: str, api_key: Optional[str] = None)
             num_retries=3,    # LiteLLM internal retry for transient API errors.
         )
 
-    # Online provider (Gemini and future API-based models).
+    if model_provider == "vertex":
+        # model_name is a bare model name (e.g. "gemini-2.5-flash"); prepend vertex_ai/.
+        # Strip any accidental provider prefix for backwards compatibility.
+        # Auth is handled automatically: VERTEXAI_CREDENTIALS, VERTEXAI_PROJECT,
+        # and VERTEXAI_LOCATION are read from os.environ by LiteLLM (loaded via python-dotenv).
+        model_bare = model_name.split("/", 1)[-1] if "/" in model_name else model_name
+        vertex_model = f"vertex_ai/{model_bare}"
+        logger.info(f"🧹 Creating CleanedLLMWrapper for Vertex AI model: {vertex_model}")
+        return CleanedLLMWrapper(
+            model=vertex_model,
+            num_retries=3,
+            is_litellm=True,
+        )
+
+    # Gemini provider (Google AI Studio).
+    # model_name is a bare model name (e.g. "gemini-2.5-flash"); prepend gemini/.
+    # Strip any accidental provider prefix for backwards compatibility.
     # is_litellm=True has no routing effect — CleanedLLMWrapper.__new__ bypasses
     # LLM.__new__ entirely. Kept for documentation clarity only.
-    logger.info(f"🧹 Creating CleanedLLMWrapper for model: {model_name}")
+    model_bare = model_name.split("/", 1)[-1] if "/" in model_name else model_name
+    gemini_model = f"gemini/{model_bare}"
+    logger.info(f"🧹 Creating CleanedLLMWrapper for Gemini model: {gemini_model}")
     return CleanedLLMWrapper(
         api_key=api_key or os.getenv("GEMINI_API_KEY"),
-        model=model_name,
+        model=gemini_model,
         num_retries=3,    # LiteLLM internal retry for transient API errors (429, 503, etc.)
         is_litellm=True,
     )

--- a/src/backend/crew_ai/cleaned_llm_wrapper.py
+++ b/src/backend/crew_ai/cleaned_llm_wrapper.py
@@ -241,7 +241,7 @@ def get_llm(model_provider: str, model_name: str, api_key: Optional[str] = None)
 
     Args:
         model_provider: "gemini" for Google AI Studio, "vertex" for Vertex AI,
-                        "local" for Ollama.
+                        "local" for Ollama. Any other value raises ValueError.
         model_name: Bare model name without provider prefix (e.g. "gemini-2.5-flash",
                     "qwen2.5-coder:14b"). The provider prefix is prepended here.
         api_key: API key for Gemini models (optional, falls back to GEMINI_API_KEY
@@ -249,6 +249,9 @@ def get_llm(model_provider: str, model_name: str, api_key: Optional[str] = None)
 
     Returns:
         CleanedLLMWrapper instance ready for use with CrewAI agents
+
+    Raises:
+        ValueError: If model_provider is not one of: "gemini", "vertex", "local".
     """
     if model_provider == "local":
         # LiteLLM routes "ollama/<model>" to the Ollama HTTP API.
@@ -283,17 +286,24 @@ def get_llm(model_provider: str, model_name: str, api_key: Optional[str] = None)
             is_litellm=True,
         )
 
-    # Gemini provider (Google AI Studio).
-    # model_name is a bare model name (e.g. "gemini-2.5-flash"); prepend gemini/.
-    # Strip any accidental provider prefix for backwards compatibility.
-    # is_litellm=True has no routing effect — CleanedLLMWrapper.__new__ bypasses
-    # LLM.__new__ entirely. Kept for documentation clarity only.
-    model_bare = model_name.split("/", 1)[-1] if "/" in model_name else model_name
-    gemini_model = f"gemini/{model_bare}"
-    logger.info(f"🧹 Creating CleanedLLMWrapper for Gemini model: {gemini_model}")
-    return CleanedLLMWrapper(
-        api_key=api_key or os.getenv("GEMINI_API_KEY"),
-        model=gemini_model,
-        num_retries=3,    # LiteLLM internal retry for transient API errors (429, 503, etc.)
-        is_litellm=True,
+    if model_provider == "gemini":
+        # Gemini provider (Google AI Studio).
+        # model_name is a bare model name (e.g. "gemini-2.5-flash"); prepend gemini/.
+        # Strip any accidental provider prefix for backwards compatibility.
+        # is_litellm=True has no routing effect — CleanedLLMWrapper.__new__ bypasses
+        # LLM.__new__ entirely. Kept for documentation clarity only.
+        model_bare = model_name.split("/", 1)[-1] if "/" in model_name else model_name
+        gemini_model = f"gemini/{model_bare}"
+        logger.info(f"🧹 Creating CleanedLLMWrapper for Gemini model: {gemini_model}")
+        return CleanedLLMWrapper(
+            api_key=api_key or os.getenv("GEMINI_API_KEY"),
+            model=gemini_model,
+            num_retries=3,    # LiteLLM internal retry for transient API errors (429, 503, etc.)
+            is_litellm=True,
+        )
+
+    raise ValueError(
+        f"Unsupported model_provider: '{model_provider}'. "
+        f"Must be one of: 'gemini', 'vertex', 'local'. "
+        f"Check your MODEL_PROVIDER environment variable."
     )

--- a/src/backend/crew_ai/crew.py
+++ b/src/backend/crew_ai/crew.py
@@ -102,7 +102,7 @@ def run_crew(query: str, model_provider: str, model_name: str, library_type: str
 
     Args:
         query: User's natural language test description
-        model_provider: "local" or "online"
+        model_provider: "local", "gemini", or "vertex"
         model_name: Model identifier
         library_type: "selenium" or "browser" (optional, defaults to config setting)
         workflow_id: Unique workflow identifier for metrics tracking
@@ -145,10 +145,20 @@ def run_crew(query: str, model_provider: str, model_name: str, library_type: str
     baseline_context_tokens = 0
     optimized_context_tokens = 0
     
-    # Build properly prefixed model name for LiteLLM token counting
-    # Online models already have prefix (e.g., "gemini/gemini-2.5-flash")
-    # Local models need prefix added (e.g., "llama3" -> "ollama/llama3")
-    token_model = model_name if model_provider != "local" else f"ollama/{model_name}"
+    # Build properly prefixed model name for LiteLLM token counting.
+    # The token_model must match the model string passed to LiteLLM by get_llm(),
+    # because LiteLLM's model cost database has separate entries per provider prefix
+    # (e.g. gemini/ vs vertex_ai/ have different pricing).
+    if model_provider == "local":
+        token_model = f"ollama/{model_name}"
+    elif model_provider == "vertex":
+        model_bare = model_name.split("/", 1)[-1] if "/" in model_name else model_name
+        token_model = f"vertex_ai/{model_bare}"
+    else:
+        # Gemini provider: strip any accidental prefix then prepend gemini/
+        # to match the model string built by get_llm() for LiteLLM cost lookup.
+        model_bare = model_name.split("/", 1)[-1] if "/" in model_name else model_name
+        token_model = f"gemini/{model_bare}"
     
     hint_metadata = {}
 

--- a/src/backend/requirements.txt
+++ b/src/backend/requirements.txt
@@ -22,6 +22,11 @@ crewai==1.8.1
 litellm==1.74.15.post2
 
 # LLM Providers
+# google-auth: required by LiteLLM's vertex_ai path for all auth routes
+# (google.auth.default() for ADC, google.oauth2.service_account for key files).
+# LiteLLM does NOT declare this as a base dependency — it only appears in the
+# optional [vertex] extra, which we do not install to avoid heavy transitive deps.
+google-auth
 
 # ChromaDB for semantic keyword search (uses default ONNX embedding - no pytorch needed)
 chromadb

--- a/src/backend/services/workflow_service.py
+++ b/src/backend/services/workflow_service.py
@@ -124,7 +124,7 @@ def run_agentic_workflow(natural_language_query: str, model_provider: str, model
             return
         if not os.path.exists(creds_path):
             logging.error(f"Orchestrator: Credentials file not found at: {creds_path}")
-            yield {"status": "error", "message": f"Credentials file not found: {creds_path}. Check VERTEXAI_CREDENTIALS in your .env."}
+            yield {"status": "error", "message": "Vertex AI credentials file not found. Check that VERTEXAI_CREDENTIALS in your .env points to a valid service account JSON file."}
             return
         if not settings.VERTEXAI_PROJECT:
             logging.error("Orchestrator: VERTEXAI_PROJECT not set for vertex provider.")

--- a/src/backend/services/workflow_service.py
+++ b/src/backend/services/workflow_service.py
@@ -98,7 +98,7 @@ def run_agentic_workflow(natural_language_query: str, model_provider: str, model
     
     Args:
         natural_language_query: User's test description
-        model_provider: "local" or "online"
+        model_provider: "local", "gemini", or "vertex"
         model_name: Model identifier
     """
     logging.info("--- Starting CrewAI Workflow with Vision Integration ---")
@@ -110,11 +110,29 @@ def run_agentic_workflow(natural_language_query: str, model_provider: str, model
     # Start with welcome message
     yield {"status": "running", "message": f"{EMOJI['start']} Starting your test generation journey...", "progress": 0}
 
-    if model_provider == "online":
+    if model_provider == "gemini":
         if not os.getenv("GEMINI_API_KEY"):
-            logging.error(
-                "Orchestrator: GEMINI_API_KEY not found for online provider.")
+            logging.error("Orchestrator: GEMINI_API_KEY not found for gemini provider.")
             yield {"status": "error", "message": "GEMINI_API_KEY not found."}
+            return
+
+    elif model_provider == "vertex":
+        creds_path = os.getenv("VERTEXAI_CREDENTIALS")
+        if not creds_path:
+            logging.error("Orchestrator: VERTEXAI_CREDENTIALS not set for vertex provider.")
+            yield {"status": "error", "message": "VERTEXAI_CREDENTIALS not set. Point it to your service account JSON file."}
+            return
+        if not os.path.exists(creds_path):
+            logging.error(f"Orchestrator: Credentials file not found at: {creds_path}")
+            yield {"status": "error", "message": f"Credentials file not found: {creds_path}. Check VERTEXAI_CREDENTIALS in your .env."}
+            return
+        if not settings.VERTEXAI_PROJECT:
+            logging.error("Orchestrator: VERTEXAI_PROJECT not set for vertex provider.")
+            yield {"status": "error", "message": "VERTEXAI_PROJECT not set in .env for Vertex AI."}
+            return
+        if not settings.VERTEXAI_LOCATION:
+            logging.error("Orchestrator: VERTEXAI_LOCATION not set for vertex provider.")
+            yield {"status": "error", "message": "VERTEXAI_LOCATION not set in .env for Vertex AI."}
             return
 
     # Run CrewAI workflow with simple progress updates

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,9 +17,9 @@ from unittest.mock import patch, MagicMock
 def mock_settings():
     """Patched Settings with test defaults — no real env vars read."""
     with patch.dict(os.environ, {
-        "MODEL_PROVIDER": "online",
+        "MODEL_PROVIDER": "gemini",
         "GEMINI_API_KEY": "test-key-123",
-        "ONLINE_MODEL": "gemini/gemini-2.5-flash",
+        "ONLINE_MODEL": "gemini-2.5-flash",
         "LOCAL_MODEL": "llama3",
         "APP_PORT": "5000",
         "BROWSER_USE_SERVICE_URL": "http://localhost:4999",

--- a/tests/test_api/test_api_endpoints.py
+++ b/tests/test_api/test_api_endpoints.py
@@ -32,8 +32,8 @@ def api_client():
          patch("src.backend.api.endpoints.get_docker_status") as mock_docker_status, \
          patch("src.backend.api.endpoints.get_feedback_loop") as mock_feedback:
 
-        mock_settings.MODEL_PROVIDER = "online"
-        mock_settings.ONLINE_MODEL = "gemini/gemini-2.5-flash"
+        mock_settings.MODEL_PROVIDER = "gemini"
+        mock_settings.ONLINE_MODEL = "gemini-2.5-flash"
         mock_settings.LOCAL_MODEL = "llama3"
         mock_settings.GEMINI_API_KEY = "test-key"
 

--- a/tests/test_core/test_config.py
+++ b/tests/test_core/test_config.py
@@ -24,9 +24,9 @@ class TestSettingsDefaults:
 
     def _make_settings(self, overrides=None):
         env = {
-            "MODEL_PROVIDER": "online",
+            "MODEL_PROVIDER": "gemini",
             "GEMINI_API_KEY": "test",
-            "ONLINE_MODEL": "gemini/gemini-2.5-flash",
+            "ONLINE_MODEL": "gemini-2.5-flash",
             "ROBOT_LIBRARY": "selenium",
             "BROWSER_HEADLESS": "true",
             "MAX_AGENT_ITERATIONS": "3",
@@ -42,9 +42,9 @@ class TestSettingsDefaults:
             return Settings()
 
     def test_default_model_provider(self):
-        """Default MODEL_PROVIDER is 'online'."""
+        """Default MODEL_PROVIDER is 'gemini'."""
         s = self._make_settings()
-        assert s.MODEL_PROVIDER == "online"
+        assert s.MODEL_PROVIDER == "gemini"
 
     def test_default_robot_library(self):
         """Default ROBOT_LIBRARY is validated and lowercased."""
@@ -72,9 +72,9 @@ class TestSettingsValidators:
 
     def _make_settings(self, overrides):
         env = {
-            "MODEL_PROVIDER": "online",
+            "MODEL_PROVIDER": "gemini",
             "GEMINI_API_KEY": "test",
-            "ONLINE_MODEL": "gemini/gemini-2.5-flash",
+            "ONLINE_MODEL": "gemini-2.5-flash",
             "ROBOT_LIBRARY": "selenium",
             "MAX_AGENT_ITERATIONS": "3",
             "CUSTOM_ACTION_TIMEOUT": "5",
@@ -119,3 +119,18 @@ class TestSettingsValidators:
         """MAX_LOCATOR_STRATEGIES=100 raises ValidationError."""
         with pytest.raises(ValidationError):
             self._make_settings({"MAX_LOCATOR_STRATEGIES": "100"})
+
+    def test_model_provider_accepts_vertex(self):
+        """Verify MODEL_PROVIDER=vertex passes validation."""
+        s = self._make_settings({"MODEL_PROVIDER": "vertex"})
+        assert s.MODEL_PROVIDER == "vertex"
+
+    def test_model_provider_rejects_online(self):
+        """Verify the removed 'online' value is rejected by the validator."""
+        with pytest.raises(ValidationError):
+            self._make_settings({"MODEL_PROVIDER": "online"})
+
+    def test_model_provider_rejects_invalid(self):
+        """Verify arbitrary strings are rejected."""
+        with pytest.raises(ValidationError):
+            self._make_settings({"MODEL_PROVIDER": "aws"})

--- a/tests/test_crew_ai/test_cleaned_llm_wrapper.py
+++ b/tests/test_crew_ai/test_cleaned_llm_wrapper.py
@@ -5,6 +5,7 @@ Purpose: get_llm is the factory that creates the correct LLM wrapper based
          on MODEL_PROVIDER.
 """
 
+import os
 import pytest
 from unittest.mock import patch
 
@@ -12,16 +13,16 @@ class TestGetLlm:
     """Tests for get_llm factory function."""
 
     @patch("src.backend.crew_ai.cleaned_llm_wrapper.CleanedLLMWrapper")
-    def test_online_returns_cleaned_wrapper(self, MockCleanedLLMWrapper):
-        """Online provider creates CleanedLLMWrapper."""
+    def test_gemini_returns_cleaned_wrapper(self, MockCleanedLLMWrapper):
+        """Gemini provider creates CleanedLLMWrapper."""
         from src.backend.crew_ai.cleaned_llm_wrapper import get_llm
 
         with patch.dict('os.environ', {"GEMINI_API_KEY": "test-key"}):
-            llm = get_llm(model_provider="online", model_name="gemini-2.5-flash")
+            llm = get_llm(model_provider="gemini", model_name="gemini-2.5-flash")
             assert llm == MockCleanedLLMWrapper.return_value
             MockCleanedLLMWrapper.assert_called_once_with(
                 api_key="test-key",
-                model="gemini-2.5-flash",
+                model="gemini/gemini-2.5-flash",
                 num_retries=3,
                 is_litellm=True
             )
@@ -50,11 +51,55 @@ class TestGetLlm:
         from src.backend.crew_ai.cleaned_llm_wrapper import get_llm
 
         with patch.dict('os.environ', {"GEMINI_API_KEY": "env-key-123"}):
-            llm = get_llm(model_provider="online", model_name="gemini-2.5-flash")
+            llm = get_llm(model_provider="gemini", model_name="gemini-2.5-flash")
             assert llm == MockCleanedLLMWrapper.return_value
             MockCleanedLLMWrapper.assert_called_once_with(
                 api_key="env-key-123",
-                model="gemini-2.5-flash",
+                model="gemini/gemini-2.5-flash",
                 num_retries=3,
                 is_litellm=True
             )
+
+    @patch("src.backend.crew_ai.cleaned_llm_wrapper.CleanedLLMWrapper")
+    def test_get_llm_vertex_strips_gemini_prefix(self, MockCleanedLLMWrapper):
+        """Verify get_llm(model_provider='vertex') strips gemini/ and prepends vertex_ai/."""
+        from src.backend.crew_ai.cleaned_llm_wrapper import get_llm
+
+        with patch.dict(os.environ, {"VERTEXAI_CREDENTIALS": "creds.json",
+                                      "VERTEXAI_PROJECT": "test-project",
+                                      "VERTEXAI_LOCATION": "us-central1"}):
+            llm = get_llm(model_provider="vertex", model_name="gemini/gemini-2.5-flash")
+            assert llm == MockCleanedLLMWrapper.return_value
+            MockCleanedLLMWrapper.assert_called_once_with(
+                model="vertex_ai/gemini-2.5-flash",
+                num_retries=3,
+                is_litellm=True,
+            )
+
+    @patch("src.backend.crew_ai.cleaned_llm_wrapper.CleanedLLMWrapper")
+    def test_get_llm_vertex_handles_bare_model_name(self, MockCleanedLLMWrapper):
+        """Verify get_llm(model_provider='vertex') works with no prefix in model name."""
+        from src.backend.crew_ai.cleaned_llm_wrapper import get_llm
+
+        with patch.dict(os.environ, {"VERTEXAI_CREDENTIALS": "creds.json",
+                                      "VERTEXAI_PROJECT": "test-project",
+                                      "VERTEXAI_LOCATION": "us-central1"}):
+            llm = get_llm(model_provider="vertex", model_name="gemini-2.5-flash")
+            assert llm == MockCleanedLLMWrapper.return_value
+            MockCleanedLLMWrapper.assert_called_once_with(
+                model="vertex_ai/gemini-2.5-flash",
+                num_retries=3,
+                is_litellm=True,
+            )
+
+    @patch("src.backend.crew_ai.cleaned_llm_wrapper.CleanedLLMWrapper")
+    def test_get_llm_vertex_does_not_pass_api_key(self, MockCleanedLLMWrapper):
+        """Verify vertex provider does not inject an api_key (auth is via service account)."""
+        from src.backend.crew_ai.cleaned_llm_wrapper import get_llm
+
+        with patch.dict(os.environ, {"VERTEXAI_CREDENTIALS": "creds.json",
+                                      "VERTEXAI_PROJECT": "test-project",
+                                      "VERTEXAI_LOCATION": "us-central1"}):
+            get_llm(model_provider="vertex", model_name="gemini/gemini-2.5-flash")
+            call_kwargs = MockCleanedLLMWrapper.call_args[1]
+            assert "api_key" not in call_kwargs

--- a/tests/test_crew_ai/test_cleaned_llm_wrapper.py
+++ b/tests/test_crew_ai/test_cleaned_llm_wrapper.py
@@ -100,6 +100,17 @@ class TestGetLlm:
         with patch.dict(os.environ, {"VERTEXAI_CREDENTIALS": "creds.json",
                                       "VERTEXAI_PROJECT": "test-project",
                                       "VERTEXAI_LOCATION": "us-central1"}):
-            get_llm(model_provider="vertex", model_name="gemini/gemini-2.5-flash")
-            call_kwargs = MockCleanedLLMWrapper.call_args[1]
+            llm = get_llm(model_provider="vertex", model_name="gemini/gemini-2.5-flash")
+            assert llm == MockCleanedLLMWrapper.return_value
+            MockCleanedLLMWrapper.assert_called_once()
+            call_kwargs = MockCleanedLLMWrapper.call_args.kwargs
+            assert call_kwargs["model"] == "vertex_ai/gemini-2.5-flash"
             assert "api_key" not in call_kwargs
+
+    @pytest.mark.parametrize("bad_provider", ["openai", "anthropic", "gemni", "", "GEMINI", "gpt-4"])
+    def test_unsupported_provider_raises_value_error(self, bad_provider):
+        """Unknown model_provider values must raise ValueError immediately, not silently route."""
+        from src.backend.crew_ai.cleaned_llm_wrapper import get_llm
+
+        with pytest.raises(ValueError, match="Unsupported model_provider"):
+            get_llm(model_provider=bad_provider, model_name="some-model")

--- a/tests/test_integration/test_live_crew.py
+++ b/tests/test_integration/test_live_crew.py
@@ -5,7 +5,7 @@ Purpose: Verify that run_crew() produces valid Robot Framework code when
          executed with a real LLM provider.
 
 Requires:
-  - GEMINI_API_KEY env variable set (for online provider)
+  - GEMINI_API_KEY env variable set (for gemini provider)
   - OR a running Ollama instance (for local provider)
 
 Run with:
@@ -74,8 +74,8 @@ class TestLiveLLMCrewOnline:
         from src.backend.crew_ai.crew import run_crew
         result = run_crew(
             "click the login button on example.com",
-            model_provider="online",
-            model_name="gemini/gemini-2.0-flash",
+            model_provider="gemini",
+            model_name="gemini-2.0-flash",
             workflow_id="live-test-001",
         )
         assert len(result) == 4
@@ -85,8 +85,8 @@ class TestLiveLLMCrewOnline:
         from src.backend.crew_ai.crew import run_crew
         validation_output, _, _, _ = run_crew(
             "click the login button on example.com",
-            model_provider="online",
-            model_name="gemini/gemini-2.0-flash",
+            model_provider="gemini",
+            model_name="gemini-2.0-flash",
             workflow_id="live-test-002",
         )
         assert isinstance(validation_output, str)
@@ -97,8 +97,8 @@ class TestLiveLLMCrewOnline:
         from src.backend.crew_ai.crew import run_crew
         validation_output, _, _, _ = run_crew(
             "navigate to google.com and search for python",
-            model_provider="online",
-            model_name="gemini/gemini-2.0-flash",
+            model_provider="gemini",
+            model_name="gemini-2.0-flash",
             workflow_id="live-test-003",
         )
         assert _is_valid_robot_code(validation_output), (
@@ -110,8 +110,8 @@ class TestLiveLLMCrewOnline:
         from src.backend.crew_ai.crew import run_crew
         _, _, _, hint_metadata = run_crew(
             "click the submit button on example.com",
-            model_provider="online",
-            model_name="gemini/gemini-2.0-flash",
+            model_provider="gemini",
+            model_name="gemini-2.0-flash",
             workflow_id="live-test-004",
         )
         assert isinstance(hint_metadata, dict)
@@ -121,8 +121,8 @@ class TestLiveLLMCrewOnline:
         from src.backend.crew_ai.crew import run_crew
         _, _, optimization_metrics, _ = run_crew(
             "open the home page of example.com",
-            model_provider="online",
-            model_name="gemini/gemini-2.0-flash",
+            model_provider="gemini",
+            model_name="gemini-2.0-flash",
             workflow_id="live-test-005",
         )
         if optimization_metrics is not None:

--- a/tests/test_integration/test_live_workflow.py
+++ b/tests/test_integration/test_live_workflow.py
@@ -8,7 +8,7 @@ Purpose: Verify the full workflow pipeline when the NL backend is running —
 Requires:
   - NL backend running on localhost:5000
   - Docker Desktop running
-  - GEMINI_API_KEY set in environment (for 'online' provider tests)
+  - GEMINI_API_KEY set in environment (for 'gemini' provider tests)
 
 Run with:
   pytest tests/test_integration/test_live_workflow.py -m integration -v
@@ -66,12 +66,12 @@ class TestWorkflowStreamEvents:
                 break
 
     def test_missing_api_key_yields_error_event(self):
-        """When GEMINI_API_KEY absent, online provider yields error immediately."""
+        """When GEMINI_API_KEY absent, gemini provider yields error immediately."""
         original = os.environ.pop("GEMINI_API_KEY", None)
         try:
             from src.backend.services.workflow_service import run_agentic_workflow
             # Force re-import to pick up env change
-            events = list(run_agentic_workflow("test", "online", "gemini"))
+            events = list(run_agentic_workflow("test", "gemini", "gemini"))
             statuses = [e["status"] for e in events]
             assert "error" in statuses
         finally:

--- a/tests/test_services/test_workflow_service.py
+++ b/tests/test_services/test_workflow_service.py
@@ -14,6 +14,9 @@ Tests:
   - Workflow metrics collection
 """
 
+import json
+import os
+import tempfile
 import pytest
 from unittest.mock import patch, MagicMock, AsyncMock
 
@@ -34,7 +37,7 @@ class TestStreamGenerateOnly:
         import asyncio
         async def run_gen():
             events = []
-            async for e in stream_generate_only("test query", "online", "gemini-2.5-flash"):
+            async for e in stream_generate_only("test query", "gemini", "gemini-2.5-flash"):
                 events.append(e)
             return events
         events = asyncio.run(run_gen())
@@ -49,7 +52,7 @@ class TestStreamGenerateOnly:
         import asyncio
         async def run_gen():
             events = []
-            async for e in stream_generate_only("test query", "online", "gemini-2.5-flash"):
+            async for e in stream_generate_only("test query", "gemini", "gemini-2.5-flash"):
                 events.append(e)
             return events
         events = asyncio.run(run_gen())
@@ -94,3 +97,53 @@ class TestStreamExecuteOnly:
             return events
         events = asyncio.run(run_gen())
         assert len(events) > 0
+
+
+class TestVertexCredentialValidation:
+    """Tests for vertex provider credential validation in run_agentic_workflow."""
+
+    def test_vertex_missing_credentials_yields_error(self):
+        """Verify vertex provider yields error when VERTEXAI_CREDENTIALS is empty."""
+        from src.backend.services.workflow_service import run_agentic_workflow
+        with patch.dict(os.environ, {"VERTEXAI_CREDENTIALS": ""}, clear=False):
+            events = list(run_agentic_workflow("test query", "vertex", "gemini-2.5-flash"))
+        assert any("VERTEXAI_CREDENTIALS" in e.get("message", "") for e in events)
+
+    def test_vertex_missing_credentials_file_yields_error(self):
+        """Verify vertex provider yields error when credentials file does not exist."""
+        from src.backend.services.workflow_service import run_agentic_workflow
+        with patch.dict(os.environ, {"VERTEXAI_CREDENTIALS": "/nonexistent/path.json"}, clear=False):
+            events = list(run_agentic_workflow("test query", "vertex", "gemini-2.5-flash"))
+        assert any("not found" in e.get("message", "").lower() for e in events)
+
+    def test_vertex_missing_project_yields_error(self):
+        """Verify vertex provider yields error when VERTEXAI_PROJECT is not set."""
+        from src.backend.services.workflow_service import run_agentic_workflow
+        with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as f:
+            f.write(b"{}")
+            creds_path = f.name
+        try:
+            with patch.dict(os.environ, {"VERTEXAI_CREDENTIALS": creds_path}, clear=False), \
+                 patch("src.backend.services.workflow_service.settings") as mock_settings:
+                mock_settings.VERTEXAI_PROJECT = None
+                mock_settings.VERTEXAI_LOCATION = "us-central1"
+                events = list(run_agentic_workflow("test query", "vertex", "gemini-2.5-flash"))
+            assert any("VERTEXAI_PROJECT" in e.get("message", "") for e in events)
+        finally:
+            os.unlink(creds_path)
+
+    def test_vertex_missing_location_yields_error(self):
+        """Verify vertex provider yields error when VERTEXAI_LOCATION is not set."""
+        from src.backend.services.workflow_service import run_agentic_workflow
+        with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as f:
+            f.write(b"{}")
+            creds_path = f.name
+        try:
+            with patch.dict(os.environ, {"VERTEXAI_CREDENTIALS": creds_path}, clear=False), \
+                 patch("src.backend.services.workflow_service.settings") as mock_settings:
+                mock_settings.VERTEXAI_PROJECT = "test-project"
+                mock_settings.VERTEXAI_LOCATION = None
+                events = list(run_agentic_workflow("test query", "vertex", "gemini-2.5-flash"))
+            assert any("VERTEXAI_LOCATION" in e.get("message", "") for e in events)
+        finally:
+            os.unlink(creds_path)

--- a/tests/test_services/test_workflow_service.py
+++ b/tests/test_services/test_workflow_service.py
@@ -14,7 +14,6 @@ Tests:
   - Workflow metrics collection
 """
 
-import json
 import os
 import tempfile
 import pytest

--- a/tools/browser_use_service.py
+++ b/tools/browser_use_service.py
@@ -151,7 +151,17 @@ if __name__ == '__main__':
         logger.error("❌ Configuration validation failed:")
         for error in validation_errors:
             logger.error(f"   - {error}")
-        logger.warning("⚠️ Service starting with invalid configuration - some features may not work correctly")
+        if config.llm.model_provider == "vertex":
+            # Vertex AI failures are fatal: missing or invalid credentials mean every
+            # workflow request will fail with no possibility of recovery. Abort now
+            # so the operator is forced to fix the config before the service accepts work.
+            logger.error(
+                "💀 Vertex AI configuration is invalid. "
+                "Fix the errors above and restart the service."
+            )
+            sys.exit(1)
+        else:
+            logger.warning("⚠️ Service starting with invalid configuration - some features may not work correctly")
     else:
         logger.info("✅ Configuration validation passed")
 


### PR DESCRIPTION
- Changed default MODEL_PROVIDER to "vertex" and updated documentation accordingly.
- Added a new setup guide for Google Cloud Vertex AI, detailing authentication and service account creation.
- Updated environment variable configurations for model providers, including handling for "gemini" and "vertex".
- Refactored code to support new model provider options in various modules, including API endpoints and workflow services.
- Enhanced error handling for missing credentials and project/location settings for Vertex AI.
- Updated tests to reflect changes in model provider logic and added tests for Vertex AI credential validation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Google Cloud Vertex AI as a supported model provider alongside Gemini and local.
  * Added Docker Compose override to enable Vertex AI credentials mounting for local deployment.

* **Configuration**
  * Default model provider changed to "vertex".
  * Added VERTEXAI_PROJECT, VERTEXAI_LOCATION, VERTEXAI_CREDENTIALS env vars.
  * Model names now use bare names (provider prefixing handled internally).

* **Tests**
  * Added Vertex credential validation tests and updated existing tests for provider changes.

* **Dependencies**
  * Added google-auth for Vertex support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->