### PR TITLE
Pin browser-use 0.13.7 in the browser-service venv lockfile

### DIFF
--- a/requirements-bus.txt
+++ b/requirements-bus.txt
@@ -6,14 +6,21 @@
 # must NEVER be installed into the backend venv. This mirrors production:
 # Dockerfile.browser-service already builds without crewai.
 #
-# Versions pinned to the working set verified on 2026-07-18 (traceloop-sdk excepted — see its line).
-browser-use==0.12.6
+# Versions pinned to the working set verified on 2026-07-18 (traceloop-sdk excepted — see its line),
+# browser-use bumped 0.12.6 -> 0.13.7 on 2026-07-31 (dependency-upgrade Phase 2).
+#
+# requests and python-dotenv are NOT independent choices: browser-use exact-pins
+# its whole tree, so bumping browser-use alone fails to resolve ("you require
+# requests==2.32.5 ... unsatisfiable"). These two are the only additional bumps
+# needed; 331 packages resolve with uv pip compile --universal, and playwright,
+# traceloop-sdk, posthog, pydantic and pydantic-settings all hold.
+browser-use==0.13.7
 playwright==1.57.0          # locator validation uses the Playwright Python API directly
 Flask==3.1.2                # HTTP service shell (gunicorn is Docker-only)
-requests==2.32.5
+requests==2.33.0            # forced: browser-use 0.13.7 exact-pins requests==2.33.0
 PyYAML==6.0.3               # needed by src.backend.core.config, imported by the entrypoint
 pydantic-settings==2.10.1
-python-dotenv==1.2.1
+python-dotenv==1.2.2        # forced: browser-use 0.13.7 exact-pins python-dotenv==1.2.2
 structlog==25.5.0           # JSON structured logging (Enhancement #4)
 traceloop-sdk==0.62.1       # OTel instrumentation (Enhancement #3), Grafana-stack only.
 # NOT 0.45.6: it pins posthog<4, unsatisfiable next to browser-use's posthog==7.7.0.


### PR DESCRIPTION
Pins `browser-use==0.13.7` in `requirements-bus.txt`, the lockfile for the
browser-service venv (`venv-bus/`). Phase 2 of the dependency-upgrade program.

Backend `venv/` is untouched — browser-use is never installed there, and that
separation is the entire reason the two-venv split exists.

## Why three packages moved, not one

browser-use exact-pins its whole dependency tree, so bumping it alone fails to
resolve. `requests` 2.32.5 → 2.33.0 and `python-dotenv` 1.2.1 → 1.2.2 are
**forced** by that pinning, not independent choices, and they are the only
additional bumps needed. 331 packages resolve with `uv pip compile --universal`;
playwright, traceloop-sdk, posthog, pydantic and pydantic-settings all hold.

## Paired browser-service change

Depends on monkscode/browser-service#22, which carries the same upgrade plus a
fix for an action-schema cost the upgrade exposed. Ordering note: this repo's
`Dockerfile.browser-service` installs `browser-service` **unpinned** from PyPI,
so the container keeps running 0.12.6 until that PR merges (which auto-publishes)
and the image is rebuilt.

## Verification

30-query bench on the upgraded build, against the 0.12.6 baseline:

| Gate | Requirement | Result |
|---|---|---|
| Pass rate | ≥ 96.7% | **30/30 = 100%** |
| `locator_success_rate` | 1.0 | 1.0, paired +0.0% |
| `flake_retries − dryrun_repairs` | 0 | 0 |
| Planner salvage | 0 | 0 cleaned, 0 empty retries |
| Tokens | flat-or-down | prompt **−1.87% paired**, up on 0/10 queries |
| Cost | flat-or-down | cache-invariant **−0.14% paired** |

Also `budget exhausted` 0/30 and unresolved elements 0/30.

Backend suite: **1783 passed, 8 skipped**.

## Honest attribution

The token improvement is **not** a benefit of 0.13.7. Measured separately:
0.13.7 on its own is **+2.1%** tokens (up on 10/10 queries — a regression, caused
by browser-use bloating `SaveAsPdfAction`'s schema, which ships on every LLM
call). The browser-service PR's `save_as_pdf` exclusion is **−3.8%**. Net is
−1.87%. That exclusion was always available on 0.12.6; the upgrade only prompted
the investigation that found it.

The upgrade's real value is dependency posture plus a cost-accounting correctness
fix (0.12.6 double-counted cached-read tokens in `UsageSummary.total_cost`;
0.13.7 charges once, so reported cost drops ~$0.0018/run as bookkeeping, not
efficiency).

## Not claimed

Timing from that bench window is **not** comparable — the baseline ran degraded
(`llm_max_s` 599.9s, a single ten-minute LLM call), which is what produces the
apparent −26% `total_s`. Phase 2 made nothing measurably faster. Two open
observations carried in the browser-service PR: a consistent `session_setup_s` /
`cold_start_s` rise (~+0.5s/run) and `locator_latency_ms` ~+10%, neither
attributed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the browser-use dependency set to version 0.13.7.
  * Updated related networking and environment-configuration packages for compatibility.
  * Added documentation describing dependency constraints and verification details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->