### PR TITLE
Update image triggers, Vertex thinking budget, and URL extraction

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - 'src/**'
       - 'tools/**'
+      - 'pyproject.toml'
       - 'browser_service/**'
       - 'browser-service/**'
       - 'Dockerfile.fastapi'
@@ -20,6 +21,7 @@ on:
     paths:
       - 'src/**'
       - 'tools/**'
+      - 'pyproject.toml'
       - 'browser_service/**'
       - 'browser-service/**'
       - 'Dockerfile.fastapi'

--- a/.gitignore
+++ b/.gitignore
@@ -61,6 +61,10 @@ docs/tasks/
 # deliberately NOT ignored — it is tracked.
 docs/superpowers/plans/
 docs/superpowers/specs/
+# Top-level notes (HANDOFF-*, FINDINGS-*, UPSTREAM-*) were untracked but NOT
+# ignored, so `git add -A` could still sweep them in. `*` does not match `/`,
+# so this covers direct children only and leaves acceptance/ tracked.
+docs/superpowers/*.md
 .agents/workflows/development-workflow.md
 tasks/*
 logs/crewai.log.txt

--- a/bench/run_bench.py
+++ b/bench/run_bench.py
@@ -82,6 +82,25 @@ def _warn(msg: str) -> None:
     print(f"[bench] WARNING: {msg}", file=sys.stderr, flush=True)
 
 
+def warn_if_zero_crewai_tokens(data: dict, query_id: str, repeat: int,
+                               workflow_id: str) -> None:
+    """Warn when a run captured no crewai tokens at all.
+
+    crewai_tokens is ~19.9% of the baseline median llm_tokens (7,888.5 of
+    39,722), so a zeroed accumulator reads as a 20% improvement against a
+    flat-or-down token gate — an invisible false pass. The failure mode is
+    exactly zero (crewai 1.15 rerouting the agent loop through instructor),
+    not a small drift, so an equality check is the right shape.
+
+    Deliberately a warning and not a CSV column: adding a column would trip
+    gate_schema against every existing baseline.
+    """
+    if data.get("crewai_tokens", 0) == 0:
+        _warn(f"{query_id} repeat {repeat}: crewai_tokens == 0 for {workflow_id} — "
+              f"the crewai token accumulator is not being written. Do NOT trust "
+              f"llm_tokens/llm_cost_usd from this run.")
+
+
 def fetch_health(url: str) -> dict:
     """GET {url}/health or exit with a clear pointer to ./run.sh bench."""
     try:
@@ -282,6 +301,7 @@ def run_once(base_url: str, token: str | None, query_id: str, query: str,
         if ident["generation_status"] == "complete":
             data = fetch_metrics_data(conn, workflow_id)
             if data is not None:
+                warn_if_zero_crewai_tokens(data, query_id, repeat, workflow_id)
                 metrics = extract_metrics_fields(data)
                 # Guardrail number: metrics-row flakes + dryrun repair rounds.
                 metrics["flake_retries"] += repairs

--- a/src/backend/crew_ai/cleaned_llm_wrapper.py
+++ b/src/backend/crew_ai/cleaned_llm_wrapper.py
@@ -570,9 +570,15 @@ def get_llm(model_provider: str, model_name: str, api_key: Optional[str] = None,
         # LLM.__init__ has its own same-named `thinking` param (Anthropic-oriented)
         # that is never stored or forwarded, so passing thinking=... as a
         # constructor kwarg above would silently no-op. additional_params is the
-        # only attribute _prepare_completion_params forwards untouched to LiteLLM,
-        # which does map "thinking" to Vertex's thinkingConfig.thinkingBudget.
-        llm.additional_params["thinking"] = {"type": "enabled", "budget_tokens": 0}
+        # only attribute _prepare_completion_params forwards untouched to LiteLLM.
+        #
+        # Send Vertex's own thinkingConfig rather than LiteLLM's `thinking`
+        # shorthand: from litellm 1.94.1 _map_thinking_param routes every
+        # "Gemini 3 or newer" model down a thinkingLevel branch that drops the
+        # budget and emits only includeThoughts=False, which hides thoughts
+        # without stopping them. thinkingConfig reaches generationConfig
+        # untouched and reproduces what 1.75.3 put on the wire.
+        llm.additional_params["thinkingConfig"] = {"thinkingBudget": 0}
         return llm
 
     # model_provider == "gemini" — Google AI Studio.

--- a/src/backend/crew_ai/element_identification.py
+++ b/src/backend/crew_ai/element_identification.py
@@ -132,6 +132,20 @@ _NAVIGABLE_SCHEMES = frozenset({"http", "https"})
 _SCHEME_RE = re.compile(r"^([A-Za-z][A-Za-z0-9+.\-]*):")
 _PORT_RE = re.compile(r"^\d{1,5}(?:[/?#]|$)")
 
+# An absolute URL buried inside a longer value. PlannedStep has no browser
+# field, so the planner packs browser params into `value` — 21 of the 30 plans
+# in the 2026-07-31 baseline do. Usually they ride on their own step and the
+# destination stays separate; when the destination is packed in beside them
+# ("chromium, headless=True, url=https://...") the token-based passes cannot
+# see it. Restricted to the navigable schemes so this cannot readmit
+# about:blank or mailto:, which the passes above reject deliberately.
+_EMBEDDED_URL_RE = re.compile(r"https?://[^\s,;'\"<>]+", re.IGNORECASE)
+
+# Punctuation the planner leaves glued to a URL when it packs one into a list
+# or a sentence. A trailing dot is sentence punctuation here, never a root-zone
+# label — the browser service would resolve the mangled host either way.
+_VALUE_SEPARATORS = ",;."
+
 # Schemes to reject even when a bare port is what follows the colon. This is
 # the one shape the port test cannot resolve on structure: `tel` and
 # `localhost` are both valid host labels, so "tel:12345" and "localhost:12345"
@@ -236,7 +250,13 @@ def _url_candidate(value: Any) -> str | None:
     tokens = (value or "").strip().split()
     if not tokens:
         return None
-    candidate = tokens[0]
+    # A packed value leaves its separator glued to the URL
+    # ("https://books.toscrape.com, browser=chromium"), which otherwise rode
+    # through into the navigation target as a silent mangle rather than a
+    # loud skip.
+    candidate = tokens[0].rstrip(_VALUE_SEPARATORS)
+    if not candidate:
+        return None
     scheme = _explicit_scheme(candidate)
     if scheme:
         return candidate if scheme in _NAVIGABLE_SCHEMES else None
@@ -277,6 +297,23 @@ def extract_plan_url(steps: list[Any]) -> str | None:
         candidate = _url_candidate(step.get("value"))
         if candidate and _explicit_scheme(candidate) in _NAVIGABLE_SCHEMES:
             return candidate
+    # Last resort: an absolute URL packed inside a longer value. Least
+    # trusted, so it runs only after both token-based passes have failed.
+    #
+    # Scanned per token, skipping any token whose own leading scheme is
+    # non-navigable: "blob:https://x/9f8e" and "view-source:https://x" embed a
+    # real URL inside a scheme the passes above reject on purpose, and a plain
+    # search would hand it back as a navigation target.
+    for step in dict_steps:
+        for token in str(step.get("value") or "").split():
+            scheme = _explicit_scheme(token)
+            if scheme and scheme not in _NAVIGABLE_SCHEMES:
+                continue
+            match = _EMBEDDED_URL_RE.search(token)
+            if match:
+                recovered = match.group(0).rstrip(_VALUE_SEPARATORS)
+                if recovered:
+                    return recovered
     return None
 
 

--- a/tests/test_bench/test_crewai_token_guard.py
+++ b/tests/test_bench/test_crewai_token_guard.py
@@ -1,0 +1,56 @@
+"""The bench guard for a zeroed crewai token accumulator.
+
+crewai_tokens is 19.9% of the baseline median llm_tokens (7,888.5 of 39,722),
+so an accumulator that silently reads zero shows up as a ~20% IMPROVEMENT
+against a flat-or-down token gate. That is the exact failure mode the crewai
+1.15 response_model reroute produces, and it is invisible in the CSV.
+
+The guard warns at the capture point instead of adding a CSV column — a new
+column would trip gate_schema against every existing baseline.
+"""
+
+from unittest.mock import patch
+
+
+class TestCrewaiTokenGuard:
+    def test_warns_when_crewai_tokens_is_zero(self):
+        """Exactly zero is the failure signature — warn loudly."""
+        from bench.run_bench import warn_if_zero_crewai_tokens
+
+        with patch("bench.run_bench._warn") as mock_warn:
+            warn_if_zero_crewai_tokens({"crewai_tokens": 0}, "q01", 1, "wf-abc")
+
+        mock_warn.assert_called_once()
+        msg = mock_warn.call_args.args[0]
+        assert "crewai_tokens == 0" in msg
+        assert "wf-abc" in msg
+        assert "q01" in msg
+
+    def test_warns_when_crewai_tokens_key_is_absent(self):
+        """A missing key is the same blindness as a zero."""
+        from bench.run_bench import warn_if_zero_crewai_tokens
+
+        with patch("bench.run_bench._warn") as mock_warn:
+            warn_if_zero_crewai_tokens({"browser_use_tokens": 500}, "q02", 2, "wf-def")
+
+        mock_warn.assert_called_once()
+
+    def test_silent_when_crewai_tokens_is_populated(self):
+        """A healthy run must not emit noise."""
+        from bench.run_bench import warn_if_zero_crewai_tokens
+
+        with patch("bench.run_bench._warn") as mock_warn:
+            warn_if_zero_crewai_tokens({"crewai_tokens": 7888}, "q03", 1, "wf-ghi")
+
+        mock_warn.assert_not_called()
+
+    def test_warning_says_not_to_trust_the_cost_columns(self):
+        """The point of the warning is that llm_tokens and llm_cost_usd are
+        derived from crewai_tokens, so both are untrustworthy for this run."""
+        from bench.run_bench import warn_if_zero_crewai_tokens
+
+        with patch("bench.run_bench._warn") as mock_warn:
+            warn_if_zero_crewai_tokens({"crewai_tokens": 0}, "q04", 1, "wf-jkl")
+
+        msg = mock_warn.call_args.args[0]
+        assert "llm_tokens" in msg and "llm_cost_usd" in msg

--- a/tests/test_crew_ai/test_cleaned_llm_wrapper.py
+++ b/tests/test_crew_ai/test_cleaned_llm_wrapper.py
@@ -131,6 +131,11 @@ class TestGetLlm:
         stored or forwarded (verified against the pinned crewai==1.8.1 source), so
         the override must land in additional_params post-construction — that's
         the only path LLM._prepare_completion_params forwards untouched to LiteLLM.
+
+        The guard carries Vertex's own thinkingConfig, not LiteLLM's `thinking`
+        shorthand; see test_vertex_thinking_guard_maps_to_a_zero_budget_on_the_wire
+        for why, and prefer that test — it asserts the outcome rather than this
+        key, so it survives the next mapping change.
         """
         from src.backend.crew_ai.cleaned_llm_wrapper import get_llm
 
@@ -139,7 +144,45 @@ class TestGetLlm:
                                       "VERTEXAI_LOCATION": "us-central1"}):
             llm = get_llm(model_provider="vertex", model_name="gemini-3.5-flash")
 
-        assert llm.additional_params["thinking"] == {"type": "enabled", "budget_tokens": 0}
+        assert llm.additional_params["thinkingConfig"] == {"thinkingBudget": 0}
+
+    @pytest.mark.parametrize("model_name", ["gemini-3.5-flash", "gemini-2.5-flash"])
+    def test_vertex_thinking_guard_maps_to_a_zero_budget_on_the_wire(self, model_name):
+        """The guard is only worth what LiteLLM actually puts on the wire.
+
+        Asserting on additional_params (the tests above) checks our half of the
+        contract and cannot see the other half. litellm 1.94.1 silently stopped
+        honouring thinking={'budget_tokens': 0} for gemini-3.5-flash: its
+        _map_thinking_param treats any "Gemini 3 or newer" model as thinkingLevel-
+        based and emits only includeThoughts=False, so Vertex fell back to
+        server-side thinking-ON. Measured cost of that gap: reasoning tokens ate
+        the 65,535-token output allowance, truncating the planner's JSON to its
+        first step (0 elements identified, vacuous passing tests) or past
+        parsing entirely (max_tokens ConverterError, dead run).
+
+        So assert the OUTCOME, not the mechanism — whatever key we use, the
+        mapped provider params must carry a zero thinking budget for the models
+        we actually run.
+        """
+        from litellm.utils import get_optional_params
+
+        from src.backend.crew_ai.cleaned_llm_wrapper import get_llm
+
+        with patch.dict(os.environ, {"VERTEXAI_CREDENTIALS": "creds.json",
+                                      "VERTEXAI_PROJECT": "test-project",
+                                      "VERTEXAI_LOCATION": "us-central1"}):
+            llm = get_llm(model_provider="vertex", model_name=model_name)
+
+        mapped = get_optional_params(
+            model=model_name,
+            custom_llm_provider="vertex_ai",
+            **llm.additional_params,
+        )
+
+        assert mapped.get("thinkingConfig", {}).get("thinkingBudget") == 0, (
+            f"{model_name}: guard did not reach the wire as a zero thinking "
+            f"budget — mapped to {mapped.get('thinkingConfig')!r}"
+        )
 
     def test_get_llm_gemini_does_not_disable_thinking_budget(self):
         """The thinking-ON flip is Vertex-specific (probe-verified 2026-07-18) —

--- a/tests/test_crew_ai/test_element_identification.py
+++ b/tests/test_crew_ai/test_element_identification.py
@@ -199,6 +199,65 @@ class TestExtractPlanUrl:
         steps = [_step("Open Browser", value="Flipkart")]
         assert extract_plan_url(steps) == "Flipkart"
 
+    def test_compound_value_packing_params_and_url_still_yields_the_url(self):
+        """Measured on the crewai 1.15.10 bench (q01 rep2/rep3): with every
+        PlannedStep field forced required and non-null, the planner packed the
+        browser params AND the destination into one value and emitted no
+        navigation step. The first token is 'chromium,' — no scheme, no dot,
+        not alone — so both existing passes returned None, the browser call was
+        skipped and every element got a found:false placeholder.
+
+        PlannedStep has no browser field (see the dotless-site-name test), so
+        params riding in `value` is a shape the planner has always produced —
+        21 of 30 plans in the 2026-07-31 baseline carry them. Only the packed
+        variant is unreachable, and it must not cost the whole run."""
+        steps = [_step("New Browser",
+                       value="chromium, headless=True, url=https://github.com/monkscode"),
+                 _step("Get Text", description="the first pinned repository title")]
+        assert extract_plan_url(steps) == "https://github.com/monkscode"
+
+    def test_compound_value_led_by_the_url_drops_the_trailing_separator(self):
+        """Same bench, q10 rep3: value 'https://books.toscrape.com, browser=
+        chromium, headless=True'. The first token carries a navigable scheme,
+        so it was returned verbatim — including the comma — and handed to the
+        browser service as the navigation target. A silent mangle rather than a
+        loud skip, and reachable on crewai 1.8.1 too."""
+        steps = [_step("New Browser",
+                       value="https://books.toscrape.com, browser=chromium, headless=True")]
+        assert extract_plan_url(steps) == "https://books.toscrape.com"
+
+    def test_packed_url_followed_by_sentence_punctuation_is_trimmed(self):
+        """Same bench, q09 rep1: the planner narrated inside the value and left
+        a full stop glued to the URL. Same silent-mangle class as the comma —
+        the browser service would be handed a host that is not the one the
+        query named."""
+        steps = [_step("New Browser",
+                       value="setup chromium then open https://example.org/tryit.asp?x=1. Next step")]
+        assert extract_plan_url(steps) == "https://example.org/tryit.asp?x=1"
+
+    def test_compound_params_without_any_url_still_yield_none(self):
+        """The fallback must not invent a destination. This is the 21-of-30
+        baseline shape once the separate navigation step is removed: browser
+        params and nothing else."""
+        steps = [_step("New Browser", value="browser=chromium, headless=True"),
+                 _step("Input Text", description="search box", value="Cierra")]
+        assert extract_plan_url(steps) is None
+
+    def test_embedded_non_navigable_scheme_is_not_resurrected(self):
+        """about:blank and mailto: are rejected by the existing passes on
+        purpose. Scanning inside a value must not be the hole that lets them
+        back in."""
+        steps = [_step("New Browser", value="open about:blank then wait"),
+                 _step("Click", description="contact mailto:sales@example.com")]
+        assert extract_plan_url(steps) is None
+
+    def test_navigation_step_still_beats_a_packed_compound_value(self):
+        """Pass order is unchanged: a real navigation keyword outranks anything
+        recovered from inside another step's value."""
+        steps = [_step("New Browser", value="chromium, url=https://fallback.com"),
+                 _step("Go To", value="https://explicit-nav.com")]
+        assert extract_plan_url(steps) == "https://explicit-nav.com"
+
     def test_scheme_less_host_port_is_returned(self):
         """Same class as the exemplar: no dot, still a real destination."""
         steps = [_step("New Page", value="localhost:3000")]

--- a/tests/test_crew_ai/test_llm_trace_callback.py
+++ b/tests/test_crew_ai/test_llm_trace_callback.py
@@ -352,16 +352,20 @@ class TestCleanedLLMWrapperEmptyRetry:
     """
 
     def _make_wrapper(self):
-        """Live wrapper with real LLMFormattingMonitor so we can assert counters."""
+        """Live wrapper with real LLMFormattingMonitor so we can assert counters.
+
+        Built through the real constructor. The previous shortcut —
+        object.__new__ plus a stubbed BaseLLM.__init__ — stopped working on
+        crewai 1.15: BaseLLM is a Pydantic model there, so Pydantic converts
+        the single-underscore class constants (_EMPTY_RETRY_BASE_SECONDS,
+        _EMPTY_RETRY_CAP_SECONDS) into private attributes served out of
+        __pydantic_private__, and skipping BaseLLM.__init__ leaves that dict
+        uninitialised. Reading either constant then raises AttributeError.
+        Production was never affected: CleanedLLMWrapper.__new__ calls
+        BaseLLM.__init__ for real, so wrappers from get_llm() initialise it.
+        """
         from src.backend.crew_ai.cleaned_llm_wrapper import CleanedLLMWrapper
-        from src.backend.crew_ai.llm_output_cleaner import LLMFormattingMonitor
-        with patch("crewai.llm.BaseLLM.__init__", return_value=None):
-            instance = object.__new__(CleanedLLMWrapper)
-            instance.model = "vertex_ai/gemini-3.5-flash"
-            instance.context_window_size = 0
-            instance._monitor = LLMFormattingMonitor()
-            instance.base_url = None
-            return instance
+        return CleanedLLMWrapper(model="vertex_ai/gemini-3.5-flash")
 
     def _patch_settings(self, max_retries: int):
         """Patch settings.LLM_EMPTY_RESPONSE_MAX_RETRIES for the wrapper's lazy import."""


### PR DESCRIPTION
Four unrelated fixes bundled by the crewai 1.15.10 investigation that surfaced
them. The Vertex thinking guard is the one with production consequences.

## The Vertex thinking guard

litellm 1.94.1's `_map_thinking_param` routes every "Gemini 3 or newer" model
down a `thinkingLevel` branch that never emits `thinkingBudget`, so
`thinking={'type':'enabled','budget_tokens':0}` degraded to
`includeThoughts: False` — thoughts hidden from the response, still generated,
still billed. `gemini-2.5-flash` is unaffected, which is why the suite, the
container check and a live smoke all stayed green.

Measured on the real wrapper, same model, same prompt:

| litellm | completion | reasoning | output |
|---|---|---|---|
| 1.75.3 (production) | 16 | none | 66 chars |
| 1.94.1 as-is | 375 | 352 | 72 chars |
| 1.94.1 with this fix | 16 | none | 68 chars |

Cost of the gap in the 2026-08-01 bench, stopped at 9/30: reasoning tokens ate
the 65,535-token output allowance, so the planner's JSON truncated to its first
step (0 elements identified, `locator_success_rate` 0.0, tests that opened a
browser and closed it while reporting pass) or past parsing entirely
(`max_tokens` ConverterError, dead run and an all-null CSV row). Runs reached
`plan_s` 626.6s and $0.626 against a 2–4s, $0.0477 baseline.

**The fix is behaviour-neutral on the pinned litellm 1.75.3.** Verified directly
— `thinking` and `thinkingConfig` map to the identical wire payload
(`{"thinkingConfig": {"thinkingBudget": 0}}`) for both `gemini-3.5-flash` and
`gemini-2.5-flash`, and `thinkingConfig` survives litellm's `GenerationConfig`
filter into the request body.

## Bench

`bench/baselines/2026-08-02-vertex-thinking-guard.csv`, all gates green:

| Gate | Result |
|---|---|
| Pass rate ≥ 96.7% | 29/30 = 96.7% |
| `locator_success == 1.0` | min 1.000, mean 1.0000 (the 07-23 gate baseline had one 0.0) |
| `flake_retries − dryrun_repairs == 0` | 0 |
| Planner salvage | 0 |
| Tokens vs the 2026-07-23 gate | prompt 42,747 → 41,810 (−2.19%), completion 1,315 → 1,215 (−7.6%) |

Suite: 2,497 passed / 1 skipped.

**Tokens are flat-or-down, not attributable.** Nothing in this PR touches a
prompt, and the comparison is against a 10-day-old baseline with no same-day
control — so read that row as "the gate is not breached", not as a saving.
Cost is not claimed at all: it moves inside the known Gemini implicit-cache
noise band.

## URL extraction

`PlannedStep` has no browser field, so the planner improvises browser params
into `value` — 21 of the 30 plans in the 2026-07-31 baseline carry them.
Harmless while the destination rides on its own step. When it is packed in
beside them, both token-based passes miss it, `extract_plan_url` returns None,
the browser call is skipped and every element gets a `found:false` placeholder.

Adds a third, least-trusted pass that runs only after both existing passes
fail: scanned per token, restricted to http/https, skipping any token whose own
leading scheme is non-navigable (`blob:https://x/9f8e` and
`view-source:https://x` embed a real URL inside a scheme the passes above reject
on purpose), and skipping steps that TYPE a value so the URL a user wants
entered in a search box cannot become the page to open.

**Replayed over the full capture — 1,564 runs, not the 30 the third commit
claims.** 6 answers change and every one is an improvement:

| Change | Count |
|---|---|
| `None` → a correct URL | 5 |
| `https://books.toscrape.com,` → `https://books.toscrape.com` | 1 |
| A URL changed to a *different* URL | **0** |

The typed-value filter is lossless on that corpus: the embedded pass fires 5
times in 1,313 runs and all 5 are `New Browser` steps.

## Bench guard

`crewai_tokens` is ~19.9% of the baseline median `llm_tokens` (7,888.5 of
39,722), so a zeroed accumulator reads as a 20% **improvement** against a
flat-or-down token gate — a false pass no existing column reveals, and exactly
what the crewai 1.15 `response_model` reroute produces. The check is equality
against zero because the failure mode is exactly zero, and it warns at the
capture point rather than adding a CSV column (a new column would trip
`gate_schema` against every existing baseline). No false positives: across
1,567 captured runs, `crewai_tokens` is present every time and zero never.

## Review follow-ups carried on #78

Two findings against this PR's own code are fixed in #78 rather than here, so
this branch is not force-pushed under an open review:

- `test_vertex_thinking_guard_maps_to_a_zero_budget_on_the_wire` could not
  fail. `thinkingConfig` is absent from `get_supported_openai_params`, so
  LiteLLM echoes it back the way it echoes any unrecognised vertex kwarg
  (probed: `thinkingConfigTYPO` and `totalNonsenseKey` come back verbatim) —
  the assertion was satisfied by its own input. Now asserted on the built
  request body, which is the stage that can actually drop it.
- The embedded pass had no step-type filter and would return a URL out of an
  `Input Text` value. The filter described above is the fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved URL detection in compound navigation steps, including embedded web addresses and trailing punctuation.
  - Prevented unsupported URL schemes from being incorrectly treated as navigable links.
  - Improved Vertex AI model configuration for zero-budget reasoning behavior.
  - Added clearer warnings when CrewAI token metrics are missing or reported as zero, indicating that cost data may be unreliable.

- **Tests**
  - Added regression coverage for URL extraction, model configuration, and token-metric warnings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
