### PR TITLE
Converge the bench venv's playwright pin up to the shipped 1.62.0

### DIFF
--- a/Dockerfile.browser-service
+++ b/Dockerfile.browser-service
@@ -35,11 +35,15 @@ WORKDIR /app
 #      reusable for it — it would add traceloop-sdk and the OTel stack (absent
 #      here) and downgrade pydantic-settings 2.14.2 -> 2.10.1.
 #
-# These are NOT the same versions as requirements-bus.txt (playwright 1.57.0,
-# structlog 25.5.0, Flask 3.1.2, pydantic-settings 2.10.1), which is what the bench
-# validates. That container-vs-bench fork is real and predates this pin — closing it
-# means either upgrading the bus venv or downgrading production, so it is a
-# deliberate open decision, not an oversight. Do not "fix" it by editing one side.
+# playwright MUST stay equal to the pin in requirements-bus.txt, which is what the bench
+# runs. It is the browser engine the locator stack resolves against, so a fork means the
+# bench validates an engine production does not run. It was forked — 1.62.0/Chromium 151
+# here vs 1.57.0/Chromium 143 in the bus venv — until 2026-08-03, when the bus venv was
+# converged UP to this value. Change both files together or not at all.
+#
+# The other versions still differ from requirements-bus.txt (structlog 25.5.0, Flask
+# 3.1.2, pydantic-settings 2.10.1 there). None of them touch locator resolution, so that
+# part of the fork is tolerated. Do not "fix" it by editing one side.
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv pip install --system --no-cache \
     flask==3.1.3 \

--- a/requirements-bus.txt
+++ b/requirements-bus.txt
@@ -15,7 +15,14 @@
 # needed; 331 packages resolve with uv pip compile --universal, and playwright,
 # traceloop-sdk, posthog, pydantic and pydantic-settings all hold.
 browser-use==0.13.7
-playwright==1.57.0          # locator validation uses the Playwright Python API directly
+# playwright MUST stay equal to the pin in Dockerfile.browser-service. It is the browser
+# engine the locator stack resolves against, so a fork here means the bench validates an
+# engine production does not run. It was forked — 1.57.0/Chromium 143 here vs
+# 1.62.0/Chromium 151 in the shipped image — until 2026-08-03, when this venv was
+# converged UP to the shipped value. Bumping it moves nothing else: `uv pip compile
+# --universal` resolves the same 331 packages on either pin, playwright is the only line
+# that differs. Change both files together or not at all.
+playwright==1.62.0          # locator validation uses the Playwright Python API directly
 Flask==3.1.2                # HTTP service shell (gunicorn is Docker-only)
 requests==2.33.0            # forced: browser-use 0.13.7 exact-pins requests==2.33.0
 PyYAML==6.0.3               # needed by src.backend.core.config, imported by the entrypoint

--- a/run.sh
+++ b/run.sh
@@ -82,10 +82,35 @@ else
     VENV_ACTIVATE="$VENV_DIR/bin/activate"
 fi
 
+# A venv is only as fresh as the manifest it was built from. Both blocks below used to
+# install ONLY when the venv was missing, so editing a requirements file left an existing
+# venv silently stale — and the bench then measures package versions the manifest does
+# not claim. That is how the playwright bench-vs-container fork could reappear after
+# being closed. Each venv now stores a hash of its manifest and reinstalls in place when
+# it changes. In place, never renamed: uv console-script trampolines hardcode an absolute
+# interpreter path.
+_req_hash() {
+    if command -v sha256sum >/dev/null 2>&1; then
+        sha256sum "$1" | cut -d' ' -f1
+    else
+        shasum -a 256 "$1" | cut -d' ' -f1
+    fi
+}
+
+BACKEND_REQ="src/backend/requirements.txt"
+VENV_STAMP="$VENV_DIR/.requirements-hash"
+BACKEND_HASH="$(_req_hash "$BACKEND_REQ")"
+
 # Check if venv exists and is valid
 if [ -d "$VENV_DIR" ] && [ -f "$VENV_ACTIVATE" ]; then
     echo "Using existing virtual environment..."
     source "$VENV_ACTIVATE"
+    if [ "$(cat "$VENV_STAMP" 2>/dev/null)" != "$BACKEND_HASH" ]; then
+        echo "$BACKEND_REQ changed — updating virtual environment..."
+        command -v uv >/dev/null 2>&1 || pip install uv
+        uv pip install -r "$BACKEND_REQ"
+        echo "$BACKEND_HASH" > "$VENV_STAMP"
+    fi
 else
     echo "Creating new virtual environment..."
     # Remove invalid venv if it exists
@@ -94,8 +119,9 @@ else
     source "$VENV_ACTIVATE"
     echo "Installing dependencies..."
     pip install uv
-    uv pip install -r src/backend/requirements.txt
+    uv pip install -r "$BACKEND_REQ"
     uv pip install pytest pytest-asyncio pytest-cov
+    echo "$BACKEND_HASH" > "$VENV_STAMP"
 fi
 
 # --- Browser-use service venv (isolated — see requirements-bus.txt header) ---
@@ -105,12 +131,22 @@ if [[ "$OSTYPE" == "msys" || "$OSTYPE" == "cygwin" || "$OSTYPE" == "win32" ]]; t
 else
     BUS_PY="$BUS_VENV_DIR/bin/python"
 fi
+BUS_STAMP="$BUS_VENV_DIR/.requirements-hash"
+BUS_HASH="$(_req_hash requirements-bus.txt)"
 if [ ! -f "$BUS_PY" ]; then
     echo "Creating browser-service virtual environment..."
     [ -d "$BUS_VENV_DIR" ] && rm -rf "$BUS_VENV_DIR"
     python -m venv "$BUS_VENV_DIR"
     "$BUS_PY" -m pip install -r requirements-bus.txt
     "$BUS_PY" -m playwright install chromium
+    echo "$BUS_HASH" > "$BUS_STAMP"
+elif [ "$(cat "$BUS_STAMP" 2>/dev/null)" != "$BUS_HASH" ]; then
+    # Reinstall the browser too: the pin that changed may be playwright itself, and the
+    # engine is what the locator stack resolves against.
+    echo "requirements-bus.txt changed — updating browser-service virtual environment..."
+    "$BUS_PY" -m pip install -r requirements-bus.txt
+    "$BUS_PY" -m playwright install chromium
+    echo "$BUS_HASH" > "$BUS_STAMP"
 fi
 
 # --- Postgres (auth + learning stack live here as of Phase 4) ---


### PR DESCRIPTION
`requirements-bus.txt` pinned playwright **1.57.0 (Chromium 143)** while `Dockerfile.browser-service` shipped **1.62.0 (Chromium 151)**. `run.sh:152` runs the bus from `venv-bus`, not Docker, so the 96.7% gate and `locator_success == 1.0` had only ever been measured on a browser engine production does not run. Eight Chromium majors apart, across exactly the surfaces `smart_locator.py` depends on — the accessibility tree, shadow-DOM piercing, and the CSS selector engine.

Doing nothing was not neutral: production was already running an unvalidated engine. This converges the bench venv **up** to what ships, so the two agree for the first time.

## The change is exactly one variable

`uv pip compile --universal` resolves **331 packages on either pin, with `playwright` the only differing line**. The installed `venv-bus` freeze differs by that same single line. No transitive drift to confound the bench.

```
116c116
< playwright==1.57.0
---
> playwright==1.62.0
```

## Verification

**browser-service locator suite**, control vs shipped engine — identical:

| engine | result |
|---|---|
| playwright 1.61.0 (control) | 684 passed |
| playwright 1.62.0 / Chromium 151 | **684 passed** |

(4 further tests are `test_live_browser_service.py`, which need the bus running on :4999; they fail with `ConnectionRefusedError` in both runs and were deselected from the second.)

**Bench, run twice on 2026-08-03:**

| | pass | `locator_min` | `flake−repairs` | salvage |
|---|---|---|---|---|
| baseline 08-02 · pw1.57/Chr143 | 29/30 | 1.000 | 0 | — |
| run 1 · pw1.62/Chr151 | **30/30** | 1.000 | 0 | **0** |
| run 2 · pw1.62/Chr151 | **30/30** | 1.000 | 0 | **0** |

Salvage was verified independently per run from the application log — 30 clean strategy-1 guardrail parses each, zero fallbacks.

**Cost is flat, and it took two runs to say so honestly.** Run 1 alone looked like a 2% improvement:

```
cost median $   baseline 0.04855   run1 0.04760 (-2.0%)   run2 0.04955 (+2.1%)
spread between the two 1.62 runs: 4.1%
```

The baseline sits between the two runs — that spread is the implicit-cache lottery, not a change. Tokens are flat across all three (43,180 / 43,052 / 43,134). Run 1's `llm_calls` median of 4.5 was a median tie-break; run 2 returned 5.0, matching baseline.

## What this does not establish

**Timing.** Both runs were 429-polluted — 69 and 60 throttle lines in their windows, against 7 in the baseline's. A pre-run probe measured active throttling (1 of 5 calls hard-429'd, median latency 4.78s vs a ~2.0s baseline), so this was known going in; the second run proceeded because pass rate and cost are load-independent and were the gates still open.

The new CSVs are authoritative for pass rate, locator success, salvage and cost — **not for timing**. Settling timing needs a same-session A/B against 1.57.0 in a quiet window; comparing across sessions is unsound here, since Vertex latency has swung 0.76s → 18.2s within a single day.

Locator latency did land below baseline in both runs (−3.4% and −15.4% on the median), which is suggestive but not quotable from throttled runs.

## Note on the bench data

`bench/baselines/` and `bench/runs/` are gitignored, so no bench CSVs are in this PR by design.

Both files now cross-reference each other, so the pins cannot silently re-fork.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the browser service to Playwright 1.62.0.
  * Aligned the browser-service environment with the shipped container image.
  * Clarified dependency-version documentation and update requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->