### PR TITLE
Declare PyYAML in the browser-service image

### DIFF
--- a/Dockerfile.browser-service
+++ b/Dockerfile.browser-service
@@ -6,13 +6,20 @@ FROM ${BASE_IMAGE}
 
 WORKDIR /app
 
-# Install browser-service and its dependencies using UV
+# Install browser-service and its dependencies using UV.
+# PyYAML is declared explicitly because the entrypoint (tools/browser_use_service.py)
+# imports src.backend.core.config, which imports yaml. It used to arrive by accident
+# as a transitive of browser-service's langchain-google-genai declaration
+# (langchain-google-genai -> langchain-core -> pyyaml); browser-service 1.0.32 dropped
+# that declaration since it has no langchain imports, which broke this image's startup.
+# requirements-bus.txt already declares PyYAML for the local bus venv for the same reason.
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv pip install --system --no-cache \
     flask \
     gunicorn \
     playwright \
     structlog>=24.1.0 \
+    PyYAML \
     browser-service && \
     playwright install chromium && \
     chmod -R 755 /opt/playwright-browsers


### PR DESCRIPTION
The rebuilt browser-service container could not start. Fixes it.

## What broke

`Dockerfile.browser-service` never declared `PyYAML`. It arrived by accident as a
transitive of `browser-service`'s `langchain-google-genai` declaration:

```
langchain-google-genai -> langchain-core -> pyyaml
```

`browser-service` 1.0.32 dropped that declaration, and it was **right** to —
`browser_service/` has zero langchain imports. But this image's entrypoint
`tools/browser_use_service.py` imports `src.backend.core.config`, which does
`import yaml`. So the upgrade silently deleted a package this image needs, and
gunicorn died on `ModuleNotFoundError: No module named 'yaml'` before binding.

## Why no gate caught it

**No test or bench imports the container entrypoint.** When this broke, the bs
suite was 1315 passed, every CI check on both PRs was green, and the 30-query
bench was 30/30. All of that ran against local venvs, never the image. Only
building the image and importing the entrypoint surfaces this class of failure —
a version probe alone reports success on a broken image.

`requirements-bus.txt:21` has always declared `PyYAML` for the local bus venv,
with the comment "needed by src.backend.core.config, imported by the entrypoint".
Only the Dockerfile relied on the accident.

## Verification on a rebuilt image

| Check | Result |
|---|---|
| `browser-use` | 0.13.7 |
| `browser-service` | 1.0.32 |
| `requests` / `python-dotenv` / `PyYAML` | 2.33.0 / 1.2.2 / 6.0.3 |
| Vendored path | `/app/tools/browser_service/agent/actions.py` (not site-packages) |
| Entrypoint import | OK, `app = Flask` |
| Container under gunicorn | `/health` returns `status: healthy` in ~2s |

Note the image installs `browser-service` **unpinned**, so its dependency closure
is an uncontrolled input — any future declaration removed upstream can delete a
package this image needs, with no gate to catch it.