### PR TITLE
Stop instructing the planner to emit forbidden keys, and make the URL fallback deterministic

### DIFF
--- a/bench/run_bench.py
+++ b/bench/run_bench.py
@@ -89,8 +89,12 @@ def warn_if_zero_crewai_tokens(data: dict, query_id: str, repeat: int,
     crewai_tokens is ~19.9% of the baseline median llm_tokens (7,888.5 of
     39,722), so a zeroed accumulator reads as a 20% improvement against a
     flat-or-down token gate — an invisible false pass. The failure mode is
-    exactly zero (crewai 1.15 rerouting the agent loop through instructor),
-    not a small drift, so an equality check is the right shape.
+    exactly zero, not a small drift, so an equality check is the right shape.
+
+    The reproducer is the IN-FLIGHT crewai 1.15 upgrade, where output_pydantic
+    reroutes the agent loop through instructor and the accumulator never gets
+    written. The bench itself still runs the pinned crewai==1.8.1 — the guard
+    exists so that upgrade cannot land a silent 20% token "win".
 
     Deliberately a warning and not a CSV column: adding a column would trip
     gate_schema against every existing baseline.

--- a/src/backend/crew_ai/cleaned_llm_wrapper.py
+++ b/src/backend/crew_ai/cleaned_llm_wrapper.py
@@ -578,7 +578,18 @@ def get_llm(model_provider: str, model_name: str, api_key: Optional[str] = None,
         # budget and emits only includeThoughts=False, which hides thoughts
         # without stopping them. thinkingConfig reaches generationConfig
         # untouched and reproduces what 1.75.3 put on the wire.
-        llm.additional_params["thinkingConfig"] = {"thinkingBudget": 0}
+        #
+        # Gated on the model family, because that same switch removed the loud
+        # failure that used to cover this. Vertex also serves Anthropic, Llama
+        # and Mistral, and resolve_model_string does not check the family —
+        # ONLINE_MODEL is a free string, so one config edit reaches here with a
+        # non-Gemini model. Measured on the pinned litellm 1.75.3: `thinking`
+        # raised UnsupportedParamsError on llama/mistral and mapped to a real
+        # Anthropic param on claude, while thinkingConfig is accepted silently
+        # by all three and would ship a Gemini-only generationConfig field to a
+        # non-Gemini endpoint.
+        if "gemini" in routed_model.lower():
+            llm.additional_params["thinkingConfig"] = {"thinkingBudget": 0}
         return llm
 
     # model_provider == "gemini" — Google AI Studio.

--- a/src/backend/crew_ai/element_identification.py
+++ b/src/backend/crew_ai/element_identification.py
@@ -265,7 +265,7 @@ def _url_candidate(value: Any) -> str | None:
     return candidate if len(tokens) == 1 else None
 
 
-def extract_plan_url(steps: list[Any]) -> str | None:
+def extract_plan_url(steps: list[Any], user_query: str = "") -> str | None:
     """The URL is the first navigation step that carries one — nothing is guessed.
 
     A navigation step whose value cannot name a page — a non-navigable
@@ -286,6 +286,11 @@ def extract_plan_url(steps: list[Any]) -> str | None:
     and every element got a found:false placeholder). If no navigation step
     carries one, the first *literal* URL among the step values is taken;
     non-URL values (browser names, input text) are never eligible.
+
+    Last resort: the user's own query. Every pass above reads the plan, so all
+    of them fail together when the planner writes no destination anywhere —
+    34 of 1,260 captured runs were one prompt quirk away from exactly that
+    (see the user_query pass below).
     """
     dict_steps = [_as_dict(step) for step in steps]
     for step in dict_steps:
@@ -314,6 +319,29 @@ def extract_plan_url(steps: list[Any]) -> str | None:
                 recovered = match.group(0).rstrip(_VALUE_SEPARATORS)
                 if recovered:
                     return recovered
+    # Every pass above reads the plan. When the planner names no destination on
+    # any step, they all return None together and the run is already lost:
+    # identify_elements skips the browser call and hands every element a
+    # found:false placeholder. The user wrote the URL down too, and that copy
+    # is the one the planner cannot corrupt.
+    #
+    # This is not a new capability, it is an existing one made deliberate.
+    # Measured over 1,260 captured runs with parseable plans, 34 reached a URL
+    # ONLY because the browser-launch step's `value` carried one; blanking it
+    # makes all three passes above return None. Nothing put it there on
+    # purpose — PLANNING_OUTPUT_RULES rule 6 demanded `browser`/`headless`
+    # keys that PlannedStep does not define and the response schema forbids,
+    # so the planner improvised into `value` and the destination sometimes
+    # rode along. All 34 of those user queries state the URL in plain text.
+    #
+    # Runs last on purpose: the plan is the more specific signal, and output
+    # rule 5's search-engine default must be able to send a URL-bearing query
+    # somewhere other than the URL it names.
+    match = _EMBEDDED_URL_RE.search(user_query or "")
+    if match:
+        recovered = match.group(0).rstrip(_VALUE_SEPARATORS)
+        if recovered:
+            return recovered
     return None
 
 
@@ -557,7 +585,7 @@ def identify_elements(
     notify(22, "🔍 Scanning webpage for interactive elements...")
 
     elements, step_element_ids = build_elements(dict_steps)
-    url = extract_plan_url(dict_steps)
+    url = extract_plan_url(dict_steps, user_query)
     locator_mapping: dict[str, dict[str, Any]] = {}
 
     if elements and url:

--- a/src/backend/crew_ai/element_identification.py
+++ b/src/backend/crew_ai/element_identification.py
@@ -309,7 +309,14 @@ def extract_plan_url(steps: list[Any], user_query: str = "") -> str | None:
     # non-navigable: "blob:https://x/9f8e" and "view-source:https://x" embed a
     # real URL inside a scheme the passes above reject on purpose, and a plain
     # search would hand it back as a navigation target.
+    #
+    # Steps that TYPE a value are skipped: scanning every token would undo the
+    # first-token rule _url_candidate exists to enforce, and turn the URL a user
+    # wants entered in a search box into the page to open. Lossless — across
+    # 1,313 captured runs this pass fires 5 times, all on New Browser steps.
     for step in dict_steps:
+        if action_for_keyword(step.get("keyword") or "") in _VALUE_ACTIONS:
+            continue
         for token in str(step.get("value") or "").split():
             scheme = _explicit_scheme(token)
             if scheme and scheme not in _NAVIGABLE_SCHEMES:

--- a/src/backend/crew_ai/element_identification.py
+++ b/src/backend/crew_ai/element_identification.py
@@ -132,6 +132,11 @@ _NAVIGABLE_SCHEMES = frozenset({"http", "https"})
 _SCHEME_RE = re.compile(r"^([A-Za-z][A-Za-z0-9+.\-]*):")
 _PORT_RE = re.compile(r"^\d{1,5}(?:[/?#]|$)")
 
+# The scheme sitting directly in front of an embedded URL. Anchored to the END
+# of the text before the match, so it sees the wrapper in both "blob:https://x"
+# and "url=blob:https://x" — the leading-scheme test only saw the first.
+_PRECEDING_SCHEME_RE = re.compile(r"([A-Za-z][A-Za-z0-9+.\-]*):$")
+
 # An absolute URL buried inside a longer value. PlannedStep has no browser
 # field, so the planner packs browser params into `value` — 21 of the 30 plans
 # in the 2026-07-31 baseline do. Usually they ride on their own step and the
@@ -139,7 +144,14 @@ _PORT_RE = re.compile(r"^\d{1,5}(?:[/?#]|$)")
 # ("chromium, headless=True, url=https://...") the token-based passes cannot
 # see it. Restricted to the navigable schemes so this cannot readmit
 # about:blank or mailto:, which the passes above reject deliberately.
-_EMBEDDED_URL_RE = re.compile(r"https?://[^\s,;'\"<>]+", re.IGNORECASE)
+#
+# The comma is NOT a terminator: it is legal in an HTTP path or query, and
+# excluding it truncated "?tags=python,robot" to "?tags=python" — a valid URL
+# for a DIFFERENT page, which navigates and tests the wrong thing instead of
+# failing loudly. A genuinely trailing comma is still removed, by the rstrip
+# below. The semicolon stays excluded: it separates packed fields
+# ("url=https://x;browser=chromium") and has no such rescue.
+_EMBEDDED_URL_RE = re.compile(r"https?://[^\s;'\"<>]+", re.IGNORECASE)
 
 # Punctuation the planner leaves glued to a URL when it packs one into a list
 # or a sentence. A trailing dot is sentence punctuation here, never a root-zone
@@ -183,6 +195,12 @@ def _explicit_scheme(candidate: str) -> str | None:
     if _PORT_RE.match(candidate[match.end():]) and scheme not in _NUMERIC_PAYLOAD_SCHEMES:
         return None
     return scheme
+
+
+def _preceding_scheme(prefix: str) -> str | None:
+    """The URI scheme the text ends on, lowercased, or None."""
+    match = _PRECEDING_SCHEME_RE.search(prefix)
+    return match.group(1).lower() if match else None
 
 
 def _normalize_keyword(keyword: str | None) -> str:
@@ -297,44 +315,16 @@ def extract_plan_url(steps: list[Any], user_query: str = "") -> str | None:
     (see the user_query pass below).
     """
     dict_steps = [_as_dict(step) for step in steps]
-    for step in dict_steps:
-        if _normalize_keyword(step.get("keyword")) in _NAVIGATION_KEYWORDS:
-            candidate = _url_candidate(step.get("value"))
-            if candidate:
-                return candidate
-    for step in dict_steps:
-        candidate = _url_candidate(step.get("value"))
-        if candidate and _explicit_scheme(candidate) in _NAVIGABLE_SCHEMES:
-            return candidate
-    # Last resort: an absolute URL packed inside a longer value. Least
-    # trusted, so it runs only after both token-based passes have failed.
-    #
-    # Scanned per token, skipping any token whose own leading scheme is
-    # non-navigable: "blob:https://x/9f8e" and "view-source:https://x" embed a
-    # real URL inside a scheme the passes above reject on purpose, and a plain
-    # search would hand it back as a navigation target.
-    #
-    # Steps that TYPE a value are skipped: scanning every token would undo the
-    # first-token rule _url_candidate exists to enforce, and turn the URL a user
-    # wants entered in a search box into the page to open. Lossless — across
-    # 1,313 captured runs this pass fires 5 times, all on New Browser steps.
-    for step in dict_steps:
-        if action_for_keyword(step.get("keyword") or "") in _VALUE_ACTIONS:
-            continue
-        for token in str(step.get("value") or "").split():
-            scheme = _explicit_scheme(token)
-            if scheme and scheme not in _NAVIGABLE_SCHEMES:
-                continue
-            match = _EMBEDDED_URL_RE.search(token)
-            if match:
-                recovered = match.group(0).rstrip(_VALUE_SEPARATORS)
-                if recovered:
-                    return recovered
-    # Every pass above reads the plan. When the planner names no destination on
-    # any step, they all return None together and the run is already lost:
-    # identify_elements skips the browser call and hands every element a
-    # found:false placeholder. The user wrote the URL down too, and that copy
-    # is the one the planner cannot corrupt.
+    for find_url in (_url_on_a_navigation_step,
+                     _url_led_by_a_step_value,
+                     _url_embedded_in_a_step_value):
+        url = find_url(dict_steps)
+        if url:
+            return url
+    # Last resort — the user's own words. Every pass above reads the plan, so
+    # they fail together when the planner names no destination anywhere, and
+    # the run is then already lost: identify_elements skips the browser call
+    # and hands every element a found:false placeholder.
     #
     # This is not a new capability, it is an existing one made deliberate.
     # Measured over 1,260 captured runs with parseable plans, 34 reached a URL
@@ -349,8 +339,71 @@ def extract_plan_url(steps: list[Any], user_query: str = "") -> str | None:
     # Runs last on purpose: the plan is the more specific signal, and output
     # rule 5's search-engine default must be able to send a URL-bearing query
     # somewhere other than the URL it names.
-    match = _EMBEDDED_URL_RE.search(user_query or "")
-    if match:
+    return _recover_embedded_url(user_query)
+
+
+def _url_on_a_navigation_step(dict_steps: list[dict[str, Any]]) -> str | None:
+    """Pass 1 — the destination where the contract says it lives."""
+    for step in dict_steps:
+        if _normalize_keyword(step.get("keyword")) in _NAVIGATION_KEYWORDS:
+            candidate = _url_candidate(step.get("value"))
+            if candidate:
+                return candidate
+    return None
+
+
+def _url_led_by_a_step_value(dict_steps: list[dict[str, Any]]) -> str | None:
+    """Pass 2 — a value that *starts* with a literal URL, on any keyword.
+
+    The planner's keyword vocabulary is a free string, so the URL sometimes
+    rides on a non-navigation step (bench 2026-07-11 q03: keyword "New
+    Browser", value=<url> — the whitelist miss skipped the browser call and
+    every element got a found:false placeholder).
+    """
+    for step in dict_steps:
+        candidate = _url_candidate(step.get("value"))
+        if candidate and _explicit_scheme(candidate) in _NAVIGABLE_SCHEMES:
+            return candidate
+    return None
+
+
+def _url_embedded_in_a_step_value(dict_steps: list[dict[str, Any]]) -> str | None:
+    """Pass 3 — a URL buried mid-value, e.g. "chromium, url=https://...".
+
+    Steps that TYPE a value are skipped: scanning every token would undo the
+    first-token rule _url_candidate exists to enforce, and turn the URL a user
+    wants entered in a search box into the page to open. Lossless — across
+    1,313 captured runs this pass fires 5 times, all on New Browser steps.
+    """
+    for step in dict_steps:
+        if action_for_keyword(step.get("keyword") or "") in _VALUE_ACTIONS:
+            continue
+        recovered = _recover_embedded_url(step.get("value"))
+        if recovered:
+            return recovered
+    return None
+
+
+def _recover_embedded_url(text: Any) -> str | None:
+    """The first absolute http(s) URL inside free text, or None.
+
+    Scanned per whitespace token so a wrapper scheme cannot smuggle its payload
+    past the allowlist: "blob:https://x/9f8e" and "view-source:https://x" embed
+    a real URL inside a scheme the passes above reject on purpose.
+
+    The scheme tested is the one IMMEDIATELY BEFORE the match, not the token's
+    leading one. Testing the token's start looked equivalent and was not:
+    "url=blob:https://x" has no token-leading scheme at all — `=` is not a
+    scheme character, so the match fails and the guard waved it through — and
+    packed field labels are precisely the shape this pass exists to read.
+    """
+    for token in str(text or "").split():
+        match = _EMBEDDED_URL_RE.search(token)
+        if not match:
+            continue
+        scheme = _preceding_scheme(token[:match.start()])
+        if scheme and scheme not in _NAVIGABLE_SCHEMES:
+            continue
         recovered = match.group(0).rstrip(_VALUE_SEPARATORS)
         if recovered:
             return recovered

--- a/src/backend/crew_ai/element_identification.py
+++ b/src/backend/crew_ai/element_identification.py
@@ -337,9 +337,10 @@ def extract_plan_url(steps: list[Any], user_query: str = "") -> str | None:
     # ONLY because the browser-launch step's `value` carried one; blanking it
     # makes all three passes above return None. Nothing put it there on
     # purpose — PLANNING_OUTPUT_RULES rule 6 demanded `browser`/`headless`
-    # keys that PlannedStep does not define and the response schema forbids,
-    # so the planner improvised into `value` and the destination sometimes
-    # rode along. All 34 of those user queries state the URL in plain text.
+    # keys that PlannedStep does not define, and structured output constrains
+    # the reply to the declared properties, so the planner improvised into
+    # `value` and the destination sometimes rode along. All 34 of those user
+    # queries state the URL in plain text.
     #
     # Runs last on purpose: the plan is the more specific signal, and output
     # rule 5's search-engine default must be able to send a URL-bearing query

--- a/src/backend/crew_ai/element_identification.py
+++ b/src/backend/crew_ai/element_identification.py
@@ -266,7 +266,11 @@ def _url_candidate(value: Any) -> str | None:
 
 
 def extract_plan_url(steps: list[Any], user_query: str = "") -> str | None:
-    """The URL is the first navigation step that carries one — nothing is guessed.
+    """The URL is the first navigation step that carries one.
+
+    Four passes, most trusted first; the plan always outranks the query. Only
+    the last pass guesses: it takes the FIRST http(s) URL in the user's own
+    words, which is a guess when the query names more than one.
 
     A navigation step whose value cannot name a page — a non-navigable
     scheme, or prose — is skipped rather than trusted (see _url_candidate for
@@ -351,6 +355,42 @@ def extract_plan_url(steps: list[Any], user_query: str = "") -> str | None:
         if recovered:
             return recovered
     return None
+
+
+def adopt_recovered_url(steps: list[dict[str, Any]], url: str) -> bool:
+    """Write a URL recovered from the user query back onto the plan.
+
+    extract_plan_url feeds the browser call, but that is only half the run: the
+    Assembler is built from the merged steps and nothing else
+    (tasks.assemble_code_task takes identified_steps_json — no query, no URL
+    argument). A URL that reaches the browser call but not the plan locates
+    every element and then generates a test that never navigates.
+
+    Measured on the 34 captured runs the query pass exists to serve: with the
+    rule-6 improvisation gone, 0 of 34 carry a navigation step with a URL and 0
+    carry any http string anywhere — yet 34 of 34 emitted `New Page <url>`
+    today, because the Assembler read it out of the launch step's value. So the
+    plan is the channel, and this puts the destination back on it.
+
+    A navigation step is the right slot and wins; the launch step is the
+    fallback (the shape the Assembler already handled 34 of 34 times). The
+    value is overwritten unconditionally, which is safe only because the caller
+    reaches here exclusively after every plan pass returned None — so whatever
+    is there is prose, about:blank or nothing, never a usable destination.
+    Returns False when the plan has no slot at all.
+    """
+    fallback: dict[str, Any] | None = None
+    for step in steps:
+        keyword = _normalize_keyword(step.get("keyword"))
+        if keyword in _NAVIGATION_KEYWORDS:
+            step["value"] = url
+            return True
+        if fallback is None and keyword == "new browser":
+            fallback = step
+    if fallback is not None:
+        fallback["value"] = url
+        return True
+    return False
 
 
 def rewrite_form_description(description: str) -> str:
@@ -593,7 +633,17 @@ def identify_elements(
     notify(22, "🔍 Scanning webpage for interactive elements...")
 
     elements, step_element_ids = build_elements(dict_steps)
-    url = extract_plan_url(dict_steps, user_query)
+    url = extract_plan_url(dict_steps)
+    if url is None:
+        # Last resort. The plan named no destination, so fall back to the user's
+        # own words — and put the answer back on the plan, because the Assembler
+        # reads the destination from there and from nowhere else.
+        url = extract_plan_url(dict_steps, user_query)
+        if url is not None and not adopt_recovered_url(dict_steps, url):
+            logger.warning(
+                "Recovered URL %s from the user query but the plan has no "
+                "navigation or launch step to carry it — the browser call will "
+                "run, the generated test will not navigate", url)
     locator_mapping: dict[str, dict[str, Any]] = {}
 
     if elements and url:

--- a/src/backend/crew_ai/prompts/components.py
+++ b/src/backend/crew_ai/prompts/components.py
@@ -769,9 +769,7 @@ If the user's query implies a loop (e.g., "for every link", "for each item"), yo
 3.  For validation steps, use "Should Be True" keyword with a "condition_expression" key.
 4.  The keys `condition_type`, `condition_value`, `loop_type`, and `loop_source` are OPTIONAL and should only be included for steps with conditional logic or loops.
 5.  If the query involves a web search (e.g., "search for X") but does not specify a URL, you MUST generate a first step to open a search engine. Use 'https://www.google.com' as the value for the URL.
-6.  When generating a browser initialization step, you MUST include library-specific parameters:
-{browser_init_placeholder}
-7.  **MOST CRITICAL**: DO NOT add popup dismissal, cookie consent, or any steps not explicitly mentioned in user query. The browser automation handles these automatically.
+6.  **MOST CRITICAL**: DO NOT add popup dismissal, cookie consent, or any steps not explicitly mentioned in user query. The browser automation handles these automatically.
 """
 
     # NOTE: the IDENTIFICATION COMPONENTS (FORM_ELEMENT_HANDLING,

--- a/src/backend/crew_ai/tasks.py
+++ b/src/backend/crew_ai/tasks.py
@@ -393,7 +393,6 @@ class RobotTasks:
         # RobotAgents._get_agent_context); the task description used to re-ship
         # both verbatim (~1,130 tokens/run, finding F1).
         self._cached_keyword_guidelines = self._get_keyword_guidelines()
-        self._cached_browser_init = self._get_browser_init_instructions()
 
     def _get_keyword_guidelines(self) -> str:
         """Get MINIMAL keyword guidelines for planning phase."""
@@ -410,28 +409,6 @@ class RobotTasks:
             • Keyboard Actions: Pressing keys
             
             Focus on HIGH-LEVEL steps. Code Assembler handles details.
-            """
-
-    def _get_browser_init_instructions(self) -> str:
-        """Get library-specific browser initialization instructions."""
-        if self.library_context:
-            params = self.library_context.browser_init_params
-            # Browser Library is the only supported target (Task 11/E8)
-            param_list = ', '.join([f'{k}={v}' for k, v in params.items()])
-            return f"""
-    - For Browser Library: Use "New Browser" keyword
-    - Include these parameters: {param_list}
-    - Example: {{"keyword": "New Browser", "browser": "{params.get('browser', 'chromium')}", "headless": "{params.get('headless', 'True')}"}}
-    - DO NOT include 'options' parameter for Browser Library
-            """
-        else:
-            # Fallback when constructed without a context (identification-only
-            # usage in tests) — Browser Library defaults.
-            logger.warning(
-                "No library context available, using Browser Library defaults")
-            return """
-    - Use "New Browser" keyword with browser=chromium and headless parameters
-    - Example: {"keyword": "New Browser", "browser": "chromium", "headless": "True"}
             """
 
     def _get_task_hints(self, role: str) -> str:
@@ -491,7 +468,7 @@ class RobotTasks:
 
             {PromptComponents.PLANNING_LOOP_HANDLING}
 
-            {PromptComponents.PLANNING_OUTPUT_RULES.replace("{browser_init_placeholder}", self._cached_browser_init)}
+            {PromptComponents.PLANNING_OUTPUT_RULES}
 
             """
         return Task(

--- a/tests/test_bench/test_crewai_token_guard.py
+++ b/tests/test_bench/test_crewai_token_guard.py
@@ -2,8 +2,12 @@
 
 crewai_tokens is 19.9% of the baseline median llm_tokens (7,888.5 of 39,722),
 so an accumulator that silently reads zero shows up as a ~20% IMPROVEMENT
-against a flat-or-down token gate. That is the exact failure mode the crewai
-1.15 response_model reroute produces, and it is invisible in the CSV.
+against a flat-or-down token gate, and it is invisible in the CSV.
+
+That is the exact failure mode the IN-FLIGHT crewai 1.15 upgrade produces —
+its response_model reroute sends the agent loop through instructor and the
+accumulator is never written. The bench runs the pinned crewai==1.8.1; the
+guard exists so the upgrade cannot land a silent 20% token "win".
 
 The guard warns at the capture point instead of adding a CSV column — a new
 column would trip gate_schema against every existing baseline.

--- a/tests/test_crew_ai/test_cleaned_llm_wrapper.py
+++ b/tests/test_crew_ai/test_cleaned_llm_wrapper.py
@@ -133,9 +133,9 @@ class TestGetLlm:
         the only path LLM._prepare_completion_params forwards untouched to LiteLLM.
 
         The guard carries Vertex's own thinkingConfig, not LiteLLM's `thinking`
-        shorthand; see test_vertex_thinking_guard_maps_to_a_zero_budget_on_the_wire
-        for why, and prefer that test — it asserts the outcome rather than this
-        key, so it survives the next mapping change.
+        shorthand; see test_vertex_thinking_guard_reaches_the_request_body for
+        why, and prefer that test — this one only checks that we set the key,
+        which says nothing about whether it survives into the request.
         """
         from src.backend.crew_ai.cleaned_llm_wrapper import get_llm
 
@@ -147,7 +147,7 @@ class TestGetLlm:
         assert llm.additional_params["thinkingConfig"] == {"thinkingBudget": 0}
 
     @pytest.mark.parametrize("model_name", ["gemini-3.5-flash", "gemini-2.5-flash"])
-    def test_vertex_thinking_guard_maps_to_a_zero_budget_on_the_wire(self, model_name):
+    def test_vertex_thinking_guard_reaches_the_request_body(self, model_name):
         """The guard is only worth what LiteLLM actually puts on the wire.
 
         Asserting on additional_params (the tests above) checks our half of the
@@ -160,11 +160,27 @@ class TestGetLlm:
         first step (0 elements identified, vacuous passing tests) or past
         parsing entirely (max_tokens ConverterError, dead run).
 
-        So assert the OUTCOME, not the mechanism — whatever key we use, the
-        mapped provider params must carry a zero thinking budget for the models
-        we actually run.
+        Assert on the BUILT REQUEST BODY, not on get_optional_params. Since the
+        guard switched from `thinking` to `thinkingConfig` it no longer passes
+        through any mapping: `thinkingConfig` is absent from
+        get_supported_openai_params(), so LiteLLM echoes it back verbatim the way
+        it echoes any unrecognised vertex kwarg (probe: thinkingConfigTYPO and
+        totalNonsenseKey come back untouched). A test on that stage is satisfied
+        by its own input and cannot fail.
+
+        The stage that CAN drop it is _transform_request_body, which filters
+        optional_params against GenerationConfig.__annotations__ before building
+        generationConfig. Drop `thinkingConfig` from that TypedDict — exactly the
+        shape of the 1.94.1 change — and the body comes back {} while the
+        get_optional_params assertion stays green.
+
+        Importing a private LiteLLM helper is deliberate: if a future bump moves
+        or renames it the import fails loudly on the version bump, which is when
+        the wire needs re-verifying anyway.
         """
-        from litellm.utils import get_optional_params
+        from litellm.llms.vertex_ai.gemini.transformation import (
+            _transform_request_body,
+        )
 
         from src.backend.crew_ai.cleaned_llm_wrapper import get_llm
 
@@ -173,15 +189,19 @@ class TestGetLlm:
                                       "VERTEXAI_LOCATION": "us-central1"}):
             llm = get_llm(model_provider="vertex", model_name=model_name)
 
-        mapped = get_optional_params(
+        body = _transform_request_body(
+            messages=[{"role": "user", "content": "ping"}],
             model=model_name,
+            optional_params=dict(llm.additional_params),
             custom_llm_provider="vertex_ai",
-            **llm.additional_params,
+            litellm_params={},
+            cached_content=None,
         )
+        generation_config = body.get("generationConfig", {})
 
-        assert mapped.get("thinkingConfig", {}).get("thinkingBudget") == 0, (
-            f"{model_name}: guard did not reach the wire as a zero thinking "
-            f"budget — mapped to {mapped.get('thinkingConfig')!r}"
+        assert generation_config.get("thinkingConfig", {}).get("thinkingBudget") == 0, (
+            f"{model_name}: the guard did not survive into the request body as a "
+            f"zero thinking budget — generationConfig was {generation_config!r}"
         )
 
     def test_get_llm_gemini_does_not_disable_thinking_budget(self):

--- a/tests/test_crew_ai/test_cleaned_llm_wrapper.py
+++ b/tests/test_crew_ai/test_cleaned_llm_wrapper.py
@@ -204,6 +204,37 @@ class TestGetLlm:
             f"zero thinking budget — generationConfig was {generation_config!r}"
         )
 
+    @pytest.mark.parametrize("model_name", [
+        "claude-sonnet-4@20250514",
+        "llama-3.1-405b-instruct-maas",
+        "mistral-large@2411",
+    ])
+    def test_non_gemini_vertex_models_get_no_thinking_config(self, model_name):
+        """thinkingConfig is a Gemini generationConfig field. Vertex also serves
+        Anthropic, Llama and Mistral, and resolve_model_string does not check
+        the family — ONLINE_MODEL is a free string, so one config edit reaches
+        this branch with a non-Gemini model.
+
+        Switching from `thinking` to `thinkingConfig` removed the loud failure
+        that used to cover that. Measured on the pinned litellm 1.75.3:
+
+            thinking       llama/mistral -> UnsupportedParamsError (loud)
+                           claude        -> a valid Anthropic thinking param
+            thinkingConfig every one     -> silently accepted, Gemini-only
+                                            field shipped to a non-Gemini model
+
+        So the guard has to carry its own family check."""
+        from src.backend.crew_ai.cleaned_llm_wrapper import get_llm
+
+        with patch.dict(os.environ, {"VERTEXAI_CREDENTIALS": "creds.json",
+                                      "VERTEXAI_PROJECT": "test-project",
+                                      "VERTEXAI_LOCATION": "us-central1"}):
+            llm = get_llm(model_provider="vertex", model_name=model_name)
+
+        assert "thinkingConfig" not in llm.additional_params, (
+            f"{model_name} is not a Gemini model — a Gemini-only "
+            f"generationConfig field must not be attached to it")
+
     def test_get_llm_gemini_does_not_disable_thinking_budget(self):
         """The thinking-ON flip is Vertex-specific (probe-verified 2026-07-18) —
         Google AI Studio isn't touched, so gemini provider must stay untouched."""

--- a/tests/test_crew_ai/test_element_identification.py
+++ b/tests/test_crew_ai/test_element_identification.py
@@ -811,6 +811,56 @@ class TestIdentifyElements:
         assert result["steps"][1]["locator"] == "ol > li"
         assert result["steps"][1]["found"] is True
 
+    def test_a_query_recovered_url_is_written_back_onto_the_plan(self):
+        """The browser call is only half the run. The Assembler is built from
+        these steps alone (assemble_code_task takes identified_steps_json and
+        nothing else — no query, no URL argument), so a URL recovered from the
+        query would locate elements and then generate a test that never
+        navigates.
+
+        Measured on the 34 captured runs this fallback exists to serve: after
+        the rule-6 improvisation is gone, 0 of 34 still carry a navigation step
+        with a URL and 0 carry any http string anywhere — yet 34 of 34 emitted a
+        New Page with a URL today, because the Assembler read it out of the
+        launch step's value. Blanking that value without writing the recovered
+        URL back reproduces the captured vacuous artifact: New Browser →
+        New Context → Close Browser, a browser opened and closed."""
+        steps = [
+            _step("New Browser"),
+            _step("Get Elements", description="all book titles"),
+        ]
+        run_tool, _ = self._tool_recorder(self._success_response({
+            "elem_1": _mapping_entry(locator="ol > li"),
+        }))
+        result = identify_elements(
+            steps, "Go to https://books.toscrape.com, get the titles of all books",
+            run_tool=run_tool)
+
+        values = [s.get("value") for s in result["steps"]]
+        assert "https://books.toscrape.com" in values, (
+            "the Assembler sees only these steps — a URL that reaches the "
+            f"browser call but not the plan generates a test that never "
+            f"navigates; got {values!r}")
+
+    def test_a_url_already_in_the_plan_is_never_rewritten(self):
+        """Write-back is for the recovered case only. When the plan names the
+        destination itself, the steps must come back untouched — the query is
+        the backstop, never an override."""
+        steps = [
+            _step("New Page", value="https://explicit-nav.com"),
+            _step("Get Elements", description="all book titles"),
+        ]
+        run_tool, calls = self._tool_recorder(self._success_response({
+            "elem_1": _mapping_entry(locator="ol > li"),
+        }))
+        result = identify_elements(
+            steps, "Go to https://books.toscrape.com, get all titles",
+            run_tool=run_tool)
+
+        assert calls[0]["url"] == "https://explicit-nav.com"
+        assert [s.get("value") for s in result["steps"]][0] == "https://explicit-nav.com"
+        assert "https://books.toscrape.com" not in str(result["steps"])
+
     def test_a_plan_without_any_url_and_a_query_without_one_still_skips(self):
         """The complement — the pass must not invent a destination. No URL
         anywhere means the browser call is skipped, exactly as before."""

--- a/tests/test_crew_ai/test_element_identification.py
+++ b/tests/test_crew_ai/test_element_identification.py
@@ -251,6 +251,34 @@ class TestExtractPlanUrl:
                  _step("Click", description="contact mailto:sales@example.com")]
         assert extract_plan_url(steps) is None
 
+    def test_a_url_being_typed_into_a_field_is_not_a_navigation_target(self):
+        """The embedded pass must not undo the first-token rule it sits behind.
+
+        _url_candidate reads only the first token precisely so that prose and
+        typed text cannot become the destination. The embedded pass scans every
+        token, so without a filter the string the user wants TYPED into a search
+        box becomes the page to open — here a competitor's site instead of the
+        one under test.
+
+        Reachable: pass 1 rejects the documented "New Page -> about:blank"
+        shape (4 of 897 captured runs), pass 2 finds no step led by a URL, and
+        pass 3 then reaches the Input Text value.
+
+        Provably lossless: across 1,313 captured runs the embedded pass fires 5
+        times and all 5 are New Browser steps (action get_text) — never an
+        input or select."""
+        steps = [_step("New Page", value="about:blank"),
+                 _step("Input Text", description="search box",
+                       value="find reviews of https://competitor.example.com")]
+        assert extract_plan_url(steps) is None
+
+    def test_the_embedded_pass_still_reads_a_launch_step(self):
+        """The complement — the 5 real captured hits are all this shape, so the
+        input/select filter must not cost them."""
+        steps = [_step("New Page", value="about:blank"),
+                 _step("New Browser", value="chromium, url=https://github.com/monkscode")]
+        assert extract_plan_url(steps) == "https://github.com/monkscode"
+
     def test_navigation_step_still_beats_a_packed_compound_value(self):
         """Pass order is unchanged: a real navigation keyword outranks anything
         recovered from inside another step's value."""

--- a/tests/test_crew_ai/test_element_identification.py
+++ b/tests/test_crew_ai/test_element_identification.py
@@ -279,6 +279,38 @@ class TestExtractPlanUrl:
                  _step("New Browser", value="chromium, url=https://github.com/monkscode")]
         assert extract_plan_url(steps) == "https://github.com/monkscode"
 
+    def test_a_comma_inside_the_query_string_is_not_a_terminator(self):
+        """A comma is legal in an HTTP path or query. Excluding it from the
+        match class truncated `?tags=python,robot` to `?tags=python` — not a
+        loud mangle but a VALID URL for a different page, which is the worst
+        shape: the run navigates, locates, and tests the wrong thing.
+
+        The comma still terminates in practice where it matters, because
+        rstrip(_VALUE_SEPARATORS) removes it when it is genuinely trailing.
+        The semicolon stays excluded — it is a real packed-value separator
+        ("url=https://x;browser=chromium") with no such rescue."""
+        steps = [_step("New Browser",
+                       value="chromium, url=https://example.org/s?tags=python,robot")]
+        assert extract_plan_url(steps) == "https://example.org/s?tags=python,robot"
+
+    def test_a_semicolon_still_separates_packed_fields(self):
+        steps = [_step("New Browser", value="url=https://example.com;browser=chromium")]
+        assert extract_plan_url(steps) == "https://example.com"
+
+    def test_a_packed_field_label_cannot_smuggle_a_non_navigable_scheme(self):
+        """The scheme guard read only the START of the token, but `url=` breaks
+        the scheme match (`=` is not a scheme character), so `_explicit_scheme`
+        returned None and the guard passed — then the regex recovered the
+        embedded https URL. blob: and view-source: wrap a real URL inside a
+        scheme the passes above reject on purpose; the packed form is the shape
+        this pass exists to read, so it is exactly where the hole was."""
+        assert extract_plan_url(
+            [_step("New Browser", value="chromium, url=blob:https://example.com/9f8e")]
+        ) is None
+        assert extract_plan_url(
+            [_step("New Browser", value="chromium, url=view-source:https://example.com")]
+        ) is None
+
     def test_navigation_step_still_beats_a_packed_compound_value(self):
         """Pass order is unchanged: a real navigation keyword outranks anything
         recovered from inside another step's value."""
@@ -438,6 +470,22 @@ class TestExtractPlanUrlFromUserQuery:
         assert extract_plan_url(steps, self.QUERY) == "https://books.toscrape.com"
         assert extract_plan_url(steps, "Go to https://example.org/a. Then click.") == \
             "https://example.org/a"
+
+    def test_a_wrapper_scheme_in_the_query_is_not_a_destination(self):
+        """The query pass searched the whole string with no scheme check, so a
+        wrapper scheme recovered its payload and navigated there — the plan
+        passes reject exactly that. Same allowlist, both sides."""
+        steps = [_step("New Browser")]
+        assert extract_plan_url(steps, "Open view-source:https://example.com now") is None
+        assert extract_plan_url(steps, "Open blob:https://example.com/9f8e now") is None
+
+    def test_a_wrapper_scheme_does_not_hide_a_later_real_url(self):
+        """Rejecting the wrapper token must not abandon the query — a genuine
+        URL further along is still the destination."""
+        steps = [_step("New Browser")]
+        assert extract_plan_url(
+            steps, "Ignore blob:https://cdn.example.net/x and go to https://real.example.com"
+        ) == "https://real.example.com"
 
     def test_the_first_url_in_the_query_is_the_destination(self):
         """Queries read left to right; the opening navigation is the target."""

--- a/tests/test_crew_ai/test_element_identification.py
+++ b/tests/test_crew_ai/test_element_identification.py
@@ -754,6 +754,42 @@ class TestIdentifyElements:
         assert result["steps"][1]["locator"] == "name=q"
         assert result["steps"][2]["locator"] == "css=.product"
 
+    def test_query_url_reaches_the_browser_call_when_the_plan_has_none(self):
+        """The wiring, not the function. extract_plan_url's query pass is unit
+        tested and was replayed over 1,260 captured plans, but both exercise it
+        directly — neither proves identify_elements forwards user_query to it,
+        nor that the browser call then happens at all.
+
+        The 2026-08-02 bench could not close this: every one of its 30 plans
+        carried its own navigation step, so the pass never executed. Without
+        the forward, this plan reaches the documented dead end instead — no
+        URL, no browser call, every element a found:false placeholder."""
+        steps = [
+            _step("New Browser"),
+            _step("Get Elements", description="all book titles"),
+        ]
+        run_tool, calls = self._tool_recorder(self._success_response({
+            "elem_1": _mapping_entry(locator="ol > li"),
+        }))
+        result = identify_elements(
+            steps, "Go to https://books.toscrape.com, get the titles of all books",
+            run_tool=run_tool)
+
+        assert len(calls) == 1, "the browser call must happen, not be skipped"
+        assert calls[0]["url"] == "https://books.toscrape.com"
+        assert result["steps"][1]["locator"] == "ol > li"
+        assert result["steps"][1]["found"] is True
+
+    def test_a_plan_without_any_url_and_a_query_without_one_still_skips(self):
+        """The complement — the pass must not invent a destination. No URL
+        anywhere means the browser call is skipped, exactly as before."""
+        steps = [_step("New Browser"), _step("Click", description="login button")]
+        run_tool, calls = self._tool_recorder(self._success_response({}))
+        result = identify_elements(steps, "click the login button", run_tool=run_tool)
+
+        assert calls == [], "no URL anywhere → no browser call"
+        assert result["steps"][1]["found"] is False
+
     def test_tool_error_means_no_retry_and_placeholder_path(self):
         """CONTRACT: tool error → one call only, every locator step
         found:false. The old LLM's rogue second call is the failure mode

--- a/tests/test_crew_ai/test_element_identification.py
+++ b/tests/test_crew_ai/test_element_identification.py
@@ -347,6 +347,74 @@ class TestExtractPlanUrl:
         assert extract_plan_url([_step("New Page", value="MAILTO:a@b.com")]) is None
 
 
+class TestExtractPlanUrlFromUserQuery:
+    """Last-resort pass: the URL the user literally wrote.
+
+    Measured over the whole capture (1,260 runs with parseable plans): 34 got
+    their target URL ONLY because the browser-launch step carried one in
+    `value`, and blanking that value makes every earlier pass return None.
+    Nothing put it there on purpose — PLANNING_OUTPUT_RULES rule 6 told the
+    planner to emit `browser`/`headless` keys that PlannedStep does not have
+    and the response schema forbids (additionalProperties: false), so the model
+    improvised into `value`, and the destination sometimes rode along. That is
+    an accident, not a contract: any prompt, model or provider change removes
+    it silently, and the run then hits the documented dead end — no URL, no
+    browser call, every element a found:false placeholder.
+
+    All 34 of those user queries contain the URL in plain text. So the plan is
+    not the only place the destination is written down, and this pass reads the
+    one source the planner cannot corrupt.
+    """
+
+    QUERY = "Go to https://books.toscrape.com, get the titles of all books"
+
+    def test_user_query_url_is_used_when_the_plan_carries_none(self):
+        steps = [_step("New Browser"), _step("Get Elements", description="books")]
+        assert extract_plan_url(steps, self.QUERY) == "https://books.toscrape.com"
+
+    def test_a_navigation_step_still_wins_over_the_query(self):
+        """The plan is the more specific signal — the query is the backstop.
+        A user query naming one site while the plan navigates to another must
+        not be overridden (multi-site plans, and the search-engine default of
+        output rule 5, both depend on this ordering)."""
+        steps = [_step("New Page", value="https://explicit-nav.com")]
+        assert extract_plan_url(steps, self.QUERY) == "https://explicit-nav.com"
+
+    def test_a_url_anywhere_in_the_plan_still_wins_over_the_query(self):
+        """Pass 4 runs after the two token passes AND the embedded pass, so
+        removing rule 6 cannot change the answer for any run that works today."""
+        steps = [_step("New Browser", value="https://packed.example.com")]
+        assert extract_plan_url(steps, self.QUERY) == "https://packed.example.com"
+
+    def test_no_query_keeps_the_old_answer(self):
+        """Every existing caller and test passes steps only."""
+        assert extract_plan_url([_step("New Browser", value="chromium")]) is None
+
+    def test_a_query_without_a_url_guesses_nothing(self):
+        steps = [_step("New Browser", value="chromium")]
+        assert extract_plan_url(steps, "Search Flipkart for running shoes") is None
+
+    def test_a_non_navigable_scheme_in_the_query_is_not_a_destination(self):
+        """Same allowlist the value passes enforce: only http(s) names a page."""
+        steps = [_step("New Browser")]
+        assert extract_plan_url(steps, "Email mailto:sales@example.com to ask") is None
+        assert extract_plan_url(steps, "Open about:blank and wait") is None
+
+    def test_sentence_punctuation_is_stripped_from_the_recovered_url(self):
+        """The literal form users write: the URL is mid-sentence, so the comma
+        or full stop is glued to it and would be handed to the browser."""
+        steps = [_step("New Browser")]
+        assert extract_plan_url(steps, self.QUERY) == "https://books.toscrape.com"
+        assert extract_plan_url(steps, "Go to https://example.org/a. Then click.") == \
+            "https://example.org/a"
+
+    def test_the_first_url_in_the_query_is_the_destination(self):
+        """Queries read left to right; the opening navigation is the target."""
+        steps = [_step("New Browser")]
+        assert extract_plan_url(steps, "Go to https://first.com then https://second.com") \
+            == "https://first.com"
+
+
 # ─── FORM_ELEMENT_HANDLING port (port checklist #3) ──────────────────────────
 
 class TestRewriteFormDescription:

--- a/tests/test_crew_ai/test_element_identification.py
+++ b/tests/test_crew_ai/test_element_identification.py
@@ -382,9 +382,12 @@ class TestExtractPlanUrlFromUserQuery:
     their target URL ONLY because the browser-launch step carried one in
     `value`, and blanking that value makes every earlier pass return None.
     Nothing put it there on purpose — PLANNING_OUTPUT_RULES rule 6 told the
-    planner to emit `browser`/`headless` keys that PlannedStep does not have
-    and the response schema forbids (additionalProperties: false), so the model
-    improvised into `value`, and the destination sometimes rode along. That is
+    planner to emit `browser`/`headless` keys that PlannedStep does not have.
+    The response schema carries no additionalProperties flag (Google's Schema
+    type has no such field); what makes the keys unemittable is Gemini's
+    controlled generation, which constrains the response to the declared
+    properties. So the model improvised into `value`, and the destination
+    sometimes rode along. That is
     an accident, not a contract: any prompt, model or provider change removes
     it silently, and the run then hits the documented dead end — no URL, no
     browser call, every element a found:false placeholder.

--- a/tests/test_crew_ai/test_planner_prompt_schema_conformance.py
+++ b/tests/test_crew_ai/test_planner_prompt_schema_conformance.py
@@ -2,9 +2,12 @@
 
 The defect this pins: PLANNING_OUTPUT_RULES rule 6 injected a worked example
 reading {"keyword": "New Browser", "browser": "chromium", "headless": "True"}.
-`browser` and `headless` are not PlannedStep fields, and the response schema
-forwarded to capable providers sets additionalProperties: false — so the model
-was instructed to emit keys it had no legal way to emit. It improvised them
+`browser` and `headless` are not PlannedStep fields, so the model was instructed
+to emit keys it had no legal way to emit: on capable providers the response
+schema is forwarded and Gemini's controlled generation constrains the reply to
+the declared properties. (Not via additionalProperties — Google's Schema type
+has no such field, and PlannedStep sets no extra="forbid"; the constraint is
+the decoding, not a flag.) It improvised them
 into `value` instead: 56 of 60 plans across two benches carried an improvised
 launch-step value in 8 distinct encodings, including whole JSON blobs and
 "browser=chromium, headless=True, url=https://...".

--- a/tests/test_crew_ai/test_planner_prompt_schema_conformance.py
+++ b/tests/test_crew_ai/test_planner_prompt_schema_conformance.py
@@ -1,0 +1,89 @@
+"""The planner prompt may only name keys the planner is allowed to emit.
+
+The defect this pins: PLANNING_OUTPUT_RULES rule 6 injected a worked example
+reading {"keyword": "New Browser", "browser": "chromium", "headless": "True"}.
+`browser` and `headless` are not PlannedStep fields, and the response schema
+forwarded to capable providers sets additionalProperties: false — so the model
+was instructed to emit keys it had no legal way to emit. It improvised them
+into `value` instead: 56 of 60 plans across two benches carried an improvised
+launch-step value in 8 distinct encodings, including whole JSON blobs and
+"browser=chromium, headless=True, url=https://...".
+
+None of it ever reached the generated code — 1,512 of 1,513 captured
+test.robot files emit the same templated line, which comes from
+browser_context.code_assembly_context, not from the plan. The instruction was
+unreachable by construction.
+
+The class of bug is what matters: a prompt that names a key the schema
+forbids cannot be satisfied, and the model's improvisation lands somewhere
+undefined. This guard fails the moment a prompt does that again.
+"""
+
+import re
+from unittest.mock import MagicMock, patch
+
+from src.backend.crew_ai.library_context import BrowserLibraryContext
+from src.backend.crew_ai.tasks import PlanOutput, PlannedStep
+
+
+def _rendered_plan_description():
+    from src.backend.crew_ai.tasks import RobotTasks
+    tasks = RobotTasks(library_context=BrowserLibraryContext())
+    with patch("src.backend.crew_ai.tasks.Task") as mock_task:
+        tasks.plan_steps_task(agent=MagicMock(), query="click the button")
+    return mock_task.call_args.kwargs["description"]
+
+
+# A JSON object key as it appears in a prompt example: "some_key":
+_JSON_KEY_RE = re.compile(r'"([a-z_][a-z0-9_]*)"\s*:')
+
+
+class TestPlannerPromptNamesOnlyEmittableKeys:
+
+    def test_every_json_key_in_the_prompt_is_a_real_output_field(self):
+        description = _rendered_plan_description()
+        emittable = set(PlannedStep.model_fields) | set(PlanOutput.model_fields)
+        named = set(_JSON_KEY_RE.findall(description))
+        assert named <= emittable, (
+            f"planner prompt names keys the schema forbids: "
+            f"{sorted(named - emittable)}"
+        )
+
+    def test_the_guard_can_actually_fail(self):
+        """A guard that cannot fail pins nothing. This is the exact shape the
+        deleted rule 6 example had."""
+        named = set(_JSON_KEY_RE.findall(
+            '- Example: {"keyword": "New Browser", "browser": "chromium"}'))
+        emittable = set(PlannedStep.model_fields) | set(PlanOutput.model_fields)
+        assert named - emittable == {"browser"}
+
+    def test_the_prompt_still_names_every_field_the_planner_must_emit(self):
+        """The complement. A conformance guard that only removes text would be
+        satisfied by deleting the output contract altogether, so pin the other
+        direction too: every PlannedStep field is still named to the model,
+        whether as a JSON key, a quoted name (rule 2) or a backticked one
+        (rule 4)."""
+        description = _rendered_plan_description()
+        named = set(re.findall(r'[\"`]([a-z_][a-z0-9_]*)[\"`]', description))
+        missing = set(PlannedStep.model_fields) - named
+        assert not missing, f"planner prompt no longer names: {sorted(missing)}"
+        assert "steps" in named
+
+
+class TestBrowserInitInstructionsAreGone:
+
+    def test_no_browser_init_placeholder_survives_in_the_rendered_prompt(self):
+        """A placeholder whose .replace() target was deleted would ship the
+        literal token to the model."""
+        assert "{browser_init_placeholder}" not in _rendered_plan_description()
+
+    def test_the_popup_rule_survives_renumbering(self):
+        """Deleting rule 6 renumbers the list. The MOST CRITICAL explicit-only
+        rule must survive, as it did the last renumbering (old rule 7)."""
+        from src.backend.crew_ai.prompts.components import PromptComponents
+        assert ("DO NOT add popup dismissal"
+                in PromptComponents.PLANNING_OUTPUT_RULES)
+
+    def test_the_web_search_default_url_rule_survives_renumbering(self):
+        from src.backend.crew_ai.prompts.components import PromptComponents
+        assert "https://www.google.com" in PromptComponents.PLANNING_OUTPUT_RULES


### PR DESCRIPTION
Stacked on #77 — base is `fix/vertex-thinking-guard`, not `develop`, because the
backstop here is a fourth pass added directly after #77's third pass in
`extract_plan_url`. Retarget to `develop` once #77 merges.

Also carries the two review fixes against #77's own code, so that branch is not
force-pushed under an open review (see **Review fixes** below).

## What and why

`PLANNING_OUTPUT_RULES` rule 6 injected this example:

```json
{"keyword": "New Browser", "browser": "chromium", "headless": "True"}
```

`browser` and `headless` are not `PlannedStep` fields, so the planner was
instructed to emit keys it had no legal way to emit — on capable providers the
response schema is forwarded and Gemini's controlled generation constrains the
reply to the declared properties. It improvised them into `value` instead: 56 of
60 plans across two benches, in 8 distinct encodings, including whole JSON blobs
and `"browser=chromium, headless=True, url=https://..."`.

> Correction to an earlier version of this description: the constraint is **not**
> `additionalProperties: false`. `PlannedStep.model_config` is `{}` (no
> `extra="forbid"`), `PlanOutput.model_json_schema()` contains no
> `additionalProperties`, and neither does the schema litellm maps for
> `vertex_ai` — Google's `Schema` type has no such field. Same conclusion, right
> cause.

None of it ever reached the generated code. **1,512 of 1,513** captured
`test.robot` files emit the same templated `New Browser` line, which comes from
`browser_context.code_assembly_context`, not from the plan. The instruction was
unreachable by construction.

## The catch that set the ordering

Rule 6 was not free to delete. Replaying `extract_plan_url` over **1,260**
captured plans: **34 (2.7%)** reached a URL *only* because the browser-launch
step carried one in `value`. Blanking it makes every existing pass return
`None`, and the run then hits the documented dead end — no URL, no browser call,
every element a `found:false` placeholder.

Nothing put it there on purpose. It was an accident of rule 6 that any prompt,
model or provider change could have removed silently.

All 34 of those user queries state the URL in plain text, so the first commit
adds a last-resort pass reading the query. It runs **after** all three plan
passes: the plan stays the more specific signal, and output rule 5's
search-engine default must still be able to send a URL-bearing query elsewhere.

## The query pass alone was only half the fix

`extract_plan_url` feeds the browser call. The Assembler is built from the merged
steps and nothing else — `assemble_code_task` takes `identified_steps_json`, no
query and no URL argument, and `slim_steps_view` forwards only what is already on
a step. So a URL recovered from the query located every element and then
generated a test that never navigates.

Measured on the exact 34 runs the pass exists to serve, once rule 6's
improvisation is gone:

| Check | Result |
|---|---|
| Still carry a navigation step with a URL | **0 / 34** |
| Have any `http` string left anywhere in a step | **0 / 34** |
| Emitted `New Page <url>` today (read off the launch value) | **34 / 34** |

The captured artifact for the one run that actually reaches the query pass shows
the shape: `New Browser` → `New Context` → `Close Browser`. A browser opened and
closed.

So the recovered URL is written back onto the plan, which is the Assembler's only
channel. A navigation step wins the slot; the launch step is the fallback — the
shape the Assembler already handled 34 of 34 times. Verified on the target
population: **34/34** reach the browser call, **34/34** are written back, and in
all 34 it is the same URL the run used before.

## Evidence

Replay over the full capture:

| Check | Result |
|---|---|
| Query pass added, plan untouched | 1,563 / 1,564 answers identical |
| The one difference | `None` → `https://www.wikipedia.org/` (a run that resolves no URL today) |
| Rule 6 simulated gone | 34 / 34 recovered the identical URL, 0 lost |

No run changed from one URL to a *different* one, so the backstop cannot regress
anything — it only fires where the current code already returns `None`.

Bench `bench/baselines/2026-08-02-rule6-url-backstop.csv`, all gates green:

| Gate | Result |
|---|---|
| Pass rate ≥ 96.7% | 29/30 = 96.7% |
| `locator_success == 1.0` | min 1.000, mean 1.0000 (baseline had one 0.0) |
| `flake_retries − dryrun_repairs == 0` | 0 |
| Planner salvage | 0 across all 30 |
| 429 in window | 0 |

Suite: **2,497 passed / 1 skipped**.

**Neither tokens nor cost are a claim.** Against the same-day control
(`2026-08-02-vertex-thinking-guard.csv`, #77's run) the medians move prompt
**+0.12%**, completion **−6.71%**, cost **+3.32%** — all inside the known
cache-noise band. An earlier version of this description quoted −2.07% / −13.84%
against the 10-day-old 2026-07-23 gate, which is the wrong comparison: rule 6 is
~90 prompt tokens on one of ~5 calls, ≈0.2% of the 41.8k median, so it cannot
move either number by 2%. The justification here is correctness, not cost.

**The single bench failure is q10 r2**, the deferred collection-cardinality
defect: `Get Element Count` on a positional single-match container returned 1
(`'1 == 20' should be true`). It failed in the preceding run too, before this
change existed, and that slot has failed 9 of 46 captured runs (19.6%).

## Behaviour change worth reviewing

The planner now emits **no browser-launch step at all** — 0 of 30, down from 56
of 60. Generated code is unaffected (30/30 still emit the templated line). Every
plan carried its own navigation step this run, consistent with rule 6 having
been the source of the confusion.

## Limits of the validation

The query pass **never executed during the bench** — all 30 plans carried a
navigation step, so the earlier logic always succeeded. That is expected for a
last resort (2.7% historically ≈ 0.8 runs in 30), but it means the bench did not
exercise it. The third commit closes the resulting gap with a test that the
wiring forwards `user_query` and the browser call then happens. It is
non-vacuous: that plan resolves to `None` without the query.

Note what this makes the backstop: insurance. Post-rule-6 the planner puts the
destination on a navigation step (30/30), so the failure it covers is measured
at 0 of 30. It is kept because the dead end it prevents is total, and because it
is now complete rather than half-built.

## Guard

The conformance test fails on the class of bug, not this instance: every JSON key
named in the rendered planner prompt must be a field the planner may emit, and
every `PlannedStep` field must still be named — so the deletion cannot be
satisfied by stripping the output contract. Falsified against the pre-change
prompt: it reports `['browser', 'headless']` and goes red.

## Review fixes carried here for #77

- **The thinking guard could not fail.** `thinkingConfig` is absent from
  `get_supported_openai_params(model='gemini-3.5-flash', 'vertex_ai')`, which
  returns only `['thinking']`, so LiteLLM echoes it back the way it echoes any
  unrecognised vertex kwarg — probed with `thinkingConfigTYPO` and
  `totalNonsenseKey`, both returned verbatim. The assertion was satisfied by its
  own input. Now asserted on the built request body, the stage that filters
  against `GenerationConfig.__annotations__` and can actually drop it. Simulating
  that field's removal (the shape of the 1.94.1 change) makes the new test fail
  on both models while the old one stayed green.
- **The embedded pass had no step-type filter** and returned a URL out of an
  `Input Text` value — the string a user wants typed becoming the page to open,
  undoing the first-token rule `_url_candidate` exists to enforce. Now skips
  steps whose action is in `_VALUE_ACTIONS`. Lossless: the pass fires 5 times in
  1,313 captured runs, all on `New Browser` steps.

## Noted, not changed

`browser_init_params` is now unused outside its own tests. Left in place — it is
an `@abstractmethod` on `LibraryContext`, so removing it would widen this diff
across `base.py`, `browser_context.py` and two test modules.

Trailing-punctuation handling in the URL regex was reviewed and deliberately left
alone: across 29 distinct captured queries every URL is followed by a comma or an
alphanumeric, never a paren, bracket or bang, and none carries a comma inside its
path or query string. The current strip set covers 100% of observed shapes.

## Review round 2 — CodeRabbit threads

Seven inline comments across #77 and #78. Six fixed here, one declined.

| Thread | Outcome |
|---|---|
| #77 gitignore breadth | **Declined** — only `acceptance/` is tracked, and naming three prefixes reopens the gap for the fourth note family |
| #77 crewai version rationale | `e823bf3` — 1.15 is the in-flight upgrade, the bench runs the 1.8.1 pin; both docstrings now say so |
| #77 gate `thinkingConfig` to Gemini | `453b095` — a regression #77 introduced |
| #77 comma inside a URL | `54ce5ca` — finding right, proposed `\S+` wrong |
| #77 `url=blob:` scheme bypass | `54ce5ca` |
| #78 Sonar complexity 29 > 15 | `54ce5ca` |
| #78 query fallback scheme filtering | `54ce5ca` |

**The Gemini gate was a real regression.** Measured on the pinned litellm 1.75.3:
`thinking` raised `UnsupportedParamsError` for `llama-3.1-405b-instruct-maas` and
`mistral-large@2411` and mapped to a real Anthropic param for
`claude-sonnet-4@20250514`; `thinkingConfig` is accepted silently by all three.
`resolve_model_string` never checks the family and `ONLINE_MODEL` is a free
string, so switching to `thinkingConfig` to survive 1.94.1 also turned a loud
misconfiguration into a silent one. Now gated, and verified on the wire for
every model string the bench and production actually use — `gemini-3.5-flash`,
`gemini-2.5-flash` and the cross-prefixed `gemini/gemini-2.5-flash` all reach
the request body as `{"thinkingConfig": {"thinkingBudget": 0}}`.

**On the comma**, `\S+` was measured and rejected: it regresses
`https://example.com's`, `"https://example.com"` and
`url=https://x;browser=chromium`. Dropping only the comma from the class is
sufficient, because `rstrip` already removes a genuinely trailing one.

**`url=blob:` and the query fallback were the same bug twice.** The embedded-URL
recovery existed as two near-copies and both tested the token's *leading*
scheme — which `url=blob:https://x` does not have, since `=` is not a scheme
character. The Sonar refactor gave it one home, and the check now anchors to the
scheme immediately before the match.

### Bench provenance

`2026-08-02-rule6-url-backstop.csv` was produced at `60602c9`, **before** the
seven review-fix commits. It is not re-run here. Those commits are validated by
replay instead: all 1,313 captured runs with parseable plans give **0 differing
answers** through the pre- and post-change functions, and the one change on the
live LLM path is verified on the wire as above. Suite 2,505 passed, 1 skipped.
