### PR TITLE
fix: IPv4 loopback for dev hops + prevent smoke-test History pollution at source

### DIFF
--- a/src/backend/.env.example
+++ b/src/backend/.env.example
@@ -18,11 +18,14 @@ LOCAL_MODEL=qwen2.5-coder:14b
 APP_PORT=5000
 
 # --- Service Endpoints ---
+# NOTE: use 127.0.0.1, NOT localhost, for these local hops. On Windows `localhost`
+# resolves to IPv6 ::1 first; these services bind IPv4 only, so each call stalls
+# ~2s before falling back to 127.0.0.1. Compose overrides both to service names.
 # Vision BrowserUse service used for live locator extraction during generation/healing.
-BROWSER_USE_SERVICE_URL=http://localhost:4999
+BROWSER_USE_SERVICE_URL=http://127.0.0.1:4999
 
 # Phase 4 execution boundary: URL of the socket-holding executor service.
-RUNNER_EXEC_URL=http://localhost:4998
+RUNNER_EXEC_URL=http://127.0.0.1:4998
 
 # --- Browser Configuration ---
 # Browser headless mode for BrowserUse service element detection

--- a/src/backend/core/config.py
+++ b/src/backend/core/config.py
@@ -33,7 +33,10 @@ class Settings(BaseSettings):
     
     # Service Configuration
     APP_PORT: int = Field(default=5000, description="Port for FastAPI service")
-    BROWSER_USE_SERVICE_URL: str = Field(default="http://localhost:4999", description="URL for BrowserUse service")
+    # 127.0.0.1, NOT localhost: on Windows `localhost` resolves to IPv6 ::1 first
+    # and the service binds IPv4 only, so every call stalls ~2s before the IPv4
+    # fallback. Compose overrides this to the service name (browser-service:4999).
+    BROWSER_USE_SERVICE_URL: str = Field(default="http://127.0.0.1:4999", description="URL for BrowserUse service")
     
     # Browser Configuration
     BROWSER_HEADLESS: bool = Field(default=True, description="Run browser in headless mode (no UI) for BrowserUse service")
@@ -74,11 +77,14 @@ class Settings(BaseSettings):
         default=False,
         description="Phase 4: opt-in read-only rootfs for runner containers; default off until a live run proves headless Chrome tolerates it (validated in a later phase task).",
     )
-    # Phase 4: base URL of the socket-holding executor service. localhost for
+    # Phase 4: base URL of the socket-holding executor service. 127.0.0.1 for
     # `./run.sh` dev; compose overrides to the service name.
+    # 127.0.0.1, NOT localhost: on Windows `localhost` resolves to IPv6 ::1 first
+    # and the service binds IPv4 only, so every hop stalls ~2s before the IPv4
+    # fallback (execute makes two hops → ~4s). Compose overrides to runner-exec:4998.
     RUNNER_EXEC_URL: str = Field(
-        default="http://localhost:4998",  # NOSONAR — internal Docker network, no TLS needed
-        description="Phase 4: base URL of the runner-exec service; localhost for run.sh dev, http://runner-exec:4998 in compose.",
+        default="http://127.0.0.1:4998",  # NOSONAR — internal Docker network, no TLS needed
+        description="Phase 4: base URL of the runner-exec service; 127.0.0.1 for run.sh dev, http://runner-exec:4998 in compose.",
     )
 
     # LLM Empty-Response Retry Configuration

--- a/src/backend/runner_exec/client.py
+++ b/src/backend/runner_exec/client.py
@@ -22,7 +22,9 @@ try:
     from src.backend.core.config import settings
     _BASE_URL = settings.RUNNER_EXEC_URL
 except Exception:  # pragma: no cover — config may be absent in isolated unit runs
-    _BASE_URL = "http://localhost:4998"  # NOSONAR — internal Docker network, no TLS needed
+    # 127.0.0.1, NOT localhost — localhost resolves to IPv6 ::1 first on Windows
+    # and this service binds IPv4 only, adding a ~2s connect stall per hop.
+    _BASE_URL = "http://127.0.0.1:4998"  # NOSONAR — internal Docker network, no TLS needed
 
 _CONNECT_TIMEOUT_S = 5
 _QUICK_READ_TIMEOUT_S = 30           # status/cleanup/ensure-image (rebuild uses the long timeout)

--- a/src/backend/services/docker_service.py
+++ b/src/backend/services/docker_service.py
@@ -58,9 +58,21 @@ def resolve_host_robot_tests_dir(client: docker.DockerClient) -> str:
                     logging.info(
                         f"🐳 DOCKER SERVICE: Resolved host robot_tests mount from container inspect ({container_ref}): {source}")
                     return source
+        except docker.errors.NotFound:
+            # Expected miss: this candidate name isn't a running container (e.g.
+            # the machine HOSTNAME under `run.sh` dev, which is not a container at
+            # all). Not an error — we try the next candidate and fall back to
+            # HOST_ROBOT_TESTS_DIR if none match. DEBUG so it stops printing a
+            # false-alarm WARNING on every run.
+            logging.debug(
+                f"🐳 DOCKER SERVICE: container inspect miss for '{container_ref}' "
+                "(not a container); trying next candidate")
         except docker.errors.DockerException as e:
+            # A real Docker problem (daemon unreachable, permission denied, etc.) —
+            # keep this at WARNING; it may explain a downstream mount failure.
             logging.warning(
-            f"⚠️  DOCKER SERVICE: Could not resolve mount source via container inspect ({container_ref}): {type(e).__name__}: {e}")
+                "⚠️  DOCKER SERVICE: Docker error resolving mount source via container "
+                f"inspect ({container_ref}): {type(e).__name__}: {e}")
 
     logging.info(
         f"🐳 DOCKER SERVICE: Falling back to HOST_ROBOT_TESTS_DIR: {HOST_ROBOT_TESTS_DIR}")

--- a/tests/test_core/test_config.py
+++ b/tests/test_core/test_config.py
@@ -161,7 +161,16 @@ class TestSettingsValidators:
             self._make_settings({"OBSERVABILITY_BACKEND": "datadog"})
 
 
-def test_runner_exec_url_default():
+def test_local_service_urls_use_ipv4_loopback():
+    """Local service hops must default to 127.0.0.1, never localhost.
+
+    On Windows `localhost` resolves to IPv6 ::1 first; these services bind IPv4
+    only, so a `localhost` default adds a ~2s connect stall per hop (execute
+    makes two hops -> ~4s). Guard against a well-meaning revert to `localhost`.
+    """
     from src.backend.core.config import Settings
     s = Settings()
-    assert s.RUNNER_EXEC_URL == "http://localhost:4998"
+    assert s.RUNNER_EXEC_URL == "http://127.0.0.1:4998"
+    assert s.BROWSER_USE_SERVICE_URL == "http://127.0.0.1:4999"
+    assert "localhost" not in s.RUNNER_EXEC_URL
+    assert "localhost" not in s.BROWSER_USE_SERVICE_URL

--- a/tests/test_core/test_run_registry_org.py
+++ b/tests/test_core/test_run_registry_org.py
@@ -40,6 +40,28 @@ def test_record_start_persists_org_id(registry):
     assert registry.get_run_owner(rid) == (str(user["id"]), org_id)
 
 
+def test_list_runs_preserves_unattributed_error_rows(registry):
+    """Auth-off (AUTH_ENFORCED=false) dev runs have no owner, and a direct
+    paste-execute carries no NL query — so a real failure can be NULL user_id +
+    NULL user_query + status='error'. History MUST still show it: that shape is
+    indistinguishable from a real failure, so dropping it would hide the very
+    errors a developer needs to see. Junk rows are prevented at the source (the
+    /execute-test endpoint rejects an empty body with 400 before record_start),
+    not filtered out at read time. This guards against re-introducing such a
+    read-time filter."""
+    queryless_rid = _run_id()
+    queried_rid = _run_id()
+    # Paste-execute failure, no NL query typed (the shape a read-time filter ate).
+    registry.record_start(queryless_rid, None, None, "error", robot_code="*** Test Cases ***")
+    # Paste-execute failure with a query supplied for learning.
+    registry.record_start(queried_rid, None, "click the login button", "error")
+
+    rows, _total = registry.list_runs(limit=200)
+    ids = {r["run_id"] for r in rows}
+    assert queryless_rid in ids  # real failure preserved despite no owner/query
+    assert queried_rid in ids
+
+
 def test_backfill_maps_existing_rows_to_owner_org(registry):
     users, orgs = UserRepository(), OrgRepository()
     user = users.create_user(f"bf-{uuid.uuid4().hex[:8]}@e.com", "S3cretpw!")

--- a/tests/test_integration/test_live_workflow.py
+++ b/tests/test_integration/test_live_workflow.py
@@ -132,15 +132,26 @@ class TestWorkflowApiEndpoints:
         assert lines_seen >= 1
 
     def test_execute_endpoint_exists(self):
-        """POST /execute-test is reachable (may return error without valid code, but not 404)."""
+        """POST /execute-test is registered (not 404) — WITHOUT persisting a run.
+
+        Reachability must not leave a history row in the dev DB. An empty body is
+        rejected at endpoint validation ("Robot code not provided", 400) BEFORE
+        record_start runs, so this proves the route exists without triggering a
+        real execution or a test_runs row. (Earlier this posted dummy robot_code,
+        which — when the backend ran with AUTH_ENFORCED off — created an
+        ownerless, queryless 'error' run that polluted History.)
+        """
         resp = requests.post(
             f"{SERVICE_URL}/execute-test",
-            json={"robot_code": "*** Test Cases ***\nDummy\n    Log    hello"},
+            json={},  # no robot_code -> 400 before any persistence; no history row
             headers=_auth_headers(),
             timeout=10,
         )
-        # Anything except 404 — the endpoint exists
+        # A client-side rejection (400 empty body / 401 auth) proves the route is
+        # registered and that nothing reached execution. Must not be 404, and must
+        # not be a 2xx (which would mean a run actually started).
         assert resp.status_code != 404
+        assert 400 <= resp.status_code < 500
 
 
 class TestHintMetadataCache:


### PR DESCRIPTION
## Summary

Three related dev-quality fixes surfaced during a review of the current working changes.

### 1. IPv4 loopback for local service hops
Default `BROWSER_USE_SERVICE_URL`, `RUNNER_EXEC_URL`, and the `runner_exec` client fallback to `127.0.0.1` instead of `localhost`. On Windows, `localhost` resolves to IPv6 `::1` first while these services bind IPv4 only, adding a ~2s connect stall per hop (~4s on the two-hop execute path). Compose still overrides to service names. A `test_config` assertion guards against a revert to `localhost`.

### 2. docker_service log-level hygiene
Split the container-inspect exception handling: an expected `NotFound` miss (a candidate name that isn't a running container, e.g. `HOSTNAME` under `run.sh` dev) now logs at DEBUG instead of a false-alarm WARNING on every run. A genuine `DockerException` (daemon down, permission denied) stays at WARNING.

### 3. History pollution — fixed at the root cause, not patched
**Root cause:** the integration smoke test `test_execute_endpoint_exists` posted dummy Robot code to the live `/execute-test` endpoint, which — with auth off locally — persisted a real ownerless/queryless `error` run into the dev DB and surfaced it in History.

**Fix:** the test now posts an empty body, which the endpoint rejects with 400 *before* `record_start`, so no row is ever created. An earlier idea to filter these out at read time in `list_runs` was rejected and removed: a legitimate anonymous paste-execute failure has the identical row shape (`user_id` NULL, `user_query` NULL, `status='error'`, `robot_code` set), so a read-time filter would silently hide real failures — and such rows only ever occur in dev, since production runs with `AUTH_ENFORCED=true`. A regression test now asserts unattributed error runs are **preserved** in History, guarding against re-introducing such a filter.

## Testing
- `tests/test_core/test_config.py` and `tests/test_core/test_run_registry_org.py` — 25 passed (incl. Postgres integration tests).

## Notes
- `run_registry.py` has no net change (the read-time filter was reverted).
- Pre-existing dummy rows in a local dev DB are unaffected by this change; production has none.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated local service defaults to use `127.0.0.1` instead of `localhost`, improving reliability when connecting to locally running services.
  * Improved Docker container lookup handling so missing containers are treated as expected and other failures are reported more clearly.
  * Ensured run history continues to include certain error entries that were previously omitted.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->