### PR TITLE
Share the Vertex thinking guard with the conflict-detection path, and pin the browser-service image

### DIFF
--- a/Dockerfile.browser-service
+++ b/Dockerfile.browser-service
@@ -14,13 +14,26 @@ WORKDIR /app
 # that declaration since it has no langchain imports, which broke this image's startup.
 # requirements-bus.txt already declares PyYAML for the local bus venv for the same reason.
 #
-# EVERY VERSION IS PINNED. Left unpinned, two builds of the same commit produce
-# different images: merging any PR into the browser-service repo auto-publishes a
-# patch bump to PyPI, and browser-service is what drags in browser-use — so an
-# unpinned line here silently overrides the browser-use version Phase 2 chose.
-# Pins are the set measured inside monkscode/nlrf:browser-service-latest on
-# 2026-08-03, i.e. what production is already running; this freezes that set, it
-# does not change it.
+# EVERY DIRECTLY-INSTALLED PACKAGE IS PINNED. Left unpinned, two builds of the
+# same commit produce different images: merging any PR into the browser-service
+# repo auto-publishes a patch bump to PyPI, and browser-service is what drags in
+# browser-use — so an unpinned line here silently overrides the browser-use
+# version Phase 2 chose. Pins are the set measured inside
+# monkscode/nlrf:browser-service-latest on 2026-08-03, i.e. what production is
+# already running; this freezes that set, it does not change it.
+#
+# Two mutable surfaces remain, deliberately, and this is NOT a fully reproducible
+# image:
+#   1. BASE_IMAGE is a tag, not a digest — it carries Python, UV, Chrome and the
+#      OS libraries. Pinning a digest here would not help CI, which rebuilds the
+#      base per branch and passes the fresh tag in as `base_image_tag`
+#      (build-images.yml), overriding this ARG entirely; it would only pin local
+#      builds and would fight the documented `--build-arg BASE_IMAGE=...-local`
+#      flow. The base is reproduced by rebuilding it, not by pinning it.
+#   2. Transitive dependencies of these pins are not locked. Closing that needs a
+#      generated lockfile plus `uv pip sync`. Note requirements-bus.txt is NOT
+#      reusable for it — it would add traceloop-sdk and the OTel stack (absent
+#      here) and downgrade pydantic-settings 2.14.2 -> 2.10.1.
 #
 # These are NOT the same versions as requirements-bus.txt (playwright 1.57.0,
 # structlog 25.5.0, Flask 3.1.2, pydantic-settings 2.10.1), which is what the bench

--- a/Dockerfile.browser-service
+++ b/Dockerfile.browser-service
@@ -13,14 +13,28 @@ WORKDIR /app
 # (langchain-google-genai -> langchain-core -> pyyaml); browser-service 1.0.32 dropped
 # that declaration since it has no langchain imports, which broke this image's startup.
 # requirements-bus.txt already declares PyYAML for the local bus venv for the same reason.
+#
+# EVERY VERSION IS PINNED. Left unpinned, two builds of the same commit produce
+# different images: merging any PR into the browser-service repo auto-publishes a
+# patch bump to PyPI, and browser-service is what drags in browser-use — so an
+# unpinned line here silently overrides the browser-use version Phase 2 chose.
+# Pins are the set measured inside monkscode/nlrf:browser-service-latest on
+# 2026-08-03, i.e. what production is already running; this freezes that set, it
+# does not change it.
+#
+# These are NOT the same versions as requirements-bus.txt (playwright 1.57.0,
+# structlog 25.5.0, Flask 3.1.2, pydantic-settings 2.10.1), which is what the bench
+# validates. That container-vs-bench fork is real and predates this pin — closing it
+# means either upgrading the bus venv or downgrading production, so it is a
+# deliberate open decision, not an oversight. Do not "fix" it by editing one side.
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv pip install --system --no-cache \
-    flask \
-    gunicorn \
-    playwright \
-    structlog>=24.1.0 \
-    PyYAML \
-    browser-service && \
+    flask==3.1.3 \
+    gunicorn==26.0.0 \
+    playwright==1.62.0 \
+    structlog==26.1.0 \
+    PyYAML==6.0.3 \
+    browser-service==1.0.32 && \
     playwright install chromium && \
     chmod -R 755 /opt/playwright-browsers
 

--- a/src/backend/crew_ai/cleaned_llm_wrapper.py
+++ b/src/backend/crew_ai/cleaned_llm_wrapper.py
@@ -502,6 +502,7 @@ def get_llm(model_provider: str, model_name: str, api_key: Optional[str] = None,
         PROVIDER_PREFIXES,
         resolve_model_string,
         resolve_completion_kwargs,
+        resolve_thinking_kwargs,
     )
 
     if model_provider not in PROVIDER_PREFIXES:
@@ -565,31 +566,19 @@ def get_llm(model_provider: str, model_name: str, api_key: Optional[str] = None,
             is_litellm=True,
             **schema_kwargs,
         )
-        # Vertex flipped gemini-3.5-flash to server-side thinking-ON (2026-07-18),
-        # inflating completion tokens 4-6x and burning TPM/RPD quota. crewai's
-        # LLM.__init__ has its own same-named `thinking` param (Anthropic-oriented)
-        # that is never stored or forwarded, so passing thinking=... as a
+        # The thinking guard itself lives in llm_provider_routing so that every
+        # LiteLLM call site reads one rule — see resolve_thinking_kwargs for why
+        # it carries thinkingConfig rather than `thinking`, why it is gated on
+        # the model family, and why it must be handed the routed model string.
+        #
+        # It has to land in additional_params post-construction: crewai's
+        # LLM.__init__ has its own same-named `thinking` param (Anthropic-
+        # oriented) that is never stored or forwarded, so passing it as a
         # constructor kwarg above would silently no-op. additional_params is the
         # only attribute _prepare_completion_params forwards untouched to LiteLLM.
-        #
-        # Send Vertex's own thinkingConfig rather than LiteLLM's `thinking`
-        # shorthand: from litellm 1.94.1 _map_thinking_param routes every
-        # "Gemini 3 or newer" model down a thinkingLevel branch that drops the
-        # budget and emits only includeThoughts=False, which hides thoughts
-        # without stopping them. thinkingConfig reaches generationConfig
-        # untouched and reproduces what 1.75.3 put on the wire.
-        #
-        # Gated on the model family, because that same switch removed the loud
-        # failure that used to cover this. Vertex also serves Anthropic, Llama
-        # and Mistral, and resolve_model_string does not check the family —
-        # ONLINE_MODEL is a free string, so one config edit reaches here with a
-        # non-Gemini model. Measured on the pinned litellm 1.75.3: `thinking`
-        # raised UnsupportedParamsError on llama/mistral and mapped to a real
-        # Anthropic param on claude, while thinkingConfig is accepted silently
-        # by all three and would ship a Gemini-only generationConfig field to a
-        # non-Gemini endpoint.
-        if "gemini" in routed_model.lower():
-            llm.additional_params["thinkingConfig"] = {"thinkingBudget": 0}
+        llm.additional_params.update(
+            resolve_thinking_kwargs(model_provider, routed_model)
+        )
         return llm
 
     # model_provider == "gemini" — Google AI Studio.

--- a/src/backend/crew_ai/llm_provider_routing.py
+++ b/src/backend/crew_ai/llm_provider_routing.py
@@ -12,6 +12,9 @@ Scope (deliberately narrow):
   does not derive from env vars on its own (currently only Ollama's
   api_base; Gemini and Vertex auth comes from env vars LiteLLM reads
   natively).
+- Resolve the Vertex thinking guard, which is a fact about the provider and
+  model family rather than about any one caller, so every LiteLLM call site
+  gets it from the same place.
 
 What this module does NOT own — those are call-site policy, not routing:
 - Timeout / retry behavior (agents are long-running; triggers are snappy)
@@ -78,4 +81,47 @@ def resolve_completion_kwargs(provider: str) -> dict:
         return {
             "api_base": os.getenv("OLLAMA_API_BASE", "http://localhost:11434"),
         }
+    return {}
+
+
+def resolve_thinking_kwargs(provider: str, routed_model: str) -> dict:
+    """Vertex thinking guard — one rule, every LiteLLM call site.
+
+    Vertex flipped gemini-3.5-flash to server-side thinking-ON (2026-07-18),
+    inflating completion tokens 4-6x and burning TPM/RPD quota. Every call we
+    make to a Gemini model on Vertex must carry a zero budget.
+
+    Lives here rather than at a call site because it is a fact about the
+    provider, not about the caller: it was originally encoded inside
+    get_llm() alone, and the conflict-detection path in learning_config —
+    which calls litellm.completion() directly — silently went unguarded and
+    paid for thinking on every call.
+
+    Carries `thinkingConfig` (Vertex's own generationConfig field) rather than
+    LiteLLM's `thinking` shorthand: from litellm 1.94.1 _map_thinking_param
+    routes every "Gemini 3 or newer" model down a thinkingLevel branch that
+    drops the budget and emits only includeThoughts=False, hiding thoughts
+    without stopping them. thinkingConfig reaches generationConfig untouched
+    and reproduces what 1.75.3 put on the wire.
+
+    Gated on the model family because that same switch removed the loud
+    failure that used to cover this. Vertex also serves Anthropic, Llama and
+    Mistral, and resolve_model_string does not check the family — ONLINE_MODEL
+    is a free string, so one config edit reaches here with a non-Gemini model.
+    Measured on the pinned litellm 1.75.3: `thinking` raised
+    UnsupportedParamsError on llama/mistral and mapped to a real Anthropic
+    param on claude, while thinkingConfig is accepted silently by all three
+    and would ship a Gemini-only generationConfig field to a non-Gemini
+    endpoint.
+
+    Takes the ROUTED model string, never the bare name. resolve_model_string
+    strips a stale cross-provider prefix, so the bare argument
+    'gemini/claude-sonnet-4@20250514' routes to
+    'vertex_ai/claude-sonnet-4@20250514' — a bare-name family check sees
+    'gemini' from the stripped prefix and would attach the guard to a Claude
+    endpoint. Measured 2026-08-03; pinned by
+    test_family_check_reads_the_routed_string_not_the_bare_name.
+    """
+    if provider == "vertex" and "gemini" in routed_model.lower():
+        return {"thinkingConfig": {"thinkingBudget": 0}}
     return {}

--- a/src/backend/crew_ai/optimization/learning_config.py
+++ b/src/backend/crew_ai/optimization/learning_config.py
@@ -529,12 +529,27 @@ def _get_conflict_detection_model() -> str:
 def _get_conflict_detection_completion_kwargs() -> dict:
     """Per-provider extra kwargs for litellm.completion().
 
-    Currently only Ollama needs api_base injected — litellm.completion()
-    does NOT read OLLAMA_API_BASE from the env on its own.
+    Only Ollama needs api_base injected — litellm.completion() does NOT read
+    OLLAMA_API_BASE from the env on its own.
+
+    Also carries the Vertex thinking guard. This path calls
+    litellm.completion() directly rather than through get_llm(), so it does
+    not inherit the guard the agent wrappers get; without this it pays for
+    server-side thinking on every conflict-detection call. Both call sites
+    now read the rule from llm_provider_routing so they cannot drift apart.
     """
     from src.backend.core.config import settings
-    from src.backend.crew_ai.llm_provider_routing import resolve_completion_kwargs
-    return resolve_completion_kwargs(settings.MODEL_PROVIDER)
+    from src.backend.crew_ai.llm_provider_routing import (
+        resolve_completion_kwargs,
+        resolve_model_string,
+        resolve_thinking_kwargs,
+    )
+    provider = settings.MODEL_PROVIDER
+    routed_model = resolve_model_string(provider, settings.ONLINE_MODEL)
+    return {
+        **resolve_completion_kwargs(provider),
+        **resolve_thinking_kwargs(provider, routed_model),
+    }
 
 
 def _parse_conflict_json(content: str) -> dict:

--- a/tests/test_crew_ai/test_cleaned_llm_wrapper.py
+++ b/tests/test_crew_ai/test_cleaned_llm_wrapper.py
@@ -253,6 +253,39 @@ class TestGetLlm:
 
         assert "thinking" not in llm.additional_params
 
+    def test_get_llm_and_the_learning_path_agree_on_the_guard(self):
+        """The two LiteLLM call sites must not drift apart on the thinking guard.
+
+        The guard shipped on the agent path only. learning_config calls
+        litellm.completion() directly for conflict detection — a live path
+        (MODEL_PROVIDER=vertex, ONLINE_MODEL=gemini-3.5-flash,
+        OPTIMIZATION_ENABLED=true; 17 [CONFLICT_DETECT] calls in the retained
+        log window) that paid for server-side thinking on every call because
+        the rule was encoded at one call site instead of in the shared router.
+
+        This test is the anti-drift pin: whatever get_llm attaches, the
+        conflict-detection kwargs must carry too.
+        """
+        from src.backend.crew_ai.cleaned_llm_wrapper import get_llm
+        from src.backend.crew_ai.optimization.learning_config import (
+            _get_conflict_detection_completion_kwargs,
+        )
+        from src.backend.core import config as config_module
+
+        with patch.dict(os.environ, {"VERTEXAI_CREDENTIALS": "creds.json",
+                                      "VERTEXAI_PROJECT": "test-project",
+                                      "VERTEXAI_LOCATION": "us-central1"}):
+            llm = get_llm(model_provider="vertex", model_name="gemini-3.5-flash")
+
+        with patch.object(config_module.settings, "MODEL_PROVIDER", "vertex"), \
+                patch.object(config_module.settings, "ONLINE_MODEL", "gemini-3.5-flash"):
+            learning_kwargs = _get_conflict_detection_completion_kwargs()
+
+        assert learning_kwargs.get("thinkingConfig") == llm.additional_params.get("thinkingConfig"), (
+            "the conflict-detection path and the agent path disagree on the "
+            "Vertex thinking guard — one of them is paying for thinking"
+        )
+
     @pytest.mark.parametrize("bad_provider", ["openai", "anthropic", "gemni", "", "GEMINI", "gpt-4"])
     def test_unsupported_provider_raises_value_error(self, bad_provider):
         """Unknown model_provider values must raise ValueError immediately, not silently route."""
@@ -260,6 +293,127 @@ class TestGetLlm:
 
         with pytest.raises(ValueError, match="Unsupported model_provider"):
             get_llm(model_provider=bad_provider, model_name="some-model")
+
+
+class TestResolveThinkingKwargs:
+    """Contract for the shared Vertex thinking guard in llm_provider_routing.
+
+    The rule is one fact about Vertex billing, consumed by every LiteLLM call
+    site. It lives in the router so a second call site cannot be added without
+    it — which is exactly how the conflict-detection path ended up unguarded.
+    """
+
+    @pytest.mark.parametrize("model_name", ["gemini-3.5-flash", "gemini-2.5-flash"])
+    def test_vertex_gemini_gets_a_zero_budget(self, model_name):
+        from src.backend.crew_ai.llm_provider_routing import (
+            resolve_model_string, resolve_thinking_kwargs,
+        )
+        routed = resolve_model_string("vertex", model_name)
+        assert resolve_thinking_kwargs("vertex", routed) == {
+            "thinkingConfig": {"thinkingBudget": 0}
+        }
+
+    @pytest.mark.parametrize("model_name", [
+        "claude-sonnet-4@20250514",
+        "llama-3.1-405b-instruct-maas",
+        "mistral-large@2411",
+    ])
+    def test_non_gemini_vertex_models_get_nothing(self, model_name):
+        """thinkingConfig is a Gemini-only generationConfig field, and Vertex
+        also serves Anthropic, Llama and Mistral. litellm 1.75.3 accepts the
+        key silently for all three, so the guard must carry its own family
+        check — there is no loud failure to fall back on."""
+        from src.backend.crew_ai.llm_provider_routing import (
+            resolve_model_string, resolve_thinking_kwargs,
+        )
+        routed = resolve_model_string("vertex", model_name)
+        assert resolve_thinking_kwargs("vertex", routed) == {}
+
+    def test_family_check_reads_the_routed_string_not_the_bare_name(self):
+        """Regression pin for a real divergence, measured 2026-08-03.
+
+        resolve_model_string strips a stale cross-provider prefix, so the bare
+        argument 'gemini/claude-sonnet-4@20250514' routes to
+        'vertex_ai/claude-sonnet-4@20250514'. A family check on the BARE name
+        sees 'gemini' (from the stripped prefix) and returns True; the routed
+        string correctly says False. Keying on the bare name would ship a
+        Gemini-only field to a Claude endpoint.
+        """
+        from src.backend.crew_ai.llm_provider_routing import (
+            resolve_model_string, resolve_thinking_kwargs,
+        )
+        bare = "gemini/claude-sonnet-4@20250514"
+        routed = resolve_model_string("vertex", bare)
+
+        assert "gemini" in bare.lower()          # the trap
+        assert "gemini" not in routed.lower()    # the truth
+        assert resolve_thinking_kwargs("vertex", routed) == {}
+
+    @pytest.mark.parametrize("provider,model_name", [
+        ("gemini", "gemini-3.5-flash"),
+        ("local", "llama3"),
+    ])
+    def test_non_vertex_providers_get_nothing(self, provider, model_name):
+        """The thinking-ON flip is Vertex-specific (probe-verified 2026-07-18).
+
+        Note the gemini case also guards the router's own shape: its routed
+        string is 'gemini/gemini-3.5-flash', so the family substring is always
+        present. Only the provider gate keeps it out.
+        """
+        from src.backend.crew_ai.llm_provider_routing import (
+            resolve_model_string, resolve_thinking_kwargs,
+        )
+        routed = resolve_model_string(provider, model_name)
+        assert resolve_thinking_kwargs(provider, routed) == {}
+
+    def test_conflict_detection_guard_reaches_the_vertex_request_body(self):
+        """The learning path's kwargs are only worth what LiteLLM puts on the wire.
+
+        Same reasoning as test_vertex_thinking_guard_reaches_the_request_body:
+        thinkingConfig is absent from get_supported_openai_params(), so
+        get_optional_params echoes it back verbatim and a test at that stage is
+        satisfied by its own input. _transform_request_body is the stage that
+        filters against GenerationConfig.__annotations__ and can actually drop it.
+        """
+        from litellm.llms.vertex_ai.gemini.transformation import _transform_request_body
+
+        from src.backend.crew_ai.optimization.learning_config import (
+            _get_conflict_detection_completion_kwargs,
+        )
+        from src.backend.core import config as config_module
+
+        with patch.object(config_module.settings, "MODEL_PROVIDER", "vertex"), \
+                patch.object(config_module.settings, "ONLINE_MODEL", "gemini-3.5-flash"):
+            kwargs = _get_conflict_detection_completion_kwargs()
+
+        body = _transform_request_body(
+            messages=[{"role": "user", "content": "ping"}],
+            model="gemini-3.5-flash",
+            optional_params=dict(kwargs),
+            custom_llm_provider="vertex_ai",
+            litellm_params={},
+            cached_content=None,
+        )
+        generation_config = body.get("generationConfig", {})
+
+        assert generation_config.get("thinkingConfig", {}).get("thinkingBudget") == 0, (
+            "the conflict-detection guard did not survive into the request body "
+            f"— generationConfig was {generation_config!r}"
+        )
+
+    def test_ollama_api_base_still_threaded_through(self):
+        """The guard must not displace the api_base the local provider needs."""
+        from src.backend.crew_ai.optimization.learning_config import (
+            _get_conflict_detection_completion_kwargs,
+        )
+        from src.backend.core import config as config_module
+
+        with patch.object(config_module.settings, "MODEL_PROVIDER", "local"), \
+                patch.object(config_module.settings, "ONLINE_MODEL", "llama3"):
+            kwargs = _get_conflict_detection_completion_kwargs()
+
+        assert "api_base" in kwargs
+        assert "thinkingConfig" not in kwargs
 
 
 class TestGetLlmResponseFormat:


### PR DESCRIPTION
Two dependency-posture fixes found while auditing what was left of the dependency-upgrade program.

## 1. The Vertex thinking guard reached only one of two LiteLLM call sites

The guard lived inline in `get_llm()`. The other place that reaches LiteLLM — `learning_config`'s conflict detection, which calls `litellm.completion()` directly — never carried it, so it paid for server-side thinking on every call.

That path is live, not theoretical: `MODEL_PROVIDER=vertex`, `ONLINE_MODEL=gemini-3.5-flash`, `OPTIMIZATION_ENABLED=true`, with 17 `[CONFLICT_DETECT]` calls in the retained log window.

**Measured live against Vertex**, identical prompt, identical returned JSON:

| | completion tokens |
|---|---|
| with guard | **35** |
| without guard | **395** |

11.3x, all of it thinking.

The rule now lives in `llm_provider_routing.resolve_thinking_kwargs()` and both call sites read it, so a third call site cannot be added without it. That module already owns per-provider litellm kwargs and stays dependency-free — the guard is a pure dict.

It takes the **routed** model string, never the bare name. `resolve_model_string` strips a stale cross-provider prefix, so `gemini/claude-sonnet-4@20250514` routes to `vertex_ai/claude-sonnet-4@20250514`; a bare-name family check sees `gemini` from the stripped prefix and would ship a Gemini-only `generationConfig` field to a Claude endpoint. Pinned by a regression test.

`get_llm`'s behaviour is unchanged — inside the vertex branch the provider gate is true by construction and the family check reads the same routed string, so the condition and the literal are identical. The four pre-existing guard tests, including the one asserting on the built Vertex request body, pass untouched.

## 2. The browser-service image had no pins at all

Every line in the install floated. That matters most for `browser-service` itself: merging any PR into the browser-service repo auto-publishes a patch bump to PyPI, and `browser-service` is what drags in `browser-use` — so an unpinned line silently overrides the browser-use version Phase 2 chose.

Pins are the set already inside `monkscode/nlrf:browser-service-latest`. **This freezes what production runs; it does not change it.**

Deliberately *not* the `requirements-bus.txt` versions (playwright 1.57.0, structlog 25.5.0, Flask 3.1.2) — that container-vs-bench fork is real, predates this change, and closing it means either upgrading the bus venv or downgrading production. Left as an open decision rather than silently resolved.

## Verification

- Full suite: **2788 passed, 7 skipped, 0 failed**
- 11 new tests, written red-first
- Live Vertex check on both changed paths (table above); agent path returns and `_token_usage` still populates, so the shared-accumulator invariant holds
- Image rebuilt `--no-cache`: identical versions, entrypoint imports, and `browser_service` still resolves to the vendored `/app/tools/browser_service` after the entrypoint's `sys.path` insert

## Why no bench

The bench runs learning-OFF, so it never exercises the conflict-detection path this fixes. The `get_llm` refactor is provably inert. The Dockerfile pins reproduce the image already running. A bench would measure nothing that changed — flagging rather than assuming.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved model routing for Vertex-hosted Gemini models by applying compatible thinking settings consistently across standard and learning workflows.
  - Preserved Ollama connection settings during learning operations.

- **Bug Fixes**
  - Prevented unsupported thinking configuration from affecting non-Vertex models.
  - Improved request compatibility with Vertex model calls.

- **Tests**
  - Added coverage for provider-specific routing, thinking safeguards, Ollama settings, and Vertex request behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->