### PR TITLE
Add pluggable ArtifactStore abstraction with S3 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ __pycache__/
 *.pyc
 *.pyo
 *.pyd
+*.egg-info/
 
 # Logs
 *.log*

--- a/Dockerfile.fastapi
+++ b/Dockerfile.fastapi
@@ -54,6 +54,11 @@ WORKDIR /build
 
 ENV PYTHONDONTWRITEBYTECODE=1
 
+# Opt in to the S3 artifact-storage backend at build time. Default is off, so the
+# image ships without the AWS SDK (boto3 + botocore is ~50-80MB) unless requested:
+#   docker build --build-arg INSTALL_S3=true ...
+ARG INSTALL_S3=false
+
 # Install UV package manager
 RUN pip install --no-cache-dir uv
 
@@ -76,8 +81,10 @@ COPY pyproject.toml /build/pyproject.toml
 # still using an exact lockfile for the install itself (reproducible layer).
 # ChromaDB will use its default ONNX-based embedding function (no pytorch needed).
 RUN --mount=type=cache,target=/root/.cache/uv \
+    set --; \
+    if [ "$INSTALL_S3" = "true" ]; then set -- --extra s3; fi; \
     uv pip compile /build/pyproject.toml \
-        --no-header \
+        --no-header "$@" \
         --output-file /build/requirements-compiled.txt && \
     uv pip install --prefix=/build/install --no-cache \
         -r /build/requirements-compiled.txt

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,14 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+# S3 artifact-storage backend. Installed ONLY when ARTIFACT_STORE=s3 is used, so
+# a local-only deployment never ships the AWS SDK (boto3 + botocore is ~50-80MB).
+# boto3 is lazy-imported by S3ArtifactStore.
+#   local/dev:  pip install -e '.[s3]'
+#   Docker:     docker build --build-arg INSTALL_S3=true ... (see Dockerfile.fastapi)
+s3 = [
+    "boto3",
+]
 dev = [
     "pytest>=7.0",
     "pytest-asyncio>=0.21",

--- a/src/backend/.env.example
+++ b/src/backend/.env.example
@@ -199,3 +199,26 @@ ALLOWED_ORIGINS=http://localhost:5173,http://localhost:3000,http://localhost:500
 # Set the Secure flag on auth cookies (the Google OAuth state cookie). Keep false
 # for local http dev; set true in production so the cookie is only sent over HTTPS.
 COOKIE_SECURE=false
+
+# ============================================================================
+# Artifact storage backend (pluggable, per deployment)
+# ============================================================================
+# Where Robot Framework run artifacts (test.robot, output.xml, log.html,
+# report.html, screenshots) are stored.
+#   local — artifacts stay on disk under robot_tests/ (default).
+#   s3    — after each run, artifacts are uploaded to a bucket (still staged
+#           locally for the Docker test container). Reports are always served
+#           through the app, never via presigned URLs.
+ARTIFACT_STORE=local
+
+# The following are required only when ARTIFACT_STORE=s3.
+# boto3 is an optional dependency: install it with the 's3' extra
+#   local/dev:  pip install -e '.[s3]'
+#   Docker:     docker build --build-arg INSTALL_S3=true ... (Dockerfile.fastapi)
+ARTIFACT_S3_BUCKET=
+ARTIFACT_S3_PREFIX=runs
+ARTIFACT_S3_REGION=
+# Set for MinIO / S3-compatible endpoints; leave empty for real AWS S3.
+ARTIFACT_S3_ENDPOINT_URL=
+# Credentials use the standard AWS chain: AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY
+# in the environment, or an IAM role. Do not put secrets in this file.

--- a/src/backend/api/history_endpoints.py
+++ b/src/backend/api/history_endpoints.py
@@ -18,12 +18,11 @@ ownership rows, so a user cannot open another user's log.html by URL.
 
 Referenced by: main.py (router registration), api/endpoints.py
 (resolve_robot_code for history reruns), frontend HistoryPage.
-Depends on: core/run_registry.py, auth/jwt_utils.py, services/docker_service.py
-(ROBOT_TESTS_DIR).
+Depends on: core/run_registry.py, auth/jwt_utils.py, core/artifact_store.py
+(get_artifact_store).
 """
 
 import logging
-import os
 import uuid
 from typing import Literal, Optional
 
@@ -31,7 +30,7 @@ from fastapi import APIRouter, Depends, HTTPException
 
 from src.backend.auth.jwt_utils import is_validated_admin, require_user
 from src.backend.core.run_registry import get_run_registry
-from src.backend.services.docker_service import ROBOT_TESTS_DIR
+from src.backend.core.artifact_store import get_artifact_store
 
 logger = logging.getLogger(__name__)
 
@@ -43,18 +42,12 @@ _REPORT_STATUSES = ("passed", "failed")
 
 def resolve_robot_code(run: dict) -> str | None:
     """Stored code for a run: the test_runs.robot_code column (written at
-    generation/execution time), falling back to the run's on-disk
-    robot_tests/<id>/test.robot for executed runs that predate the column.
-    Callers UUID-validate run_id, so it is safe as a path segment. Legacy
+    generation/execution time), falling back to the run's stored test.robot
+    via the artifact store for executed runs that predate the column. Legacy
     generate-only runs have no recoverable code -> None."""
     if run.get("robot_code"):
         return run["robot_code"]
-    path = os.path.join(ROBOT_TESTS_DIR, run["run_id"], "test.robot")
-    try:
-        with open(path, encoding="utf-8") as f:
-            return f.read()
-    except OSError:
-        return None
+    return get_artifact_store().read_text(run["run_id"], "test.robot")
 
 
 @router.get("/history")

--- a/src/backend/api/report_endpoints.py
+++ b/src/backend/api/report_endpoints.py
@@ -5,69 +5,52 @@ Referenced by:
     StaticFiles("/reports") mount + reports-auth middleware.
 Depends on:
     src.backend.auth.jwt_utils.authorize_report_access — owner-or-admin gate.
-    src.backend.services.docker_service.ROBOT_TESTS_DIR — the artifact root.
+    src.backend.core.artifact_store.get_artifact_store — backend-agnostic
+        artifact resolution + serving (local FileResponse / S3 StreamingResponse).
 
 Why a route and not a StaticFiles mount:
-    The mount split one URL across two parsers. The auth middleware parsed the
-    run_id out of request.url.path one way; StaticFiles resolved the file
-    another. They disagreed on '//' (an empty leading segment) and '..' (parent
-    traversal), so any logged-in user could read another user's report — and
-    log.html records every keyword argument, including passwords typed during a
-    test. A single {run_id} path parameter is parsed ONCE here and drives BOTH
-    the ownership check and the file lookup, so that disagreement — the whole
-    bug class, not just the reported double slash — is structurally impossible.
+    The mount split one URL across two parsers (auth middleware vs StaticFiles),
+    which disagreed on '//' and '..', letting any logged-in user read another
+    user's report — and log.html records every keyword argument, including
+    passwords typed during a test. A single {run_id} path parameter is parsed
+    ONCE here and drives BOTH the ownership check and the file lookup, so that
+    whole bug class is structurally impossible.
 """
 
 import asyncio
-import os
-import uuid
 
 from fastapi import APIRouter, Request, Response
-from fastapi.responses import FileResponse, JSONResponse
+from fastapi.responses import JSONResponse
 
 from src.backend.auth.jwt_utils import authorize_report_access
-from src.backend.services.docker_service import ROBOT_TESTS_DIR
+from src.backend.core.artifact_store import get_artifact_store
 
 router = APIRouter()
-
-
-def resolve_report_file(run_id: str, file_path: str) -> str | None:
-    """Safe-join *file_path* under ROBOT_TESTS_DIR/<run_id>.
-
-    Returns the absolute path of an existing file contained in the run
-    directory, or None when: run_id is not a UUID; the resolved path escapes
-    the run directory ('..', an absolute file_path, or a symlink target); or
-    the target is missing or a directory (e.g. a bare /reports/<id>/ request).
-    realpath resolves symlinks before the containment check, so this is strictly
-    stronger than StaticFiles' default traversal protection.
-    """
-    try:
-        run_id = str(uuid.UUID(run_id))
-    except ValueError:
-        return None
-    run_root = os.path.realpath(os.path.join(ROBOT_TESTS_DIR, run_id))
-    target = os.path.realpath(os.path.join(run_root, file_path))
-    if target != run_root and not target.startswith(run_root + os.sep):
-        return None  # escaped the run directory
-    if not os.path.isfile(target):
-        return None  # missing, or a directory
-    return target
 
 
 @router.api_route("/reports/{run_id}/{file_path:path}", methods=["GET", "HEAD"])
 async def serve_report_file(run_id: str, file_path: str, request: Request) -> Response:
     """Owner-or-admin gated download of one run artifact.
 
-    The blocking ownership lookup (Postgres) runs off the event loop, as the old
+    The blocking ownership lookup (Postgres) and the blocking store read
+    (local stat or S3 GetObject) both run off the event loop, as the old
     middleware did, so report pages (log.html pulls several sub-resources) and
     the SSE streams on the loop never stall.
     """
     denied = await asyncio.to_thread(authorize_report_access, request, run_id)
     if denied is not None:
         return denied
-    path = resolve_report_file(run_id, file_path)
-    if path is None:
+    store = get_artifact_store()
+    resp = await asyncio.to_thread(
+        store.serve_artifact, run_id, file_path, request.headers.get("range"))
+    if resp is None:
         return JSONResponse({"detail": "Not found"}, status_code=404)
-    # private: an authorization-gated artifact must never be cached by a shared
-    # proxy and then served to a different user.
-    return FileResponse(path, headers={"Cache-Control": "private"})
+    # CSP sandbox: report HTML is user-generated (Robot's Log html=True) and is
+    # served same-origin with the SPA. An opaque origin makes localStorage
+    # unreachable (no token theft) AND makes the document's requests cross-site
+    # (no same-origin confused-deputy API calls). allow-scripts keeps Robot's log
+    # app interactive; the ABSENCE of allow-same-origin is what makes the origin
+    # opaque — do not add it. Applied uniformly (a no-op for PNG/XML) so every
+    # served HTML, including attacker-authored, is sandboxed.
+    resp.headers["Content-Security-Policy"] = "sandbox allow-scripts allow-popups"
+    return resp

--- a/src/backend/auth/jwt_utils.py
+++ b/src/backend/auth/jwt_utils.py
@@ -146,7 +146,7 @@ def authorize_report_access(request, run_id: str) -> "JSONResponse | None":
     filesystem path in the body).
 
     run_id is the route's parsed path parameter — NOT re-parsed from the URL.
-    The ownership check and the file lookup (report_endpoints.resolve_report_file)
+    The ownership check and the artifact store lookup (store.serve_artifact)
     therefore key off one identical value, which closes the '//' (empty segment)
     and '..' (parent traversal) parser-disagreement bypass that the old
     middleware + StaticFiles split allowed.

--- a/src/backend/core/artifact_store.py
+++ b/src/backend/core/artifact_store.py
@@ -1,0 +1,241 @@
+"""Pluggable storage for Robot Framework run artifacts.
+
+Two tiers (see docs/superpowers/specs/2026-06-17-artifact-store-design.md):
+  STAGING — a real local directory in every backend; the Docker test container
+            bind-mounts it and Robot Framework writes into it from inside.
+  DURABLE — backend-specific persistence/read/serve (local disk or S3).
+
+The backend is chosen per deployment by settings.ARTIFACT_STORE, exactly as
+settings.MODEL_PROVIDER chooses an LLM backend.
+
+Referenced by: services/docker_service.py, services/workflow_service.py,
+services/dryrun_service.py, api/report_endpoints.py, api/history_endpoints.py,
+main.py.
+Depends on: core/config.py (settings).
+"""
+
+import logging
+import mimetypes
+import os
+import uuid
+from abc import ABC, abstractmethod
+from pathlib import Path
+from threading import Lock
+
+from fastapi import Response
+from fastapi.responses import FileResponse, StreamingResponse
+
+from src.backend.core.config import settings
+
+logger = logging.getLogger(__name__)
+
+# <repo-root>/robot_tests — the local staging base. Computed here (NOT imported
+# from docker_service) so this module is the single owner of the path. This file
+# is src/backend/core/artifact_store.py, so parents[3] is the repo root.
+STAGING_ROOT = Path(__file__).resolve().parents[3] / "robot_tests"
+
+
+class ArtifactStore(ABC):
+    """Shared local staging + abstract durable operations."""
+
+    def __init__(self, staging_root: Path):
+        self.staging_root = Path(staging_root)
+        self.staging_root.mkdir(parents=True, exist_ok=True)
+
+    # ── STAGING (shared, always local — the container's bind-mount source) ──
+    def run_dir(self, run_id: str, create: bool = False) -> Path:
+        """The run's local staging directory (staging_root/<run_id>)."""
+        d = self.staging_root / run_id
+        if create:
+            d.mkdir(parents=True, exist_ok=True)
+        return d
+
+    @staticmethod
+    def _safe_subpath(base: Path, relpath: str) -> Path | None:
+        """Resolve *relpath* under *base*. Returns None when the result escapes
+        (via '..', an absolute path, or a symlink target). realpath resolves
+        symlinks before the containment check — strictly stronger than
+        StaticFiles' default traversal protection."""
+        base_real = os.path.realpath(base)
+        target = os.path.realpath(os.path.join(base_real, relpath))
+        if target != base_real and not target.startswith(base_real + os.sep):
+            return None
+        return Path(target)
+
+    @staticmethod
+    def _valid_run_id(run_id: str) -> str | None:
+        try:
+            return str(uuid.UUID(run_id))
+        except ValueError:
+            return None
+
+    # ── DURABLE (backend-specific) ──
+    @abstractmethod
+    def read_text(self, run_id: str, relpath: str) -> str | None:
+        """One artifact as text, or None if absent/escaping/unreadable."""
+
+    @abstractmethod
+    def serve_artifact(self, run_id: str, relpath: str,
+                       range_header: str | None = None) -> Response | None:
+        """A Starlette Response for the artifact, or None for 404/escape."""
+
+    @abstractmethod
+    def persist_run(self, run_id: str) -> None:
+        """Make a finished run's artifacts durable. No-op for local."""
+
+
+class LocalArtifactStore(ArtifactStore):
+    """Durable == staging. persist_run is a no-op (already on local disk)."""
+
+    def read_text(self, run_id: str, relpath: str) -> str | None:
+        rid = self._valid_run_id(run_id)
+        if rid is None:
+            return None
+        target = self._safe_subpath(self.run_dir(rid), relpath)
+        if target is None or not target.is_file():
+            return None
+        try:
+            return target.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            return None
+
+    def serve_artifact(self, run_id: str, relpath: str,
+                       range_header: str | None = None) -> Response | None:
+        rid = self._valid_run_id(run_id)
+        if rid is None:
+            return None
+        target = self._safe_subpath(self.run_dir(rid), relpath)
+        if target is None or not target.is_file():
+            return None
+        # FileResponse natively handles Range/416, ETag, Last-Modified, content
+        # types and HEAD. private: an authorized artifact must never be cached by
+        # a shared proxy and served to another user.
+        return FileResponse(str(target), headers={"Cache-Control": "private"})
+
+    def persist_run(self, run_id: str) -> None:
+        return None
+
+
+class S3ArtifactStore(ArtifactStore):
+    """Local staging + durable S3. Reads/serve are staging-first, then bucket,
+    so the immediate post-run read hits local disk and a replica that never ran
+    the test falls through to the bucket. persist_run uploads the run dir and
+    writes a .complete marker LAST: an out-of-band ops signal (an interrupted
+    upload lacks it) for bucket inspection and lifecycle tooling. The app itself
+    never reads it — read_text/serve_artifact do not gate on its presence."""
+
+    def __init__(self, staging_root: Path):
+        super().__init__(staging_root)
+        if not settings.ARTIFACT_S3_BUCKET:
+            raise ValueError("ARTIFACT_STORE=s3 requires ARTIFACT_S3_BUCKET")
+        try:
+            import boto3  # lazy: only the S3 backend needs it (optional 's3' extra)
+        except ImportError as e:
+            raise RuntimeError(
+                "ARTIFACT_STORE=s3 requires boto3. Install the 's3' extra: "
+                "pip install -e '.[s3]' (or rebuild the FastAPI image with "
+                "--build-arg INSTALL_S3=true)."
+            ) from e
+        self.bucket = settings.ARTIFACT_S3_BUCKET
+        self.prefix = settings.ARTIFACT_S3_PREFIX.strip("/")
+        kwargs = {}
+        if settings.ARTIFACT_S3_REGION:
+            kwargs["region_name"] = settings.ARTIFACT_S3_REGION
+        if settings.ARTIFACT_S3_ENDPOINT_URL:
+            kwargs["endpoint_url"] = settings.ARTIFACT_S3_ENDPOINT_URL
+        self._s3 = boto3.client("s3", **kwargs)
+
+    def _key(self, run_id: str, relpath: str) -> str:
+        return f"{self.prefix}/{run_id}/{relpath}".lstrip("/")
+
+    def persist_run(self, run_id: str) -> None:
+        rid = self._valid_run_id(run_id)
+        if rid is None:
+            return
+        d = self.run_dir(rid)
+        if not d.is_dir():
+            logger.warning("[ARTIFACT_STORE] persist_run: no staging dir for %s", rid)
+            return
+        try:
+            for path in sorted(p for p in d.rglob("*") if p.is_file()):
+                rel = path.relative_to(d).as_posix()
+                self._s3.upload_file(str(path), self.bucket, self._key(rid, rel))
+            # Ops-only completeness marker (see class docstring); not read by the app.
+            self._s3.put_object(
+                Bucket=self.bucket, Key=self._key(rid, ".complete"), Body=b"")
+            logger.info("[ARTIFACT_STORE] persisted run %s to s3://%s/%s/%s/",
+                        rid, self.bucket, self.prefix, rid)
+        except Exception as e:
+            # A failed upload must not fail the user's (already complete) run.
+            logger.error("[ARTIFACT_STORE] persist_run failed for %s: %s", rid, e)
+
+    def read_text(self, run_id: str, relpath: str) -> str | None:
+        rid = self._valid_run_id(run_id)
+        if rid is None:
+            return None
+        target = self._safe_subpath(self.run_dir(rid), relpath)
+        if target is None:
+            return None  # escape attempt
+        # staging-first: the immediate post-run read hits local disk.
+        if target.is_file():
+            try:
+                return target.read_text(encoding="utf-8")
+            except (OSError, UnicodeDecodeError):
+                pass
+        # bucket fallback (a replica that never ran the test, or cleaned staging).
+        try:
+            obj = self._s3.get_object(Bucket=self.bucket, Key=self._key(rid, relpath))
+            return obj["Body"].read().decode("utf-8")
+        except Exception:
+            return None
+
+    def serve_artifact(self, run_id: str, relpath: str,
+                       range_header: str | None = None) -> Response | None:
+        rid = self._valid_run_id(run_id)
+        if rid is None:
+            return None
+        target = self._safe_subpath(self.run_dir(rid), relpath)
+        if target is None:
+            return None  # escape attempt (also guards the S3 key)
+        if target.is_file():
+            return FileResponse(str(target), headers={"Cache-Control": "private"})
+        get_kwargs = {"Bucket": self.bucket, "Key": self._key(rid, relpath)}
+        if range_header:
+            get_kwargs["Range"] = range_header
+        try:
+            obj = self._s3.get_object(**get_kwargs)
+        except Exception:
+            return None
+        headers = {"Cache-Control": "private", "Accept-Ranges": "bytes"}
+        if obj.get("ETag"):
+            headers["ETag"] = obj["ETag"]
+        content_range = obj.get("ContentRange")
+        if content_range:
+            headers["Content-Range"] = content_range
+        media_type = mimetypes.guess_type(relpath)[0] or "application/octet-stream"
+        return StreamingResponse(
+            obj["Body"].iter_chunks(),
+            status_code=206 if content_range else 200,
+            media_type=media_type,
+            headers=headers,
+        )
+
+
+_store: ArtifactStore | None = None
+_store_lock = Lock()
+
+
+def get_artifact_store() -> ArtifactStore:
+    """Process-wide store instance (thread-safe double-checked init)."""
+    global _store
+    if _store is None:
+        with _store_lock:
+            if _store is None:
+                _store = _build_store()
+    return _store
+
+
+def _build_store() -> ArtifactStore:
+    if settings.ARTIFACT_STORE == "s3":
+        return S3ArtifactStore(STAGING_ROOT)
+    return LocalArtifactStore(STAGING_ROOT)

--- a/src/backend/core/artifact_store.py
+++ b/src/backend/core/artifact_store.py
@@ -157,9 +157,21 @@ class S3ArtifactStore(ArtifactStore):
             logger.warning("[ARTIFACT_STORE] persist_run: no staging dir for %s", rid)
             return
         try:
-            for path in sorted(p for p in d.rglob("*") if p.is_file()):
+            for path in sorted(d.rglob("*")):
+                if not path.is_file():
+                    continue
                 rel = path.relative_to(d).as_posix()
-                self._s3.upload_file(str(path), self.bucket, self._key(rid, rel))
+                # rglob + is_file() follow symlinks, so a symlink planted in the
+                # run dir (paste-and-execute Robot code can create one inside the
+                # bind-mounted container) could resolve outside the run scope.
+                # Re-resolve and containment-check before upload so a crafted
+                # symlink cannot exfiltrate host files into the bucket.
+                safe = self._safe_subpath(d, rel)
+                if safe is None or not safe.is_file():
+                    logger.warning(
+                        "[ARTIFACT_STORE] skipping unsafe path during persist: %s", path)
+                    continue
+                self._s3.upload_file(str(safe), self.bucket, self._key(rid, rel))
             # Ops-only completeness marker (see class docstring); not read by the app.
             self._s3.put_object(
                 Bucket=self.bucket, Key=self._key(rid, ".complete"), Body=b"")

--- a/src/backend/core/config.py
+++ b/src/backend/core/config.py
@@ -40,7 +40,16 @@ class Settings(BaseSettings):
     
     # Robot Framework Library Configuration
     ROBOT_LIBRARY: str = Field(default="selenium", description="Robot Framework library to use: 'selenium' or 'browser'")
-    
+
+    # Artifact storage backend — pluggable, chosen per deployment, exactly like
+    # MODEL_PROVIDER chooses an LLM backend. "local" = on-disk robot_tests/;
+    # "s3" = upload to a bucket after each run (still stages locally for Docker).
+    ARTIFACT_STORE: str = "local"
+    ARTIFACT_S3_BUCKET: str = ""          # required when ARTIFACT_STORE=s3
+    ARTIFACT_S3_PREFIX: str = "runs"
+    ARTIFACT_S3_REGION: str = ""
+    ARTIFACT_S3_ENDPOINT_URL: str = ""    # set for MinIO / S3-compatible; empty = AWS
+
     # Agent Retry Configuration
     MAX_AGENT_ITERATIONS: int = Field(default=3, description="Maximum iterations for agents with delegation enabled (retry attempts)")
 
@@ -192,7 +201,14 @@ class Settings(BaseSettings):
         if v.lower() not in ['selenium', 'browser']:
             raise ValueError(f"ROBOT_LIBRARY must be 'selenium' or 'browser', got '{v}'")
         return v.lower()
-    
+
+    @validator('ARTIFACT_STORE')
+    def validate_artifact_store(cls, v):
+        """Validate that ARTIFACT_STORE is one of the supported backends."""
+        if v.lower() not in ('local', 's3'):
+            raise ValueError(f"ARTIFACT_STORE must be 'local' or 's3', got '{v}'")
+        return v.lower()
+
     @validator('MAX_AGENT_ITERATIONS')
     def validate_max_iterations(cls, v):
         """Validate that MAX_AGENT_ITERATIONS is between 1 and 5."""

--- a/src/backend/main.py
+++ b/src/backend/main.py
@@ -82,10 +82,6 @@ app.get("/health")(health_check)
 app.get("/api/health")(api_health_check)
 
 # --- Report artifacts (generated Robot Framework reports) ---
-# Same constant Docker execution writes artifacts to.
-from src.backend.services.docker_service import ROBOT_TESTS_DIR
-os.makedirs(ROBOT_TESTS_DIR, exist_ok=True)
-
 # Reports are served by an explicit owner-gated route, not a StaticFiles mount.
 # log.html records every keyword argument (including passwords typed during a
 # test), so each file is authorized per-owner. The route parses one run_id that
@@ -105,6 +101,12 @@ async def startup_event():
             "python -c \"import secrets; print(secrets.token_urlsafe(48))\" and "
             "set it in src/backend/.env (or the container environment)."
         )
+
+    # Construct the artifact store once at startup: this ensures the staging
+    # root exists and fails fast on an invalid backend config (e.g.
+    # ARTIFACT_STORE=s3 with no bucket) instead of on the first report request.
+    from src.backend.core.artifact_store import get_artifact_store
+    get_artifact_store()
 
     logging.info("Application startup complete.")
     _check_learning_health()

--- a/src/backend/services/docker_service.py
+++ b/src/backend/services/docker_service.py
@@ -19,7 +19,12 @@ TEST_EXECUTION_TIMEOUT = int(os.getenv('TEST_EXECUTION_TIMEOUT', '1800'))
 
 DOCKERFILE_PATH = os.path.join(os.path.dirname(
     os.path.abspath(__file__)), '..', '..', '..')
-ROBOT_TESTS_DIR = os.path.join(DOCKERFILE_PATH, 'robot_tests')
+
+# The artifact store owns the staging root; docker_service consumes it so there
+# is a single source of truth for the robot_tests/ path. Host-path mount
+# resolution below stays here — that is an execution concern, not storage.
+from src.backend.core.artifact_store import STAGING_ROOT
+ROBOT_TESTS_DIR = str(STAGING_ROOT)
 
 # Docker-in-Docker Support: When running inside a Docker container, we need to use
 # the host's absolute path for volume mounts, not the container's internal path.

--- a/src/backend/services/dryrun_service.py
+++ b/src/backend/services/dryrun_service.py
@@ -44,9 +44,9 @@ import requests as _requests
 from src.backend.core.config import settings
 from src.backend.core.workflow_metrics import calculate_crewai_cost
 from src.backend.crew_ai.robot_code_normalizer import normalize_robot_code
+from src.backend.core.artifact_store import get_artifact_store
 from src.backend.services.docker_service import (
     IMAGE_TAG,
-    ROBOT_TESTS_DIR,
     build_image,
     get_docker_client,
     normalize_docker_mount_source,
@@ -287,7 +287,7 @@ def run_dryrun_in_container(client, run_id: str, robot_code: str) -> dict:
     """
     container_name = f"robot-test-dryrun-{run_id}"
     dryrun_filename = "dryrun.robot"
-    dryrun_dir = os.path.join(ROBOT_TESTS_DIR, run_id, "dryrun")
+    dryrun_dir = str(get_artifact_store().run_dir(run_id) / "dryrun")
     os.makedirs(dryrun_dir, exist_ok=True)
     dryrun_filepath = os.path.join(dryrun_dir, dryrun_filename)
     output_xml_path = os.path.join(dryrun_dir, "output.xml")

--- a/src/backend/services/report_inliner.py
+++ b/src/backend/services/report_inliner.py
@@ -95,7 +95,10 @@ def inline_report_screenshots(run_dir: str | Path) -> int:
             continue
         try:
             html = html_path.read_text(encoding="utf-8")
-        except OSError as e:
+        except (OSError, UnicodeDecodeError) as e:
+            # UnicodeDecodeError is a ValueError, not an OSError; a run that wrote
+            # non-UTF-8 bytes over log.html must degrade to a skip, not break the
+            # module's documented never-raises contract.
             logger.warning("[REPORT] could not read %s: %s", html_path, e)
             continue
 
@@ -147,7 +150,7 @@ def _warn_on_uninlined(run_dir: Path) -> None:
         if p.is_file():
             try:
                 combined += p.read_text(encoding="utf-8")
-            except OSError:
+            except (OSError, UnicodeDecodeError):
                 pass
     leftover = sorted({p.name for p in imgs if p.name in combined})
     if leftover:

--- a/src/backend/services/report_inliner.py
+++ b/src/backend/services/report_inliner.py
@@ -1,0 +1,158 @@
+"""Inline external screenshot references in Robot Framework report HTML.
+
+Once /reports serves HTML under `Content-Security-Policy: sandbox`
+(report_endpoints.serve_report_file), the report document has an opaque origin
+and its sub-resource requests no longer carry the report cookie — so an external
+<img src="screenshot.png"> would 404. This module rewrites those references to
+self-contained data: URIs BEFORE the run is persisted/served.
+
+THIS MODULE IS THE SINGLE OWNER OF ROBOT'S LOG-HTML SCREENSHOT FORMAT. If a Robot
+upgrade changes how screenshots are referenced, update _SCREENSHOT_REF_RE here —
+nowhere else. inline_report_screenshots also logs a WARNING when screenshot files
+exist on disk but were not inlined, the signature of such a format change.
+
+Referenced by: services/workflow_service.py (called once after execution, before
+artifact_store.persist_run).
+Depends on: stdlib only.
+"""
+
+import base64
+import logging
+import mimetypes
+import os
+import re
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+# Report HTML we rewrite (run root only). dryrun/ artifacts are throwaway and
+# never served as a report, so they are intentionally excluded.
+_REPORT_HTML_FILES = ("log.html", "report.html")
+
+# An image reference inside Robot's log.html. The reference lives in the embedded
+# `window.output` JS blob, so the quotes are backslash-escaped:
+#   <img src=\"browser/screenshot/fail-screenshot-1.png\" .../>
+#   <a href=\"browser/screenshot/fail-screenshot-1.png\" ...>
+# The optional backslash (\\?) also matches a plain unescaped quote, so a future
+# Robot quoting change or a raw .html file still works. The path is anchored only
+# by "image extension + the file exists on disk" (see inline_report_screenshots),
+# NOT a hardcoded folder — so the Browser layout (browser/screenshot/…) and the
+# Selenium layout (selenium-screenshot-1.png at run root) both work unchanged.
+_SCREENSHOT_REF_RE = re.compile(
+    r'(src|href)=(\\?")([^"\\]+\.(?:png|jpe?g|gif))(\\?")'
+)
+
+# The image extensions _SCREENSHOT_REF_RE accepts, as a tuple the drift detector
+# (_warn_on_uninlined) reuses — so the "present but not inlined" signal never lags
+# the matcher. Keep in sync with the extension group in the regex above.
+_IMAGE_SUFFIXES = (".png", ".jpg", ".jpeg", ".gif")
+
+
+def _resolve_within(base: Path, relpath: str) -> Path | None:
+    """Resolve *relpath* under *base*; None if it escapes (.., absolute, symlink).
+    Mirrors artifact_store's containment check; kept local so this module stays
+    dependency-free."""
+    base_real = os.path.realpath(base)
+    target = os.path.realpath(os.path.join(base_real, relpath))
+    if target != base_real and not target.startswith(base_real + os.sep):
+        return None
+    return Path(target)
+
+
+def _atomic_rewrite(path: Path, content: str, count: int) -> int:
+    """Replace *path*'s contents atomically and return *count*, or 0 on failure.
+
+    /reports streams this file on another thread, so a plain write_text
+    (truncate-then-write in place) could be read mid-write as a truncated/blank
+    report. Writing a sibling temp and os.replace-ing it in is atomic on POSIX
+    and Windows. On Windows os.replace can still raise if a reader holds the file
+    open; we swallow it (the complete old file stays) and clean up the temp, so
+    the module's never-raises contract holds and a failed rewrite counts as 0.
+    """
+    tmp_path = path.with_name(path.name + ".inlining.tmp")
+    try:
+        tmp_path.write_text(content, encoding="utf-8")
+        os.replace(tmp_path, path)
+        return count
+    except OSError as e:
+        logger.warning("[REPORT] could not rewrite %s: %s", path, e)
+        tmp_path.unlink(missing_ok=True)
+        return 0
+
+
+def inline_report_screenshots(run_dir: str | Path) -> int:
+    """Rewrite external screenshot refs in a run's report HTML to data: URIs.
+
+    Returns the number of references inlined (0 is normal for a passed run with no
+    screenshots). Idempotent — data: URIs no longer match the pattern. Never
+    raises; logs a WARNING when screenshots exist on disk but remain un-inlined.
+    """
+    run_dir = Path(run_dir)
+    total = 0
+    for name in _REPORT_HTML_FILES:
+        html_path = run_dir / name
+        if not html_path.is_file():
+            continue
+        try:
+            html = html_path.read_text(encoding="utf-8")
+        except OSError as e:
+            logger.warning("[REPORT] could not read %s: %s", html_path, e)
+            continue
+
+        count = 0
+
+        def _replace(m: "re.Match[str]") -> str:
+            nonlocal count
+            relpath = m.group(3)
+            target = _resolve_within(run_dir, relpath)
+            if target is None or not target.is_file():
+                return m.group(0)  # missing / escaping — leave unchanged
+            try:
+                raw = target.read_bytes()
+            except OSError:
+                return m.group(0)
+            mime = mimetypes.guess_type(relpath)[0] or "image/png"
+            data = base64.b64encode(raw).decode("ascii")
+            count += 1
+            # Preserve the matched attribute name and (escaped) quote delimiters.
+            return f"{m.group(1)}={m.group(2)}data:{mime};base64,{data}{m.group(4)}"
+
+        new_html = _SCREENSHOT_REF_RE.sub(_replace, html)
+        if count:
+            # _atomic_rewrite returns count once the new HTML has actually
+            # landed, 0 if it could not (the complete old file stays in place).
+            total += _atomic_rewrite(html_path, new_html, count)
+
+    _warn_on_uninlined(run_dir)
+    return total
+
+
+def _warn_on_uninlined(run_dir: Path) -> None:
+    """Drift detector: if a screenshot file on disk still appears by name in the
+    served HTML, it was not inlined — likely a Robot format change. Regex-
+    independent and idempotency-safe: a successfully inlined file's name is gone
+    from the HTML (replaced by base64). Scans the same image extensions the
+    matcher accepts (_IMAGE_SUFFIXES) so the signal never lags it."""
+    imgs = [
+        p for p in run_dir.rglob("*")
+        if p.suffix.lower() in _IMAGE_SUFFIXES
+        and p.is_file()
+        and "dryrun" not in p.relative_to(run_dir).parts
+    ]
+    if not imgs:
+        return
+    combined = ""
+    for name in _REPORT_HTML_FILES:
+        p = run_dir / name
+        if p.is_file():
+            try:
+                combined += p.read_text(encoding="utf-8")
+            except OSError:
+                pass
+    leftover = sorted({p.name for p in imgs if p.name in combined})
+    if leftover:
+        logger.warning(
+            "[REPORT] screenshots present but not inlined in %s (Robot log format "
+            "may have changed; update report_inliner._SCREENSHOT_REF_RE): %s",
+            run_dir, leftover,
+        )

--- a/src/backend/services/workflow_service.py
+++ b/src/backend/services/workflow_service.py
@@ -10,7 +10,7 @@ from typing import AsyncGenerator, Generator, Dict, Any
 from datetime import datetime, timezone
 
 from src.backend.crew_ai.crew import run_crew, extract_url_from_query
-from src.backend.services.docker_service import ROBOT_TESTS_DIR, get_docker_client, build_image, run_test_in_container
+from src.backend.services.docker_service import get_docker_client, build_image, run_test_in_container
 from src.backend.services.dryrun_service import extract_and_normalize_robot_code, validate_and_repair
 from src.backend.config.logging_config import EMOJI, bind_workflow_context
 from src.backend.core.observability import create_workflow_span
@@ -21,6 +21,8 @@ from src.backend.core.workflow_metrics import (
     calculate_crewai_cost
 )
 from src.backend.core.run_registry import get_run_registry
+from src.backend.core.artifact_store import get_artifact_store
+from src.backend.services.report_inliner import inline_report_screenshots
 from src.backend.core.config import settings
 
 
@@ -974,12 +976,10 @@ async def _stream_docker_execution(run_id: str, robot_code: str, user_query: str
     freed before the background learning step — which may make a 5-30s Trigger 1
     LLM call — runs. Idempotent: the caller's finally releases the slot too.
     """
-    run_dir = os.path.join(ROBOT_TESTS_DIR, run_id)
     test_filename = "test.robot"
-    test_filepath = os.path.join(run_dir, test_filename)
+    test_filepath = str(get_artifact_store().run_dir(run_id, create=True) / test_filename)
 
     def _write_test_file():
-        os.makedirs(run_dir, exist_ok=True)
         with open(test_filepath, "w", encoding="utf-8") as f:
             f.write(robot_code)
 
@@ -1018,6 +1018,21 @@ async def _stream_docker_execution(run_id: str, robot_code: str, user_query: str
         # background learning step so a Case B re-run's Trigger 1 LLM call
         # (~5-30s) does not hold concurrency capacity it has no need for.
         release_slot()
+
+        # Inline screenshots BEFORE persist_run so the durable copy (local serve
+        # or S3 upload) is self-contained for the CSP-sandboxed report route.
+        # Wrapped: an inlining failure must never fail a successful run.
+        try:
+            n = await asyncio.to_thread(
+                inline_report_screenshots, get_artifact_store().run_dir(run_id))
+            logging.info("Inlined %d report screenshot reference(s) for %s", n, run_id)
+        except Exception as e:
+            logging.warning("Report screenshot inlining failed for %s: %s", run_id, e)
+
+        # Artifacts are final — make them durable (no-op locally; S3 upload
+        # otherwise). persist_run never raises, so a failed upload cannot turn
+        # a successful run into an error.
+        await asyncio.to_thread(get_artifact_store().persist_run, run_id)
 
         await asyncio.to_thread(_process_learning, run_id, user_query, robot_code, result)
 

--- a/tests/fixtures/robot_log_with_screenshot.html
+++ b/tests/fixtures/robot_log_with_screenshot.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<!-- Trimmed Robot Framework log.html fixture for report_inliner tests.
+     The screenshot references live inside the embedded window.output JS blob,
+     so their quotes are backslash-escaped (\") exactly as Robot emits them. The
+     failure message holds one <a href> and one <img src> to the same file, so
+     inline_report_screenshots must report exactly two inlined references. -->
+<html lang="en">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>Test Log</title>
+</head>
+<body>
+<div id="report-or-log-link"><a href="report.html">Report</a></div>
+<div id="content"></div>
+<script type="text/javascript">
+window.output = {};
+window.output["strings"] = [];
+window.output["tests"] = [[1,"Login Test","t",[],[],[],[[2,5,0,
+"<a href=\"browser/screenshot/fail-screenshot-1.png\"><img src=\"browser/screenshot/fail-screenshot-1.png\" width=\"800px\" alt=\"screenshot\"></a>"
+]]]];
+</script>
+</body>
+</html>

--- a/tests/test_api/test_history_and_reports_access.py
+++ b/tests/test_api/test_history_and_reports_access.py
@@ -8,7 +8,7 @@ Covers the three layers added for the user/admin split:
   back to own-rows.
 - authorize_report_access: /reports/{run_id}/* is served only to the run's
   owner or a validated admin; unattributed/unknown runs are admin-only (fail
-  closed). resolve_report_file keeps traversal inside the run directory.
+  closed). The artifact store keeps traversal inside the run directory.
 
 Plus the History-reuse surface (drawer + "Run again"):
 - robot_code persistence on test_runs (newest-non-NULL-wins).
@@ -366,56 +366,6 @@ class TestReportsOwnership:
 
 
 # ---------------------------------------------------------------------------
-# resolve_report_file — path containment (the file-resolution half of the fix)
-# ---------------------------------------------------------------------------
-
-class TestResolveReportFile:
-    """Pure path-safety unit tests (no DB) for the /reports file resolver."""
-
-    _RID = "11111111-1111-4111-8111-111111111111"
-    _SIBLING = "22222222-2222-4222-8222-222222222222"
-
-    @pytest.fixture
-    def run_root(self, tmp_path, monkeypatch):
-        import src.backend.api.report_endpoints as re_mod
-        monkeypatch.setattr(re_mod, "ROBOT_TESTS_DIR", str(tmp_path))
-        shots = tmp_path / self._RID / "browser" / "screenshot"
-        shots.mkdir(parents=True)
-        (tmp_path / self._RID / "log.html").write_text("ok", encoding="utf-8")
-        (shots / "s.png").write_bytes(b"\x89PNG")
-        # A sibling run the resolver must never reach by traversal.
-        (tmp_path / self._SIBLING).mkdir()
-        (tmp_path / self._SIBLING / "log.html").write_text("SECRET", encoding="utf-8")
-        return tmp_path
-
-    def test_serves_contained_file(self, run_root):
-        from src.backend.api.report_endpoints import resolve_report_file
-        assert resolve_report_file(self._RID, "log.html") is not None
-        assert resolve_report_file(self._RID, "browser/screenshot/s.png") is not None
-
-    def test_dot_dot_escape_returns_none(self, run_root):
-        from src.backend.api.report_endpoints import resolve_report_file
-        assert resolve_report_file(self._RID, f"../{self._SIBLING}/log.html") is None
-
-    def test_absolute_file_path_returns_none(self, run_root):
-        from src.backend.api.report_endpoints import resolve_report_file
-        # os.path.join discards the run root when the second arg is absolute.
-        assert resolve_report_file(self._RID, "/etc/passwd") is None
-
-    def test_non_uuid_run_id_returns_none(self, run_root):
-        from src.backend.api.report_endpoints import resolve_report_file
-        assert resolve_report_file("not-a-uuid", "log.html") is None
-
-    def test_missing_file_returns_none(self, run_root):
-        from src.backend.api.report_endpoints import resolve_report_file
-        assert resolve_report_file(self._RID, "nope.html") is None
-
-    def test_directory_returns_none(self, run_root):
-        from src.backend.api.report_endpoints import resolve_report_file
-        assert resolve_report_file(self._RID, "browser") is None
-
-
-# ---------------------------------------------------------------------------
 # /reports route — owner-gated serving + the closed bypass class (end to end)
 # ---------------------------------------------------------------------------
 
@@ -437,7 +387,9 @@ class TestReportRouteServing:
         shots = tmp_path / self._VICTIM / "browser" / "screenshot"
         shots.mkdir(parents=True)
         (shots / "fail-screenshot-1.png").write_bytes(b"\x89PNG\r\n\x1a\n")
-        monkeypatch.setattr(re_mod, "ROBOT_TESTS_DIR", str(tmp_path))
+        from src.backend.core.artifact_store import LocalArtifactStore
+        monkeypatch.setattr(
+            re_mod, "get_artifact_store", lambda: LocalArtifactStore(tmp_path))
         reg_patch = patch(
             "src.backend.core.run_registry.get_run_registry", return_value=registry
         )
@@ -481,14 +433,14 @@ class TestReportRouteServing:
         assert "hunter2" not in r.text
 
     def test_non_owner_is_403_before_file_resolution(self, report_app):
-        # Auth runs before resolve_report_file, so a non-owner is denied (403)
+        # Auth runs before store.serve_artifact, so a non-owner is denied (403)
         # whether or not the path would resolve — file existence never leaks.
         r = report_app.get("/reports/not-a-uuid/log.html", headers=self._auth(_USER2))
         assert r.status_code == 403
 
     def test_non_uuid_run_id_is_404_past_auth(self, report_app):
-        # Admin clears the ownership gate, so this exercises the route's UUID
-        # guard in resolve_report_file: a non-UUID run id resolves to no file.
+        # Admin clears the ownership gate, so this exercises the store's UUID
+        # guard: a non-UUID run id resolves to no file.
         r = report_app.get("/reports/not-a-uuid/log.html", headers=self._auth(_ADMIN))
         assert r.status_code == 404
 
@@ -519,6 +471,17 @@ class TestReportRouteServing:
         )
         assert r.status_code != 200
         assert "hunter2" not in r.text
+
+    def test_report_response_carries_csp_sandbox(self, report_app):
+        r = report_app.get(f"/reports/{self._VICTIM}/log.html", headers=self._auth(_USER1))
+        assert r.status_code == 200
+        csp = r.headers.get("content-security-policy", "")
+        assert "sandbox" in csp
+        assert "allow-scripts" in csp
+        # The absence of allow-same-origin is what produces the opaque origin.
+        assert "allow-same-origin" not in csp
+        # The existing privacy header must remain.
+        assert r.headers.get("cache-control") == "private"
 
 
 # ---------------------------------------------------------------------------
@@ -824,9 +787,10 @@ class TestRunDetailEndpoint:
         run_dir = tmp_path / _RID_NOCODE
         run_dir.mkdir()
         (run_dir / "test.robot").write_text("*** From Disk ***", encoding="utf-8")
-        with patch(
-            "src.backend.api.history_endpoints.ROBOT_TESTS_DIR", str(tmp_path)
-        ):
+        from src.backend.core.artifact_store import LocalArtifactStore
+        import src.backend.api.history_endpoints as he_mod
+        with patch.object(he_mod, "get_artifact_store",
+                          return_value=LocalArtifactStore(tmp_path)):
             client = _client(detail_seeded, _USER1)
             try:
                 body = client.get(f"/api/history/{_RID_NOCODE}").json()
@@ -835,9 +799,10 @@ class TestRunDetailEndpoint:
         assert body["robot_code"] == "*** From Disk ***"
 
     def test_no_code_anywhere_is_null(self, detail_seeded, tmp_path):
-        with patch(
-            "src.backend.api.history_endpoints.ROBOT_TESTS_DIR", str(tmp_path)
-        ):
+        from src.backend.core.artifact_store import LocalArtifactStore
+        import src.backend.api.history_endpoints as he_mod
+        with patch.object(he_mod, "get_artifact_store",
+                          return_value=LocalArtifactStore(tmp_path)):
             client = _client(detail_seeded, _USER1)
             try:
                 body = client.get(f"/api/history/{_RID_NOCODE}").json()
@@ -938,9 +903,10 @@ class TestRerunEndpoint:
         assert captured["robot_code"] == "*** Code 2 ***"
 
     def test_run_without_stored_code_is_409(self, detail_seeded, tmp_path):
-        with patch(
-            "src.backend.api.history_endpoints.ROBOT_TESTS_DIR", str(tmp_path)
-        ):
+        from src.backend.core.artifact_store import LocalArtifactStore
+        import src.backend.api.history_endpoints as he_mod
+        with patch.object(he_mod, "get_artifact_store",
+                          return_value=LocalArtifactStore(tmp_path)):
             client, captured = _rerun_client(detail_seeded, _USER1)
             try:
                 resp = client.post("/execute-test", json={"rerun_of": _RID_NOCODE})

--- a/tests/test_core/test_artifact_store.py
+++ b/tests/test_core/test_artifact_store.py
@@ -81,3 +81,285 @@ def test_factory_builds_local_by_default(monkeypatch):
     monkeypatch.setattr(mod, "_store", None)
     assert isinstance(mod.get_artifact_store(), mod.LocalArtifactStore)
     monkeypatch.setattr(mod, "_store", None)  # reset singleton for other tests
+
+
+def test_local_read_text_invalid_rid_returns_none(store):
+    assert store.read_text("not-a-uuid", "log.html") is None
+
+
+def test_local_read_text_non_utf8_returns_none(store):
+    # read_text(encoding="utf-8") raises UnicodeDecodeError (a ValueError) on
+    # binary content; it must be caught and degrade to None, not bubble out.
+    (store.run_dir(RID) / "bin.dat").write_bytes(b"\xff\xfe\x00\x01")
+    assert store.read_text(RID, "bin.dat") is None
+
+
+# ===========================================================================
+# S3ArtifactStore — unit tests with a mocked boto3 client.
+#
+# boto3 is an optional ('s3' extra) dependency NOT installed in CI, and the real
+# round-trip (MinIO) is Docker-gated in test_artifact_store_s3.py. These tests
+# inject a fake boto3 via sys.modules so the S3 backend's branch logic (key
+# building, staging-vs-bucket fallback, range/ETag headers, the symlink-escape
+# guard, error swallowing) is covered deterministically with or without boto3.
+# ===========================================================================
+import logging
+import os
+import sys
+from unittest.mock import MagicMock, Mock, patch
+
+
+def _can_symlink() -> bool:
+    import tempfile
+    d = tempfile.mkdtemp()
+    try:
+        os.symlink(os.path.join(d, "t"), os.path.join(d, "l"))
+        return True
+    except (OSError, NotImplementedError):
+        return False
+
+
+def _make_s3_store(tmp_path, monkeypatch, region="", endpoint=""):
+    """Build an S3ArtifactStore whose boto3 client is a MagicMock.
+
+    Returns (store, fake_boto3_module, mock_s3_client)."""
+    from src.backend.core.config import settings
+    monkeypatch.setattr(settings, "ARTIFACT_S3_BUCKET", "test-bucket")
+    monkeypatch.setattr(settings, "ARTIFACT_S3_PREFIX", "runs")
+    monkeypatch.setattr(settings, "ARTIFACT_S3_REGION", region)
+    monkeypatch.setattr(settings, "ARTIFACT_S3_ENDPOINT_URL", endpoint)
+    mock_client = MagicMock()
+    fake_boto3 = MagicMock()
+    fake_boto3.client.return_value = mock_client
+    with patch.dict(sys.modules, {"boto3": fake_boto3}):
+        from src.backend.core.artifact_store import S3ArtifactStore
+        store = S3ArtifactStore(tmp_path)
+    return store, fake_boto3, mock_client
+
+
+@pytest.fixture
+def s3(tmp_path, monkeypatch):
+    return _make_s3_store(tmp_path, monkeypatch,
+                          region="us-east-1", endpoint="http://minio:9000")
+
+
+# --- construction ---
+
+def test_s3_init_forwards_region_and_endpoint(s3):
+    _store, fake_boto3, _client = s3
+    fake_boto3.client.assert_called_once_with(
+        "s3", region_name="us-east-1", endpoint_url="http://minio:9000")
+
+
+def test_s3_init_omits_blank_kwargs(tmp_path, monkeypatch):
+    _store, fake_boto3, _client = _make_s3_store(tmp_path, monkeypatch)
+    fake_boto3.client.assert_called_once_with("s3")
+
+
+def test_s3_missing_boto3_raises_runtimeerror(tmp_path, monkeypatch):
+    from src.backend.core.config import settings
+    monkeypatch.setattr(settings, "ARTIFACT_S3_BUCKET", "b")
+    # sys.modules[name] = None makes `import name` raise ImportError.
+    with patch.dict(sys.modules, {"boto3": None}):
+        from src.backend.core.artifact_store import S3ArtifactStore
+        with pytest.raises(RuntimeError, match="boto3"):
+            S3ArtifactStore(tmp_path)
+
+
+def test_s3_key_joins_prefix_run_relpath(s3):
+    store, _b, _c = s3
+    assert store._key("RID", "browser/s.png") == "runs/RID/browser/s.png"
+
+
+# --- persist_run ---
+
+def test_s3_persist_uploads_all_files_then_marker(s3):
+    store, _b, client = s3
+    rid = str(uuid.uuid4())
+    run = store.run_dir(rid, create=True)
+    (run / "log.html").write_text("hi", encoding="utf-8")
+    sub = run / "browser" / "screenshot"
+    sub.mkdir(parents=True)
+    (sub / "s.png").write_bytes(b"\x89PNG")
+    store.persist_run(rid)
+    uploaded = {c.args[2] for c in client.upload_file.call_args_list}
+    assert uploaded == {f"runs/{rid}/log.html",
+                        f"runs/{rid}/browser/screenshot/s.png"}
+    assert client.put_object.call_args.kwargs["Key"] == f"runs/{rid}/.complete"
+
+
+def test_s3_persist_invalid_rid_is_noop(s3):
+    store, _b, client = s3
+    store.persist_run("not-a-uuid")
+    client.upload_file.assert_not_called()
+
+
+def test_s3_persist_missing_dir_warns_and_skips(s3, caplog):
+    store, _b, client = s3
+    rid = str(uuid.uuid4())  # never created on disk
+    with caplog.at_level(logging.WARNING):
+        store.persist_run(rid)
+    client.upload_file.assert_not_called()
+    assert any("no staging dir" in r.message for r in caplog.records)
+
+
+def test_s3_persist_upload_error_does_not_raise(s3):
+    store, _b, client = s3
+    rid = str(uuid.uuid4())
+    run = store.run_dir(rid, create=True)
+    (run / "log.html").write_text("hi", encoding="utf-8")
+    client.upload_file.side_effect = RuntimeError("network down")
+    store.persist_run(rid)  # a failed upload must never fail the user's run
+
+
+@pytest.mark.skipif(not _can_symlink(), reason="symlink creation not permitted")
+def test_s3_persist_skips_symlink_escape(s3, tmp_path, caplog):
+    store, _b, client = s3
+    rid = str(uuid.uuid4())
+    run = store.run_dir(rid, create=True)
+    (run / "log.html").write_text("hi", encoding="utf-8")
+    secret = tmp_path / "host-secret.txt"
+    secret.write_text("TOPSECRET", encoding="utf-8")
+    os.symlink(str(secret), str(run / "evil.txt"))  # escapes the run dir
+    with caplog.at_level(logging.WARNING):
+        store.persist_run(rid)
+    keys = {c.args[2] for c in client.upload_file.call_args_list}
+    assert f"runs/{rid}/log.html" in keys
+    assert f"runs/{rid}/evil.txt" not in keys  # symlink escape was not uploaded
+    assert any("unsafe path" in r.message for r in caplog.records)
+
+
+# --- read_text ---
+
+def test_s3_read_text_staging_first(s3):
+    store, _b, client = s3
+    rid = str(uuid.uuid4())
+    run = store.run_dir(rid, create=True)
+    (run / "test.robot").write_text("*** Settings ***", encoding="utf-8")
+    assert store.read_text(rid, "test.robot") == "*** Settings ***"
+    client.get_object.assert_not_called()  # served from local staging
+
+
+def test_s3_read_text_falls_back_to_bucket(s3):
+    store, _b, client = s3
+    rid = str(uuid.uuid4())
+    store.run_dir(rid, create=True)  # dir exists, file absent
+    client.get_object.return_value = {
+        "Body": Mock(read=Mock(return_value=b"from-bucket"))}
+    assert store.read_text(rid, "test.robot") == "from-bucket"
+    client.get_object.assert_called_once()
+
+
+def test_s3_read_text_unreadable_staging_falls_back_to_bucket(s3):
+    # A corrupt / non-UTF-8 local staging copy must not mask the durable bucket
+    # copy: the staging read fails and read_text falls through to S3.
+    store, _b, client = s3
+    rid = str(uuid.uuid4())
+    run = store.run_dir(rid, create=True)
+    (run / "test.robot").write_bytes(b"\xff\xfe\x00")  # exists but not valid UTF-8
+    client.get_object.return_value = {
+        "Body": Mock(read=Mock(return_value=b"clean-from-bucket"))}
+    assert store.read_text(rid, "test.robot") == "clean-from-bucket"
+    client.get_object.assert_called_once()
+
+
+def test_s3_read_text_escape_returns_none(s3):
+    store, _b, client = s3
+    rid = str(uuid.uuid4())
+    store.run_dir(rid, create=True)
+    assert store.read_text(rid, "../secret") is None
+    client.get_object.assert_not_called()
+
+
+def test_s3_read_text_bucket_miss_returns_none(s3):
+    store, _b, client = s3
+    rid = str(uuid.uuid4())
+    store.run_dir(rid, create=True)
+    client.get_object.side_effect = Exception("NoSuchKey")
+    assert store.read_text(rid, "gone.txt") is None
+
+
+def test_s3_read_text_invalid_rid_returns_none(s3):
+    store, *_ = s3
+    assert store.read_text("not-a-uuid", "x") is None
+
+
+# --- serve_artifact ---
+
+def test_s3_serve_staging_first_fileresponse(s3):
+    store, _b, client = s3
+    rid = str(uuid.uuid4())
+    run = store.run_dir(rid, create=True)
+    (run / "log.html").write_text("x", encoding="utf-8")
+    resp = store.serve_artifact(rid, "log.html")
+    assert isinstance(resp, FileResponse)
+    assert resp.headers["cache-control"] == "private"
+    client.get_object.assert_not_called()
+
+
+def test_s3_serve_bucket_streaming_200(s3):
+    from fastapi.responses import StreamingResponse
+    store, _b, client = s3
+    rid = str(uuid.uuid4())
+    store.run_dir(rid, create=True)
+    client.get_object.return_value = {
+        "Body": Mock(iter_chunks=Mock(return_value=iter([b"data"]))),
+        "ETag": '"abc123"',
+    }
+    resp = store.serve_artifact(rid, "log.html")
+    assert isinstance(resp, StreamingResponse)
+    assert resp.status_code == 200
+    assert resp.headers["etag"] == '"abc123"'
+    assert resp.headers["accept-ranges"] == "bytes"
+    assert resp.headers["cache-control"] == "private"
+
+
+def test_s3_serve_range_returns_206(s3):
+    store, _b, client = s3
+    rid = str(uuid.uuid4())
+    store.run_dir(rid, create=True)
+    client.get_object.return_value = {
+        "Body": Mock(iter_chunks=Mock(return_value=iter([b"da"]))),
+        "ContentRange": "bytes 0-1/4",
+    }
+    resp = store.serve_artifact(rid, "log.html", range_header="bytes=0-1")
+    assert resp.status_code == 206
+    assert resp.headers["content-range"] == "bytes 0-1/4"
+    assert client.get_object.call_args.kwargs["Range"] == "bytes=0-1"
+
+
+def test_s3_serve_escape_returns_none(s3):
+    store, _b, client = s3
+    rid = str(uuid.uuid4())
+    store.run_dir(rid, create=True)
+    assert store.serve_artifact(rid, "../secret") is None
+    client.get_object.assert_not_called()
+
+
+def test_s3_serve_bucket_miss_returns_none(s3):
+    store, _b, client = s3
+    rid = str(uuid.uuid4())
+    store.run_dir(rid, create=True)
+    client.get_object.side_effect = Exception("NoSuchKey")
+    assert store.serve_artifact(rid, "gone.html") is None
+
+
+def test_s3_serve_invalid_rid_returns_none(s3):
+    store, *_ = s3
+    assert store.serve_artifact("not-a-uuid", "x") is None
+
+
+# --- factory ---
+
+def test_factory_builds_s3_when_configured(tmp_path, monkeypatch):
+    import src.backend.core.artifact_store as mod
+    from src.backend.core.config import settings
+    monkeypatch.setattr(settings, "ARTIFACT_STORE", "s3")
+    monkeypatch.setattr(settings, "ARTIFACT_S3_BUCKET", "b")
+    monkeypatch.setattr(mod, "_store", None)
+    fake_boto3 = MagicMock()
+    fake_boto3.client.return_value = MagicMock()
+    with patch.dict(sys.modules, {"boto3": fake_boto3}):
+        s = mod.get_artifact_store()
+    assert isinstance(s, mod.S3ArtifactStore)
+    monkeypatch.setattr(mod, "_store", None)  # reset singleton for other tests

--- a/tests/test_core/test_artifact_store.py
+++ b/tests/test_core/test_artifact_store.py
@@ -1,0 +1,83 @@
+"""LocalArtifactStore — staging, safe-join, read_text, serve_artifact."""
+import uuid
+
+import pytest
+from fastapi.responses import FileResponse
+
+from src.backend.core.artifact_store import LocalArtifactStore
+
+RID = str(uuid.uuid4())
+
+
+@pytest.fixture
+def store(tmp_path):
+    s = LocalArtifactStore(tmp_path)
+    run = s.run_dir(RID, create=True)
+    (run / "log.html").write_text("ok", encoding="utf-8")
+    shots = run / "browser" / "screenshot"
+    shots.mkdir(parents=True)
+    (shots / "s.png").write_bytes(b"\x89PNG")
+    # a sibling run whose file must never be reachable via traversal
+    sibling = s.run_dir("11111111-1111-1111-1111-111111111111", create=True)
+    (sibling / "log.html").write_text("SECRET", encoding="utf-8")
+    return s
+
+
+def test_run_dir_creates_when_asked(tmp_path):
+    s = LocalArtifactStore(tmp_path)
+    d = s.run_dir(RID, create=True)
+    assert d.is_dir()
+    assert d == tmp_path / RID
+
+
+def test_read_text_returns_contents(store):
+    assert store.read_text(RID, "log.html") == "ok"
+
+
+def test_read_text_missing_returns_none(store):
+    assert store.read_text(RID, "nope.html") is None
+
+
+def test_serve_contained_file_returns_fileresponse(store):
+    resp = store.serve_artifact(RID, "log.html")
+    assert isinstance(resp, FileResponse)
+    assert resp.headers["cache-control"] == "private"
+    assert store.serve_artifact(RID, "browser/screenshot/s.png") is not None
+
+
+def test_serve_dot_dot_escape_returns_none(store):
+    assert store.serve_artifact(
+        RID, "../11111111-1111-1111-1111-111111111111/log.html") is None
+
+
+def test_serve_absolute_path_returns_none(store):
+    assert store.serve_artifact(RID, "/etc/passwd") is None
+
+
+def test_serve_non_uuid_run_id_returns_none(store):
+    assert store.serve_artifact("not-a-uuid", "log.html") is None
+
+
+def test_serve_directory_returns_none(store):
+    assert store.serve_artifact(RID, "browser") is None
+
+
+def test_persist_run_is_noop(store):
+    assert store.persist_run(RID) is None
+
+
+def test_s3_store_requires_bucket(tmp_path, monkeypatch):
+    from src.backend.core.config import settings
+    from src.backend.core.artifact_store import S3ArtifactStore
+    monkeypatch.setattr(settings, "ARTIFACT_S3_BUCKET", "")
+    with pytest.raises(ValueError):
+        S3ArtifactStore(tmp_path)
+
+
+def test_factory_builds_local_by_default(monkeypatch):
+    import src.backend.core.artifact_store as mod
+    from src.backend.core.config import settings
+    monkeypatch.setattr(settings, "ARTIFACT_STORE", "local")
+    monkeypatch.setattr(mod, "_store", None)
+    assert isinstance(mod.get_artifact_store(), mod.LocalArtifactStore)
+    monkeypatch.setattr(mod, "_store", None)  # reset singleton for other tests

--- a/tests/test_core/test_artifact_store_s3.py
+++ b/tests/test_core/test_artifact_store_s3.py
@@ -1,0 +1,135 @@
+"""S3ArtifactStore against a real MinIO container (no AWS account, no mocking).
+
+Spins MinIO with the docker SDK already used for test execution. Marked
+integration so it can be selected/skipped; skips cleanly when Docker is absent.
+"""
+import socket
+import time
+import uuid
+
+import pytest
+
+pytestmark = pytest.mark.integration
+
+
+def _free_port() -> int:
+    s = socket.socket()
+    s.bind(("127.0.0.1", 0))
+    port = s.getsockname()[1]
+    s.close()
+    return port
+
+
+@pytest.fixture(scope="module")
+def minio():
+    docker = pytest.importorskip("docker")
+    boto3 = pytest.importorskip("boto3")
+    try:
+        client = docker.from_env()
+        client.ping()
+    except Exception:
+        pytest.skip("Docker not available")
+    port = _free_port()
+    container = client.containers.run(
+        "minio/minio:latest",
+        command="server /data",
+        environment={"MINIO_ROOT_USER": "minio",
+                     "MINIO_ROOT_PASSWORD": "minio123"},
+        ports={"9000/tcp": port},
+        detach=True, remove=True,
+    )
+    endpoint = f"http://127.0.0.1:{port}"
+    admin = boto3.client(
+        "s3", endpoint_url=endpoint, aws_access_key_id="minio",
+        aws_secret_access_key="minio123", region_name="us-east-1")
+    ready = False
+    for _ in range(60):
+        try:
+            admin.list_buckets()
+            ready = True
+            break
+        except Exception:
+            time.sleep(1)
+    if not ready:
+        container.stop()
+        pytest.fail("MinIO did not become ready")
+    try:
+        yield {"endpoint": endpoint, "key": "minio",
+               "secret": "minio123", "admin": admin}
+    finally:
+        container.stop()
+
+
+@pytest.fixture
+def s3_store(minio, tmp_path, monkeypatch):
+    from src.backend.core.config import settings
+    from src.backend.core.artifact_store import S3ArtifactStore
+    bucket = "t" + uuid.uuid4().hex[:16]
+    minio["admin"].create_bucket(Bucket=bucket)
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", minio["key"])
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", minio["secret"])
+    monkeypatch.setattr(settings, "ARTIFACT_S3_BUCKET", bucket)
+    monkeypatch.setattr(settings, "ARTIFACT_S3_PREFIX", "runs")
+    monkeypatch.setattr(settings, "ARTIFACT_S3_REGION", "us-east-1")
+    monkeypatch.setattr(settings, "ARTIFACT_S3_ENDPOINT_URL", minio["endpoint"])
+    return S3ArtifactStore(tmp_path)
+
+
+def _seed(store, rid):
+    run = store.run_dir(rid, create=True)
+    (run / "log.html").write_text("hello report", encoding="utf-8")
+    return run
+
+
+def test_persist_then_read_from_bucket(s3_store):
+    rid = str(uuid.uuid4())
+    run = _seed(s3_store, rid)
+    s3_store.persist_run(rid)
+    # remove staging so the read MUST come from the bucket (replica scenario)
+    (run / "log.html").unlink()
+    assert s3_store.read_text(rid, "log.html") == "hello report"
+
+
+def test_persist_writes_completion_marker(s3_store):
+    rid = str(uuid.uuid4())
+    _seed(s3_store, rid)
+    s3_store.persist_run(rid)
+    head = s3_store._s3.head_object(
+        Bucket=s3_store.bucket, Key=s3_store._key(rid, ".complete"))
+    assert head["ResponseMetadata"]["HTTPStatusCode"] == 200
+
+
+def test_serve_staging_first_returns_fileresponse(s3_store):
+    from fastapi.responses import FileResponse
+    rid = str(uuid.uuid4())
+    _seed(s3_store, rid)
+    assert isinstance(s3_store.serve_artifact(rid, "log.html"), FileResponse)
+
+
+def test_serve_from_bucket_when_staging_absent(s3_store):
+    from fastapi.responses import StreamingResponse
+    rid = str(uuid.uuid4())
+    run = _seed(s3_store, rid)
+    s3_store.persist_run(rid)
+    (run / "log.html").unlink()
+    resp = s3_store.serve_artifact(rid, "log.html")
+    assert isinstance(resp, StreamingResponse)
+    assert resp.status_code == 200
+
+
+def test_serve_range_returns_206(s3_store):
+    rid = str(uuid.uuid4())
+    run = _seed(s3_store, rid)
+    s3_store.persist_run(rid)
+    (run / "log.html").unlink()
+    resp = s3_store.serve_artifact(rid, "log.html", range_header="bytes=0-3")
+    assert resp.status_code == 206
+    assert "Content-Range" in resp.headers
+
+
+def test_escape_and_bad_id_return_none(s3_store):
+    rid = str(uuid.uuid4())
+    _seed(s3_store, rid)
+    assert s3_store.serve_artifact(rid, "../x/log.html") is None
+    assert s3_store.serve_artifact("not-a-uuid", "log.html") is None
+    assert s3_store.read_text(rid, "missing.html") is None

--- a/tests/test_core/test_config_artifact_store.py
+++ b/tests/test_core/test_config_artifact_store.py
@@ -1,0 +1,26 @@
+"""ARTIFACT_STORE config validation."""
+import pytest
+from pydantic import ValidationError
+
+from src.backend.core.config import Settings
+
+
+def test_artifact_store_defaults_to_local():
+    assert Settings().ARTIFACT_STORE == "local"
+
+
+def test_artifact_store_accepts_s3_case_insensitively():
+    assert Settings(ARTIFACT_STORE="S3").ARTIFACT_STORE == "s3"
+
+
+def test_artifact_store_rejects_unknown_backend():
+    # A @validator raising ValueError surfaces as pydantic's ValidationError,
+    # which does NOT subclass ValueError in pydantic v2.
+    with pytest.raises(ValidationError):
+        Settings(ARTIFACT_STORE="gcs")
+
+
+def test_s3_settings_have_defaults():
+    s = Settings()
+    assert s.ARTIFACT_S3_BUCKET == ""
+    assert s.ARTIFACT_S3_PREFIX == "runs"

--- a/tests/test_services/test_dryrun_service.py
+++ b/tests/test_services/test_dryrun_service.py
@@ -115,7 +115,8 @@ class TestRunDryrunInContainer:
         client, container = self._client()
         run_id = "11111111-1111-1111-1111-111111111111"
 
-        with patch.object(ds, "ROBOT_TESTS_DIR", str(tmp_path)), \
+        from src.backend.core.artifact_store import LocalArtifactStore
+        with patch.object(ds, "get_artifact_store", return_value=LocalArtifactStore(tmp_path)), \
              patch.object(ds, "resolve_host_robot_tests_dir", return_value=str(tmp_path)), \
              patch.object(ds, "normalize_docker_mount_source", side_effect=lambda p: p):
             # The container "produces" output.xml under {run_id}/dryrun/
@@ -146,7 +147,8 @@ class TestRunDryrunInContainer:
         client.containers.get.return_value = stale
         run_id = "22222222-2222-2222-2222-222222222222"
 
-        with patch.object(ds, "ROBOT_TESTS_DIR", str(tmp_path)), \
+        from src.backend.core.artifact_store import LocalArtifactStore
+        with patch.object(ds, "get_artifact_store", return_value=LocalArtifactStore(tmp_path)), \
              patch.object(ds, "resolve_host_robot_tests_dir", return_value=str(tmp_path)), \
              patch.object(ds, "normalize_docker_mount_source", side_effect=lambda p: p):
             def _fake_run(**cfg):
@@ -164,7 +166,8 @@ class TestRunDryrunInContainer:
         client, container = self._client()
         run_id = "33333333-3333-3333-3333-333333333333"
         # container.run does NOT create output.xml → infra failure
-        with patch.object(ds, "ROBOT_TESTS_DIR", str(tmp_path)), \
+        from src.backend.core.artifact_store import LocalArtifactStore
+        with patch.object(ds, "get_artifact_store", return_value=LocalArtifactStore(tmp_path)), \
              patch.object(ds, "resolve_host_robot_tests_dir", return_value=str(tmp_path)), \
              patch.object(ds, "normalize_docker_mount_source", side_effect=lambda p: p):
             with pytest.raises(RuntimeError, match="no output.xml"):

--- a/tests/test_services/test_report_inliner.py
+++ b/tests/test_services/test_report_inliner.py
@@ -131,3 +131,17 @@ def test_dryrun_screenshots_ignored_by_drift_check(tmp_path, caplog):
     with caplog.at_level(logging.WARNING):
         assert inline_report_screenshots(run) == 0
     assert not any("may have changed" in r.message for r in caplog.records)
+
+
+def test_non_utf8_html_degrades_without_raising(tmp_path):
+    # A run that overwrote log.html with non-UTF-8 bytes (paste-and-execute Robot
+    # code can) must NOT break the module's never-raises contract: UnicodeDecodeError
+    # is a ValueError, not an OSError, so it has to be caught explicitly. The png
+    # on disk also forces _warn_on_uninlined to read the bad html (second site).
+    run = tmp_path / str(uuid.uuid4())
+    run.mkdir()
+    (run / "log.html").write_bytes(b"\xff\xfe not valid utf-8 <img src=\\\"x.png\\\"/>")
+    shots = run / "browser" / "screenshot"
+    shots.mkdir(parents=True)
+    (shots / "fail-screenshot-1.png").write_bytes(_PNG)
+    assert inline_report_screenshots(run) == 0  # no exception, nothing inlined

--- a/tests/test_services/test_report_inliner.py
+++ b/tests/test_services/test_report_inliner.py
@@ -1,0 +1,133 @@
+"""LocalArtifactStore-independent unit tests for report screenshot inlining."""
+import base64
+import logging
+import uuid
+from pathlib import Path
+from unittest.mock import patch
+
+from src.backend.services.report_inliner import inline_report_screenshots
+
+# A real 1x1 PNG (bytes are encoded back to base64 by the inliner under test).
+_PNG = base64.b64decode(
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg=="
+)
+_FIXTURE = Path(__file__).resolve().parents[1] / "fixtures" / "robot_log_with_screenshot.html"
+
+
+def _make_run(tmp_path, html: str, screenshots=()):
+    run = tmp_path / str(uuid.uuid4())
+    run.mkdir()
+    (run / "log.html").write_text(html, encoding="utf-8")
+    for rel in screenshots:
+        p = run / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_bytes(_PNG)
+    return run
+
+
+def test_real_fixture_inlines_both_refs(tmp_path):
+    html = _FIXTURE.read_text(encoding="utf-8")
+    run = _make_run(tmp_path, html, ["browser/screenshot/fail-screenshot-1.png"])
+    n = inline_report_screenshots(run)
+    assert n == 2  # the <a href> and the <img src>
+    out = (run / "log.html").read_text(encoding="utf-8")
+    assert "data:image/png;base64," in out
+    assert "browser/screenshot/fail-screenshot-1.png" not in out
+
+
+def test_no_temp_sidecar_left_after_inlining(tmp_path):
+    # The atomic rewrite (sibling temp + os.replace) must leave no .inlining.tmp.
+    html = 'x<img src=\\"browser/screenshot/fail-screenshot-1.png\\"/>y'
+    run = _make_run(tmp_path, html, ["browser/screenshot/fail-screenshot-1.png"])
+    assert inline_report_screenshots(run) == 1
+    assert not list(run.glob("*.inlining.tmp"))
+    assert (run / "log.html").is_file()
+
+
+def test_rewrite_failure_swallowed_leaves_original(tmp_path):
+    # A failed os.replace (e.g. a Windows reader holding the file open) must not
+    # raise, must leave the complete original in place, must clean up the temp,
+    # and must count 0 inlined (nothing landed).
+    html = 'x<img src=\\"browser/screenshot/fail-screenshot-1.png\\"/>y'
+    run = _make_run(tmp_path, html, ["browser/screenshot/fail-screenshot-1.png"])
+    with patch("src.backend.services.report_inliner.os.replace",
+               side_effect=OSError("file in use")):
+        n = inline_report_screenshots(run)
+    assert n == 0
+    assert (run / "log.html").read_text(encoding="utf-8") == html
+    assert not list(run.glob("*.inlining.tmp"))
+
+
+def test_idempotent(tmp_path):
+    html = _FIXTURE.read_text(encoding="utf-8")
+    run = _make_run(tmp_path, html, ["browser/screenshot/fail-screenshot-1.png"])
+    inline_report_screenshots(run)
+    out1 = (run / "log.html").read_text(encoding="utf-8")
+    n2 = inline_report_screenshots(run)
+    out2 = (run / "log.html").read_text(encoding="utf-8")
+    assert n2 == 0 and out1 == out2
+
+
+def test_selenium_layout_root_screenshot(tmp_path):
+    html = 'x<img src=\\"selenium-screenshot-1.png\\" />y'
+    run = _make_run(tmp_path, html, ["selenium-screenshot-1.png"])
+    assert inline_report_screenshots(run) == 1
+    assert "data:image/png;base64," in (run / "log.html").read_text(encoding="utf-8")
+
+
+def test_multiple_screenshots_all_inlined(tmp_path):
+    html = ('a<img src=\\"browser/screenshot/fail-screenshot-1.png\\"/>'
+            'b<img src=\\"browser/screenshot/fail-screenshot-2.png\\"/>')
+    run = _make_run(tmp_path, html, [
+        "browser/screenshot/fail-screenshot-1.png",
+        "browser/screenshot/fail-screenshot-2.png",
+    ])
+    assert inline_report_screenshots(run) == 2
+
+
+def test_missing_png_left_unchanged(tmp_path):
+    html = 'x<img src=\\"browser/screenshot/missing.png\\"/>y'
+    run = _make_run(tmp_path, html)  # no file created
+    assert inline_report_screenshots(run) == 0
+    assert (run / "log.html").read_text(encoding="utf-8") == html
+
+
+def test_traversal_ref_not_inlined(tmp_path):
+    (tmp_path / "secret.png").write_bytes(_PNG)
+    html = 'x<img src=\\"../secret.png\\"/>y'
+    run = _make_run(tmp_path, html)
+    assert inline_report_screenshots(run) == 0
+    out = (run / "log.html").read_text(encoding="utf-8")
+    assert "data:" not in out and "../secret.png" in out
+
+
+def test_drift_warning_when_screenshot_not_inlined(tmp_path, caplog):
+    # File exists, but it is referenced via an attribute the matcher does not
+    # target (data-foo, not src/href) -> not inlined -> filename remains -> WARN.
+    html = 'x<span data-foo=\\"browser/screenshot/fail-screenshot-1.png\\">y</span>'
+    run = _make_run(tmp_path, html, ["browser/screenshot/fail-screenshot-1.png"])
+    with caplog.at_level(logging.WARNING):
+        n = inline_report_screenshots(run)
+    assert n == 0
+    assert any("may have changed" in r.message for r in caplog.records)
+
+
+def test_drift_warning_fires_for_non_png_too(tmp_path, caplog):
+    # The drift detector scans every extension the matcher accepts, not just png,
+    # so a jpg screenshot that fails to inline still warns (matcher/detector parity).
+    html = 'x<span data-foo=\\"browser/screenshot/fail-screenshot-1.jpg\\">y</span>'
+    run = _make_run(tmp_path, html, ["browser/screenshot/fail-screenshot-1.jpg"])
+    with caplog.at_level(logging.WARNING):
+        n = inline_report_screenshots(run)
+    assert n == 0
+    assert any("may have changed" in r.message for r in caplog.records)
+
+
+def test_dryrun_screenshots_ignored_by_drift_check(tmp_path, caplog):
+    run = _make_run(tmp_path, "no screenshots here")
+    d = run / "dryrun" / "browser" / "screenshot"
+    d.mkdir(parents=True)
+    (d / "fail-screenshot-1.png").write_bytes(_PNG)
+    with caplog.at_level(logging.WARNING):
+        assert inline_report_screenshots(run) == 0
+    assert not any("may have changed" in r.message for r in caplog.records)


### PR DESCRIPTION
feat: add pluggable artifact storage for run artifacts
Two-tier artifact store (a shared staging dir the test container writes into, plus a durable local-disk or S3 backend) selected per deployment by settings.ARTIFACT_STORE. Screenshots are inlined as data URIs so the sandboxed /reports HTML stays self-contained. Wires the docker/workflow/dryrun services and the report/history endpoints to the store; adds boto3 and ARTIFACT_* settings.

Also ignore *.egg-info/ build artifacts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable artifact storage backend—now supports both local and S3-compatible storage (AWS S3, MinIO, etc.) via environment configuration.
  * Screenshots in Robot Framework reports are now automatically embedded as data URIs for improved portability.

* **Chores**
  * Updated build configuration to support optional S3 dependencies.
  * Added comprehensive test coverage for artifact storage functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->