### PR TITLE
Read the log level from the app, and stop echoing the prompt to stdout

### DIFF
--- a/observability/README.md
+++ b/observability/README.md
@@ -177,6 +177,16 @@ should turn it into a link — Grafana cannot serve local files, and a
 
 ## Things that will mislead you if you do not know them
 
+- **Almost every line reads `unknown` in Explore's level breakdown, and that
+  is correct.** Since 2026-08-14 the level comes from the `level` field the
+  application itself writes, not from Loki guessing one out of the raw text.
+  Only 4.6% of the fastapi stream is a structlog record; 73.7% of it is
+  CrewAI echoing our own prompt to stdout, and prompt text has no level to
+  report. uvicorn's plain-text access lines keep their level because it is a
+  line-start prefix Alloy reads explicitly. Before this, 1,053 prompt-echo
+  lines carried a level Loki had invented, 270 of them `critical`. For
+  plain-text errors that carry no level at all, use the `|= "ERROR"` arm on
+  the Execution outcomes panel rather than the level breakdown.
 - **The log panel stays empty if you're running the app with `./run.sh`.**
   Alloy only scrapes Docker `json-file` container logs. `./run.sh` runs
   FastAPI and the browser service as local processes, not containers, so
@@ -296,8 +306,16 @@ should turn it into a link — Grafana cannot serve local files, and a
   `|= "ERROR"` substring arm matched 58, and the two sets overlap by
   **exactly 0**. The panel therefore ships both arms, and the "Structured log
   level" variable widens only the JSON arm — the substring arm has no level
-  field to filter on. Loki's own `detected_level` is not a substitute:
-  selecting on it returns 0 lines here.
+  field to filter on. Loki's own `detected_level` is not a substitute either,
+  but not for the reason recorded here until 2026-08-14: it was tested as a
+  stream selector, `{service=~"...", detected_level="error"}`, which matches
+  0 lines because `detected_level` is structured metadata, not an indexed
+  label. Filtered after the pipe it works — `| detected_level="error"`
+  matched 1,196 lines **before** the level pipeline changed that day, of
+  which 535 were real records and 661 were plain text Loki had guessed a
+  level for. Since the change it tracks the JSON arm instead, so it is a
+  duplicate of one arm rather than a replacement for both: plain-text errors
+  carry no level field, read `unknown`, and are only ever seen by arm B.
 - **Half the runs cannot be dated, so the Runs list is not sorted by a clock.**
   Measured 2026-08-13 over the 528 UUID-shaped run ids: 41 carry both a
   `workflow_metrics` row and a timestamp from `test_runs`/`execution_records`,

--- a/observability/alloy/config.alloy
+++ b/observability/alloy/config.alloy
@@ -47,7 +47,60 @@ discovery.relabel "containers" {
 loki.source.docker "containers" {
   host       = "unix:///var/run/docker.sock"
   targets    = discovery.relabel.containers.output
+  forward_to = [loki.process.level.receiver]
+}
+
+// Stamp detected_level from the level the application actually recorded.
+//
+// Loki's own level discovery guesses a level out of raw text, and CrewAI
+// echoes our prompt to stdout verbatim, so the prompt was being classified.
+// Measured 2026-08-14 over the five days Loki held, counting only lines that
+// are NOT structlog records: 7,769 carried a guessed level, of which 1,053
+// were CrewAI box-drawing prompt echo and every one of those was wrong —
+// 270 stamped critical, 232 warn, 551 error. Discovery was correct on all
+// 16,436 real structlog records.
+//
+// It is not only the `KEYWORD:` shape. `--- CRITICAL: ONLY EXPLICIT ELEMENTS
+// ---` is stamped critical, but so is a prompt line that merely contains the
+// bare word `error` in prose, which is where 551 of the 1,053 came from.
+//
+// The `unknown` default below only holds because discover_log_levels is off
+// in observability/loki/loki-config.yml. Loki honours an incoming
+// detected_level only when it names a real level — it treats the literal
+// string `unknown` as absent and re-runs discovery over it. Both halves are
+// required, and neither reads as broken alone: drop either and every
+// component stays healthy, every line still flows, and the prompt goes back
+// to being reported as critical.
+//
+// This only works while the services emit JSON. Under LOG_FORMAT=console
+// there is no `level` field to read and every line falls to unknown.
+loki.process "level" {
   forward_to = [loki.write.default.receiver]
+
+  stage.json {
+    expressions = { level = "level" }
+  }
+
+  // uvicorn does not write JSON — it prefixes its level at the start of the
+  // line (`INFO:     127.0.0.1:44866 - "GET /health HTTP/1.1" 200 OK`), and
+  // Loki classified those 6,408 lines CORRECTLY. Dropping them to unknown
+  // would be a regression, so read the prefix instead. Anchored at line
+  // start, which is why it cannot reach prompt text: every CrewAI echo line
+  // begins with a box-drawing character, never with `LEVEL:`. Today this
+  // channel carries only INFO, but it is the same one uvicorn uses for
+  // `ERROR:    Exception in ASGI application`.
+  stage.regex {
+    expression = "^(?P<uvicorn_level>INFO|WARNING|ERROR|CRITICAL): "
+  }
+
+  stage.template {
+    source   = "level"
+    template = "{{ if .Value }}{{ ToLower .Value }}{{ else if .uvicorn_level }}{{ ToLower .uvicorn_level }}{{ else }}unknown{{ end }}"
+  }
+
+  stage.structured_metadata {
+    values = { detected_level = "level" }
+  }
 }
 
 loki.write "default" {

--- a/observability/loki/loki-config.yml
+++ b/observability/loki/loki-config.yml
@@ -31,6 +31,12 @@ schema_config:
 limits_config:
   retention_period: 168h
   reject_old_samples: false
+  # Off because Alloy stamps detected_level from the application's own level
+  # field (observability/alloy/config.alloy). Left on, Loki re-guesses the
+  # level from raw text and overrides every line Alloy stamped `unknown` —
+  # it treats that string as absent rather than as a stamp. Our prompt
+  # headings, `--- CRITICAL: ... ---`, were stored as critical that way.
+  discover_log_levels: false
 
 compactor:
   working_directory: /loki/compactor

--- a/src/backend/core/config.py
+++ b/src/backend/core/config.py
@@ -110,6 +110,7 @@ class Settings(BaseSettings):
     ENABLE_CUSTOM_ACTIONS: bool = Field(default=True, description="Enable/disable custom actions for browser automation")
     MAX_LOCATOR_STRATEGIES: int = Field(default=21, description="Maximum number of locator strategies to try")
     TRACK_LLM_COSTS: bool = Field(default=True, description="Enable/disable LLM cost tracking and logging")
+    CREWAI_VERBOSE: bool = Field(default=False, description="Echo CrewAI agent reasoning and the full prompt to stdout. Off by default: measured 2026-08-14 it was 73.7% of the fastapi container's log stream, carries no workflow_id so it cannot be filtered to a run, and the same prompts are already in llm_traces.prompt_text on every model call")
     
     # Optimization Configuration
     OPTIMIZATION_ENABLED: bool = Field(default=True, description="Enable/disable optimization system (pattern learning, pgvector semantic search)")

--- a/src/backend/crew_ai/agents.py
+++ b/src/backend/crew_ai/agents.py
@@ -6,6 +6,8 @@ from crewai import Agent
 # called directly by the deterministic element stage
 # (src/backend/crew_ai/element_identification.py).
 
+from src.backend.core.config import settings
+
 # Import LLM factory function
 from .cleaned_llm_wrapper import get_llm
 from .tasks import AssemblyOutput, PlanOutput
@@ -144,7 +146,7 @@ class RobotAgents:
                 f"{library_guidance}"
             ),
             llm=self.planner_llm,
-            verbose=True,
+            verbose=settings.CREWAI_VERBOSE,
             allow_delegation=False,
         )
 
@@ -175,7 +177,7 @@ class RobotAgents:
                 f"{library_knowledge}"
             ),
             llm=self.llm,
-            verbose=True,
+            verbose=settings.CREWAI_VERBOSE,
             # No in-crew delegation: the LLM validator agent was removed and replaced
             # by the deterministic robot --dryrun gate (dryrun_service.py). The repair
             # loop builds a fresh single-agent crew, so this agent never delegates.

--- a/src/backend/crew_ai/crew.py
+++ b/src/backend/crew_ai/crew.py
@@ -489,7 +489,7 @@ def run_crew(query: str, model_provider: str, model_name: str, workflow_id: str 
             agents=[agent],
             tasks=[task],
             process=Process.sequential,
-            verbose=True,
+            verbose=settings.CREWAI_VERBOSE,
             output_log_file=CREWAI_LOG_FILE,
             step_callback=step_callback,
             task_callback=task_callback,

--- a/src/backend/services/dryrun_service.py
+++ b/src/backend/services/dryrun_service.py
@@ -460,7 +460,7 @@ def repair_robot_code(run_id, robot_code, dryrun_errors, model_provider,
         agents=[assembler],
         tasks=[fix_task],
         process=Process.sequential,
-        verbose=True,
+        verbose=settings.CREWAI_VERBOSE,
         output_log_file=None,  # §8.5 — keep repair noise out of logs/crewai.log
         embedder=None,
         # No step_callback/task_callback and NOT registered in progress_events:

--- a/tests/test_crew_ai/test_verbose_setting.py
+++ b/tests/test_crew_ai/test_verbose_setting.py
@@ -73,20 +73,43 @@ class TestCrewsHonourTheSetting:
 
     @pytest.mark.parametrize("verbose", [True, False])
     def test_repair_crew_verbose_follows_setting(self, verbose):
-        """dryrun_service builds its own Crew on the repair path."""
+        """dryrun_service builds its own Crew on the repair path.
+
+        `Crew` is imported INSIDE repair_robot_code, so the patch target is
+        `crewai.Crew` rather than a module attribute — the name is resolved
+        fresh on each call. kickoff() is then the mock's, so no model is
+        reached and no trace is written.
+        """
+        import crewai
         import src.backend.services.dryrun_service as mod
 
-        source = mod.__file__
-        with open(source, encoding="utf-8") as handle:
-            text = handle.read()
+        with patch.object(crewai, "Crew") as crew_cls, \
+             patch.object(mod.settings, "CREWAI_VERBOSE", verbose):
+            mod.repair_robot_code(
+                "run-id", "*** Settings ***",
+                ["No keyword with name 'Clik' found."],
+                "vertex", "gemini-3.5-flash")
 
-        assert "verbose=True" not in text, (
-            "dryrun_service still hardcodes verbose=True; the repair crew "
-            "echoes the assembler prompt on every dryrun repair")
-        assert "settings.CREWAI_VERBOSE" in text, (
-            "dryrun_service does not read CREWAI_VERBOSE")
+        assert crew_cls.call_args.kwargs["verbose"] is verbose, (
+            f"the repair crew was built with verbose="
+            f"{crew_cls.call_args.kwargs['verbose']!r} when the setting was "
+            f"{verbose!r}; it echoes the assembler prompt on every repair")
 
     def test_generation_crew_reads_the_setting(self):
+        """crew.py is checked by source, not by construction, on purpose.
+
+        Its Crew is built in `_make_crew`, a closure inside `run_crew`
+        (crew.py:487). There is no way in without invoking the whole
+        generation pipeline — planner LLM, element stage, progress queue —
+        which is an integration test's job, not this one's.
+
+        The substring scan is weaker in one direction only: an expression
+        that mentions the setting but always evaluates true, such as
+        `settings.CREWAI_VERBOSE or True`, would pass. It is stronger in
+        another — it catches a hardcoded `verbose=True` at ANY site in the
+        file, including one added later, which a single-call-site assertion
+        would miss.
+        """
         import src.backend.crew_ai.crew as mod
 
         with open(mod.__file__, encoding="utf-8") as handle:

--- a/tests/test_crew_ai/test_verbose_setting.py
+++ b/tests/test_crew_ai/test_verbose_setting.py
@@ -1,0 +1,98 @@
+"""
+Unit tests for the CREWAI_VERBOSE setting in src.backend.core.config.
+
+Purpose: CrewAI's verbose mode echoes the whole prompt to stdout inside
+         box-drawing frames. Measured 2026-08-14, that echo was 30,981 of the
+         42,045 lines the fastapi container shipped to Loki over five days —
+         73.7% of the stream — and none of it carries a workflow_id, so it
+         cannot be filtered to a run. The same prompts are already captured
+         in llm_traces.prompt_text on 100% of the 2,002 model-call spans.
+
+         CLAUDE.md documented `CREWAI_VERBOSE=true` as the debug lever long
+         before the setting existed; run.sh:92 still carries it as a
+         commented-out export that sets nothing. These tests make the lever
+         real and keep it off by default.
+
+Tests:
+  - The setting exists and defaults to off
+  - Both agents and both crews read it rather than hardcoding True
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+class TestCrewaiVerboseSetting:
+
+    def test_setting_exists_and_defaults_off(self):
+        """Verbose is opt-in: the default must not re-flood the log stream."""
+        from src.backend.core.config import Settings
+
+        field = Settings.model_fields.get("CREWAI_VERBOSE")
+        assert field is not None, (
+            "CREWAI_VERBOSE is not a setting; CLAUDE.md and run.sh:92 both "
+            "name it as the debug lever, so it must exist rather than being "
+            "a comment that sets nothing")
+        assert field.default is False, (
+            f"CREWAI_VERBOSE defaults to {field.default!r}; it must default "
+            f"to False or every run echoes the full prompt to the log stream")
+
+
+class TestAgentsHonourTheSetting:
+    """Both agents must read the setting, not hardcode verbose=True."""
+
+    def _agents(self):
+        from src.backend.crew_ai.agents import RobotAgents
+        agents = RobotAgents.__new__(RobotAgents)
+        agents.llm = MagicMock()
+        agents.planner_llm = MagicMock()
+        agents.library_context = MagicMock()
+        agents.assembler_context = None
+        return agents
+
+    @pytest.mark.parametrize("verbose", [True, False])
+    @pytest.mark.parametrize(
+        "method", ["step_planner_agent", "code_assembler_agent"])
+    def test_agent_verbose_follows_setting(self, method, verbose):
+        agents = self._agents()
+
+        with patch("src.backend.crew_ai.agents.Agent") as agent_cls, \
+             patch("src.backend.crew_ai.agents.settings") as cfg:
+            cfg.CREWAI_VERBOSE = verbose
+            getattr(agents, method)()
+
+        assert agent_cls.call_args.kwargs["verbose"] is verbose, (
+            f"{method} passed verbose="
+            f"{agent_cls.call_args.kwargs['verbose']!r} when the setting was "
+            f"{verbose!r}; it is hardcoded rather than read from config")
+
+
+class TestCrewsHonourTheSetting:
+    """The generation crew and the dryrun repair crew both echo prompts."""
+
+    @pytest.mark.parametrize("verbose", [True, False])
+    def test_repair_crew_verbose_follows_setting(self, verbose):
+        """dryrun_service builds its own Crew on the repair path."""
+        import src.backend.services.dryrun_service as mod
+
+        source = mod.__file__
+        with open(source, encoding="utf-8") as handle:
+            text = handle.read()
+
+        assert "verbose=True" not in text, (
+            "dryrun_service still hardcodes verbose=True; the repair crew "
+            "echoes the assembler prompt on every dryrun repair")
+        assert "settings.CREWAI_VERBOSE" in text, (
+            "dryrun_service does not read CREWAI_VERBOSE")
+
+    def test_generation_crew_reads_the_setting(self):
+        import src.backend.crew_ai.crew as mod
+
+        with open(mod.__file__, encoding="utf-8") as handle:
+            text = handle.read()
+
+        assert "verbose=True" not in text, (
+            "crew.py still hardcodes verbose=True")
+        assert "settings.CREWAI_VERBOSE" in text, (
+            "crew.py does not read CREWAI_VERBOSE")

--- a/tests/test_observability/test_dashboards.py
+++ b/tests/test_observability/test_dashboards.py
@@ -1042,8 +1042,18 @@ def test_aggregate_error_log_panel_reads_both_log_formats():
     it does not, and after the exclusion it is expected to stay empty until a
     genuine plain-text error appears. That is the case it is kept for.
 
-    Loki's own `detected_level` is not a third option: selecting on it
-    returns 0 lines on this deployment.
+    Loki's own `detected_level` is not a third option, but the reason
+    recorded here until 2026-08-14 was wrong: it was tested as a stream
+    selector, `{service=~"...", detected_level="error"}`, which matches 0
+    lines because `detected_level` is structured metadata rather than an
+    indexed label. After the pipe it works — `| detected_level="error"`
+    matched 1,196 lines that day, of which 535 were log records; the other
+    661 were plain text Loki had guessed a level for, and 551 of those were
+    CrewAI echoing our own prompt. Since 2026-08-14
+    Alloy stamps it from the application's own level field, so it now
+    duplicates this arm for records that carry a level and reads `unknown`
+    for everything else, which is exactly the class arm B is kept for. See
+    tests/test_observability/test_log_pipeline.py.
     """
     path = DASHBOARD_DIR / "execution-outcomes.json"
     dashboard = json.loads(path.read_text(encoding="utf-8"))

--- a/tests/test_observability/test_log_pipeline.py
+++ b/tests/test_observability/test_log_pipeline.py
@@ -160,8 +160,7 @@ def test_uvicorn_keeps_its_level_and_the_rule_cannot_reach_prompt_text():
     both prompt-echo shapes still store unknown.
     """
     expression = _stage("stage.regex")
-    assert expression.lstrip().count("^") and re.search(
-        r'expression\s*=\s*"\^', expression), (
+    assert re.search(r'expression\s*=\s*"\^', expression), (
         "the uvicorn level rule is not anchored to the start of the line; "
         "unanchored it matches prompt text and re-creates the bug")
     assert "uvicorn_level" in expression, (

--- a/tests/test_observability/test_log_pipeline.py
+++ b/tests/test_observability/test_log_pipeline.py
@@ -1,0 +1,222 @@
+"""Static guards over the log pipeline's level classification.
+
+The level a log line carries in Loki is set in TWO files that have to agree,
+and neither one reads as broken on its own. Alloy stamps `detected_level`
+from the level the application recorded; Loki is told to stop guessing one
+from the raw text. Delete either half and the other silently stops working —
+which is the whole reason this file exists.
+
+The guards below check wiring, not just presence. Four mutations that leave
+every Alloy component healthy and every line flowing were found to pass an
+earlier presence-only version of this file, the worst being an empty
+`forward_to` inside the process block: logs stop reaching Loki entirely and
+nothing complains.
+
+Referenced by: nothing — pytest entry point.
+Depends on: observability/alloy/config.alloy, observability/loki/loki-config.yml
+"""
+import re
+from pathlib import Path
+
+import yaml
+
+ALLOY_CONFIG = Path("observability/alloy/config.alloy")
+LOKI_CONFIG = Path("observability/loki/loki-config.yml")
+
+# The stages, in the only order that works. json first so a real record wins;
+# regex second so uvicorn's line-start prefix is read only when json found
+# nothing; template third to normalise and default; structured_metadata last,
+# because it can only attach a value the earlier stages have already put in
+# the extracted map.
+EXPECTED_STAGE_ORDER = [
+    "stage.json",
+    "stage.regex",
+    "stage.template",
+    "stage.structured_metadata",
+]
+
+
+def _alloy() -> str:
+    return ALLOY_CONFIG.read_text(encoding="utf-8")
+
+
+def _loki() -> dict:
+    return yaml.safe_load(LOKI_CONFIG.read_text(encoding="utf-8"))
+
+
+def _block(header: str, text: str, closing: str) -> str:
+    """The body of a `header { ... }` block, up to its own closing brace.
+
+    `closing` is what distinguishes the block's own brace from the braces of
+    the blocks nested inside it — indentation is the only thing that does,
+    and getting it wrong fails in both directions. A top-level block closes
+    at column 0; a stage nested in one closes indented. Matching "any
+    whitespace" for a top-level block stops at the first nested stage;
+    matching greedily instead runs past the block entirely and swallows
+    whatever follows, which would let a stage moved OUT of the pipeline
+    still satisfy the assertions below.
+    """
+    match = re.search(header + r"\s*\{(.*?)\n" + closing + r"\}", text, re.S)
+    assert match, f"block {header!r} not found"
+    return match.group(1)
+
+
+def _top_level(header: str) -> str:
+    """A block at column 0 — `alloy fmt` never indents these."""
+    return _block(header, _alloy(), closing="")
+
+
+def _process_block() -> str:
+    return _top_level(r'loki\.process\s+"level"')
+
+
+def _stage(name: str) -> str:
+    """A stage nested inside the process block, so its brace is indented.
+
+    Space or tab: `alloy fmt` re-indents with tabs, the committed file uses
+    spaces, and this has to hold either way.
+    """
+    return _block(re.escape(name), _process_block(), closing=r"[ \t]+")
+
+
+def test_docker_source_forwards_only_through_the_level_stage():
+    """The scrape must reach Loki via the stage, and not also bypass it.
+
+    Forwarding straight to `loki.write` stamps nothing and returns level
+    classification to Loki's guessing. Forwarding to BOTH ingests every line
+    twice, which reads as a traffic doubling rather than as a config error.
+    """
+    source = _top_level(r'loki\.source\.docker\s+"containers"')
+
+    assert "loki.process.level.receiver" in source, (
+        "the docker source does not forward through loki.process.level; "
+        "nothing stamps detected_level and Loki falls back to guessing")
+    assert "loki.write" not in source, (
+        "the docker source also forwards straight to loki.write, so every "
+        "line is ingested twice")
+
+
+def test_the_level_stage_still_reaches_loki():
+    """An empty `forward_to` drops every log line and stays healthy.
+
+    This is the failure this file exists to catch and the one a presence-only
+    guard misses: Alloy reports all components healthy, Loki simply stops
+    receiving anything.
+    """
+    assert "loki.write.default.receiver" in _process_block(), (
+        "loki.process.level does not forward to loki.write; every log line "
+        "is silently dropped and every component still reports healthy")
+
+
+def test_stages_run_in_the_only_order_that_works():
+    body = _process_block()
+    positions = []
+    for stage in EXPECTED_STAGE_ORDER:
+        assert stage in body, f"{stage} is missing from loki.process.level"
+        positions.append(body.index(stage))
+
+    assert positions == sorted(positions), (
+        f"stages are out of order: {EXPECTED_STAGE_ORDER} must appear in "
+        f"that sequence, found offsets {positions}")
+
+
+def test_alloy_stamps_detected_level_from_the_recorded_level():
+    """The stamp must come from the application's own `level` field.
+
+    Measured 2026-08-14 over the five days Loki held, counting only lines
+    that are NOT structlog records: 7,769 carried a level Loki had guessed.
+    1,053 of those were CrewAI box-drawing prompt echo and every one was
+    wrong — 270 stamped critical, 232 warn, 551 error. Discovery was correct
+    on all 16,436 real structlog records, and correct on the 6,408 uvicorn
+    access lines the regex stage below preserves.
+
+    The trigger is not only the `KEYWORD:` shape. `--- CRITICAL: ONLY
+    EXPLICIT ELEMENTS ---` is stamped critical, but so is a prompt line that
+    merely contains the bare word `error` in prose — that is where 551 of
+    the 1,053 came from.
+    """
+    extraction = _stage("stage.json")
+    assert re.search(r'\blevel\s*=\s*"level"', extraction), (
+        "stage.json does not extract the application's `level` field into "
+        "`level`; a rename here leaves every record stamped unknown")
+
+    mapping = _stage("stage.structured_metadata")
+    assert re.search(r'detected_level\s*=\s*"level"', mapping), (
+        "structured metadata does not map detected_level from the extracted "
+        "level; Loki will keep guessing from raw text")
+
+
+def test_uvicorn_keeps_its_level_and_the_rule_cannot_reach_prompt_text():
+    """uvicorn writes plain text with the level as a line-start prefix.
+
+    Loki classified those 6,408 lines correctly, so dropping them to unknown
+    would be a regression. The anchor is the safety property: every CrewAI
+    echo line starts with a box-drawing character, never with `LEVEL:`, so an
+    anchored rule cannot reach prompt text. Unanchored, it would re-introduce
+    exactly the bug this pipeline removes.
+
+    Verified live 2026-08-14: `INFO:     127.0.0.1 - "GET /health" 200 OK`
+    stores info, `ERROR:    Exception in ASGI application` stores error, and
+    both prompt-echo shapes still store unknown.
+    """
+    expression = _stage("stage.regex")
+    assert expression.lstrip().count("^") and re.search(
+        r'expression\s*=\s*"\^', expression), (
+        "the uvicorn level rule is not anchored to the start of the line; "
+        "unanchored it matches prompt text and re-creates the bug")
+    assert "uvicorn_level" in expression, (
+        "stage.regex does not capture a uvicorn_level group")
+
+
+def test_non_records_default_to_unknown():
+    """Lines that are not log records must not borrow a level.
+
+    95.4% of the fastapi stream is not a log record at all — 73.7% of it is
+    CrewAI's verbose box-drawing echo of the prompt. Those lines have no
+    level to report and must say so rather than inherit one.
+
+    Verified live 2026-08-14 against the real Alloy pipeline: a JSON record
+    with no `level` key stores `unknown`, and `ToLower` is load-bearing —
+    `"ERROR"` stores `error`, `"Warning"` stores `warning`. Only `info`,
+    `error` and `warning` occur in this deployment's logs.
+
+    Known and accepted: a numeric level (`"level": 40`, what stdlib logging
+    would write) passes through as `detected_level=40`. No logger here emits
+    one, so no guard was added for it.
+    """
+    template = _stage("stage.template")
+
+    assert re.search(r'source\s*=\s*"level"', template), (
+        "stage.template does not read the extracted `level`, so nothing is "
+        "normalised or defaulted")
+    assert re.search(r'\{\{\s*else\s*\}\}unknown\{\{\s*end\s*\}\}', template), (
+        "stage.template does not default a missing level to unknown")
+    assert template.count("ToLower") >= 2, (
+        "stage.template does not lower-case both the recorded level and the "
+        "uvicorn prefix; an upstream logger writing ERROR would stamp a "
+        "level Loki does not recognise")
+
+
+def test_loki_does_not_guess_levels_from_raw_text():
+    """Loki's discovery must be off, or it overrides our `unknown` stamps.
+
+    This is the coupling that is invisible from either file alone. Loki
+    honours an incoming `detected_level` only when it names a real level; it
+    treats the literal string `unknown` as absent and re-runs discovery.
+    Measured 2026-08-14 by pushing the same line four ways:
+
+        stamped info    + text "--- CRITICAL: ..."  -> stored info
+        stamped unknown + text "--- CRITICAL: ..."  -> stored CRITICAL
+        no stamp        + text "--- CRITICAL: ..."  -> stored critical
+        stamped unknown + text "--- ERROR: ..."     -> stored ERROR
+
+    So the Alloy stage alone does not work.
+    """
+    limits = _loki().get("limits_config", {})
+
+    assert "discover_log_levels" in limits, (
+        "discover_log_levels is unset, so it defaults to true and Loki "
+        "overrides every unknown stamp with a keyword guess")
+    assert limits["discover_log_levels"] is False, (
+        f"discover_log_levels is {limits['discover_log_levels']!r}; it must "
+        f"be false or Alloy's stamps are discarded for non-records")


### PR DESCRIPTION
Two independent log-quality fixes, one commit each.

## 1. The level in Loki was being guessed from raw text

Loki's level discovery scans the log line for a level keyword. CrewAI echoes our prompt to stdout verbatim, so the prompt was being classified as if it were log records.

Measured over the five days Loki held, counting only lines that are **not** structlog records:

| | lines | verdict |
|---|---|---|
| CrewAI prompt echo | **1,053** (270 critical, 232 warn, 551 error) | **all wrong** |
| uvicorn `INFO: ` access lines | 6,408 | Loki was right |
| structlog records | 16,436 | Loki was right |

The trigger is wider than a `KEYWORD:` shape: 551 of the 1,053 came from prompt prose containing the bare word `error`.

**Fix.** Alloy stamps `detected_level` from the `level` field the application already writes. Loki's discovery is turned off, because it does not defer to a stamp of `unknown` — it treats that string as absent and re-runs, which silently undid the stage until both halves were in place.

uvicorn is not JSON and Loki classified its access lines correctly, so an anchored rule reads its line-start prefix rather than losing them. The anchor is the safety property: prompt echo always begins with a box-drawing character, never with `LEVEL:`.

Also corrects a claim that shipped in a guard docstring and the README: `detected_level` was reported as returning 0 lines here. It was tested as a stream selector, where it cannot match because it is structured metadata. After the pipe it matched 1,196 lines. It is still not a substitute for either arm of the error panel, for a different reason.

## 2. CrewAI verbose echoed the whole prompt on every run

That echo was 30,981 of the 42,045 lines the fastapi container shipped over five days — 73.7% — against 1,934 actual log records (4.6%). None of it carries a `workflow_id`, so it can never be filtered to a run, and the same prompts are already in `llm_traces.prompt_text` on all 2,002 model-call spans.

`CREWAI_VERBOSE` has been documented in CLAUDE.md as the debug lever and carried in `run.sh` as a commented-out export, but no such setting existed and `verbose` was hardcoded `True` at four sites — including the dryrun repair crew, which echoed the assembler prompt again on every repair. This makes the lever real and defaults it off.

Nothing consumes the output: `crewai.log.txt` is written by `output_log_file` and holds task start/end entries either way.

## Guards

`tests/test_observability/test_log_pipeline.py` asserts the **wiring**, not just that stages are present. Six breaking mutations were run against it; all six fail the suite, including an empty `forward_to` that drops every log line while every Alloy component still reports healthy.

## Validation on a real run

`POST /generate-test`, HTTP 200 in 28.1s, real Robot code through the dryrun gate, on rebuilt images. Per-run figures, normalised — the two "before" windows each contained two concurrent runs:

| | lines/run | prompt-echo lines/run |
|---|---|---|
| before | ~1,608 | ~1,365 (84.9%) |
| after | **447** | **46 (10.3%)** |

~72% fewer log lines per run, ~97% fewer box-drawing lines, over a window that was 28.2s against 15.5s.

Level classification on that run: `info 282, unknown 159, error 4, warning 2`. All four errors are the known LiteLLM `apscheduler` message already excluded from the error panel. **Zero false errors or criticals from prompt text.**

Known and not addressed: the 46 remaining box lines are CrewAI's own "Execution Traces" / "Tracing Preference Saved" banners, printed regardless of `verbose`. Different source, left alone.

## Tests

- NLRF: 3,260 passed, 7 skipped (excludes `test_integration`, needs live Gemini, and `test_clients`, gitignored)
- `tests/test_observability/`: 247 passed

## Note for reviewers

This is forward-only. Structured metadata is stamped at ingest, so lines already in Loki keep their old stamps until they age out of the 168h window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added configurable CrewAI verbosity, disabled by default to reduce prompt and reasoning logs.
  - Improved observability log-level detection for structured JSON and Uvicorn logs.
  - Unrecognized log entries are labeled `unknown`, with normalized levels available as structured metadata.

- **Documentation**
  - Clarified log filtering behavior and guidance for locating unstructured errors.

- **Bug Fixes**
  - Prevented Loki from overriding log levels detected by the observability pipeline.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->