### PR TITLE
Added groups feature to the History (Test Run) page

### DIFF
--- a/src/backend/api/groups_endpoints.py
+++ b/src/backend/api/groups_endpoints.py
@@ -1,0 +1,123 @@
+"""Personal run-groups API — the History page's folder feature.
+
+Groups are per-user folders over test_runs rows (one group per run,
+test_runs.group_id). Everything here is scoped to the caller's user_id:
+cross-user reads and writes 404 so group existence cannot be probed,
+mirroring history_endpoints.py. Org-admins can SEE members' runs via
+/api/history but can never file another user's run into a group — the
+assignment UPDATE's user_id predicate enforces that at the SQL level.
+
+Token-less callers (AUTH_ENFORCED off): GET returns an empty list and all
+mutations 401 — personal groups have no meaning without an identity.
+
+Referenced by: main.py (router registration), frontend HistoryPage
+(GroupChipsRow / MoveToGroupMenu / useGroups).
+Depends on: core/run_registry.py, auth/jwt_utils.py.
+"""
+
+import logging
+import uuid
+from typing import List, Optional
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+
+from src.backend.auth.jwt_utils import require_user
+from src.backend.core.run_registry import DuplicateGroupName, get_run_registry
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+_NAME_MAX = 60
+
+
+class GroupIn(BaseModel):
+    name: str
+
+
+class AssignmentsIn(BaseModel):
+    run_ids: List[str]
+    group_id: Optional[str] = None
+
+
+def _require_identity(user: dict | None) -> str:
+    if user is None:
+        raise HTTPException(401, "Sign-in required for groups")
+    return user["user_id"]
+
+
+def _clean_name(raw: str) -> str:
+    name = raw.strip()
+    if not name or len(name) > _NAME_MAX:
+        raise HTTPException(400, f"Group name must be 1-{_NAME_MAX} characters")
+    return name
+
+
+def _valid_uuid(value: str, what: str) -> str:
+    try:
+        return str(uuid.UUID(value))
+    except ValueError:
+        raise HTTPException(400, f"Invalid {what}")
+
+
+@router.get("/groups")
+def list_groups(user: dict | None = Depends(require_user)):
+    """The caller's groups with run counts (plus the Ungrouped count) —
+    drives the History chip row."""
+    if user is None:
+        return {"groups": [], "ungrouped_count": 0}
+    reg = get_run_registry()
+    return {
+        "groups": reg.list_groups(user["user_id"]),
+        "ungrouped_count": reg.count_ungrouped(user["user_id"]),
+    }
+
+
+@router.post("/groups", status_code=201)
+def create_group(body: GroupIn, user: dict | None = Depends(require_user)):
+    user_id = _require_identity(user)
+    name = _clean_name(body.name)
+    try:
+        return get_run_registry().create_group(user_id, name)
+    except DuplicateGroupName:
+        raise HTTPException(409, f'You already have a group named "{name}"')
+
+
+@router.patch("/groups/{group_id}")
+def rename_group(
+    group_id: str, body: GroupIn, user: dict | None = Depends(require_user)
+):
+    user_id = _require_identity(user)
+    group_id = _valid_uuid(group_id, "group id")
+    name = _clean_name(body.name)
+    try:
+        renamed = get_run_registry().rename_group(user_id, group_id, name)
+    except DuplicateGroupName:
+        raise HTTPException(409, f'You already have a group named "{name}"')
+    if not renamed:
+        raise HTTPException(404, "Group not found")
+    return {"group_id": group_id, "name": name}
+
+
+@router.delete("/groups/{group_id}", status_code=204)
+def delete_group(group_id: str, user: dict | None = Depends(require_user)):
+    """Delete a group; its runs return to Ungrouped (runs are never deleted)."""
+    user_id = _require_identity(user)
+    group_id = _valid_uuid(group_id, "group id")
+    if not get_run_registry().delete_group(user_id, group_id):
+        raise HTTPException(404, "Group not found")
+
+
+@router.put("/groups/assignments")
+def assign_runs(body: AssignmentsIn, user: dict | None = Depends(require_user)):
+    """Move runs into a group (group_id null = remove from group). Atomic:
+    any run or group that isn't the caller's rejects the whole request."""
+    user_id = _require_identity(user)
+    if not body.run_ids:
+        raise HTTPException(400, "run_ids must not be empty")
+    run_ids = [_valid_uuid(r, "run id") for r in body.run_ids]
+    group_id = _valid_uuid(body.group_id, "group id") if body.group_id else None
+    if not get_run_registry().assign_runs(user_id, run_ids, group_id):
+        raise HTTPException(404, "Group or run not found")
+    return {"assigned": len(run_ids), "group_id": group_id}

--- a/src/backend/api/history_endpoints.py
+++ b/src/backend/api/history_endpoints.py
@@ -57,6 +57,7 @@ def list_history(
     offset: int = 0,
     status: Optional[Literal["generated", "running", "passed", "failed", "error"]] = None,
     q: Optional[str] = None,
+    group: Optional[str] = None,
     user: dict | None = Depends(require_user),
 ):
     """Role-scoped run history (own runs for users, all runs for admins).
@@ -64,10 +65,21 @@ def list_history(
     status narrows rows, total and pagination to one run status — the History
     tabs page within their own filter instead of the full list. q is a
     server-side substring search (description / owner email / run id) so it
-    spans the whole result set rather than just the loaded page."""
+    spans the whole result set rather than just the loaded page. group narrows
+    to one personal run group (or "ungrouped"), combining with both."""
     limit = max(1, min(limit, 200))
     offset = max(0, offset)
     q = q.strip() if q else None
+
+    # group: a run_groups id (uuid) or the literal "ungrouped". Groups are
+    # personal, so the filter needs no extra authorization: rows are already
+    # scoped below, and filtering your view by someone else's uuid just
+    # yields rows you could see anyway that happen to sit in that group.
+    if group and group != "ungrouped":
+        try:
+            group = str(uuid.UUID(group))
+        except ValueError:
+            raise HTTPException(status_code=400, detail="Invalid group id")
 
     admin = is_validated_admin(user)
     # Platform-admin and dev escape hatch (user is None) see all orgs.
@@ -86,7 +98,7 @@ def list_history(
 
     runs, total = get_run_registry().list_runs(
         user_id=scope_user_id, org_id=scope_org_id,
-        limit=limit, offset=offset, status=status, q=q,
+        limit=limit, offset=offset, status=status, q=q, group=group,
     )
     for r in runs:
         r["has_report"] = r["status"] in _REPORT_STATUSES

--- a/src/backend/core/run_registry.py
+++ b/src/backend/core/run_registry.py
@@ -25,6 +25,7 @@ Depends on: core/config.py (DATABASE_URL).
 """
 
 import logging
+import uuid
 from threading import Lock
 from typing import Any, Dict, List, Optional, Tuple
 
@@ -63,7 +64,25 @@ _SCHEMA_DDL = (
     " ON test_runs (user_id, created_at DESC)",
     "CREATE INDEX IF NOT EXISTS idx_test_runs_created"
     " ON test_runs (created_at DESC)",
+    # --- personal run groups (History page folders) ---
+    """
+    CREATE TABLE IF NOT EXISTS run_groups (
+        group_id   TEXT PRIMARY KEY,
+        user_id    TEXT NOT NULL,
+        name       TEXT NOT NULL,
+        created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+        updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+    )
+    """,
+    "CREATE UNIQUE INDEX IF NOT EXISTS idx_run_groups_user_name"
+    " ON run_groups (user_id, lower(name))",
+    "ALTER TABLE test_runs ADD COLUMN IF NOT EXISTS group_id TEXT",
+    "CREATE INDEX IF NOT EXISTS idx_test_runs_group ON test_runs (group_id)",
 )
+
+
+class DuplicateGroupName(Exception):
+    """The user already has a group with this name (case-insensitive)."""
 
 
 class RunRegistry:
@@ -158,6 +177,120 @@ class RunRegistry:
         except Exception as e:
             logger.error(f"[RUN_REGISTRY] set_status failed for {run_id}: {e}")
 
+    # ------------------------------------------------------------------
+    # Personal run groups (History page folders). User-facing CRUD: these
+    # methods PROPAGATE storage errors (the swallow-everything discipline
+    # above exists to protect the generation pipeline, not this UI path).
+    # ------------------------------------------------------------------
+
+    def list_groups(self, user_id: str) -> List[Dict[str, Any]]:
+        """The user's groups, name-sorted, each with its member-run count."""
+        with self._pool.connection() as conn:
+            rows = conn.execute(
+                "SELECT g.group_id, g.name, g.created_at, g.updated_at, "
+                "       COUNT(t.run_id) AS run_count "
+                "FROM run_groups g "
+                "LEFT JOIN test_runs t ON t.group_id = g.group_id "
+                "WHERE g.user_id = %s "
+                "GROUP BY g.group_id ORDER BY lower(g.name)",
+                (user_id,),
+            ).fetchall()
+        out = []
+        for r in rows:
+            r = dict(r)
+            r["created_at"] = r["created_at"].isoformat()
+            r["updated_at"] = r["updated_at"].isoformat()
+            out.append(r)
+        return out
+
+    def create_group(self, user_id: str, name: str) -> Dict[str, Any]:
+        """Create a group; raises DuplicateGroupName on a per-user,
+        case-insensitive name collision."""
+        try:
+            with self._pool.connection() as conn:
+                row = conn.execute(
+                    "INSERT INTO run_groups (group_id, user_id, name) "
+                    "VALUES (%s, %s, %s) "
+                    "RETURNING group_id, name, created_at, updated_at",
+                    (str(uuid.uuid4()), user_id, name),
+                ).fetchone()
+        except psycopg.errors.UniqueViolation:
+            raise DuplicateGroupName(name)
+        row = dict(row)
+        row["run_count"] = 0
+        row["created_at"] = row["created_at"].isoformat()
+        row["updated_at"] = row["updated_at"].isoformat()
+        return row
+
+    def rename_group(self, user_id: str, group_id: str, name: str) -> bool:
+        """False when the group doesn't exist or isn't the caller's; raises
+        DuplicateGroupName when the new name collides with another group."""
+        try:
+            with self._pool.connection() as conn:
+                cur = conn.execute(
+                    "UPDATE run_groups SET name = %s, updated_at = now() "
+                    "WHERE group_id = %s AND user_id = %s",
+                    (name, group_id, user_id),
+                )
+                return cur.rowcount == 1
+        except psycopg.errors.UniqueViolation:
+            raise DuplicateGroupName(name)
+
+    def delete_group(self, user_id: str, group_id: str) -> bool:
+        """Delete a group and return its member runs to Ungrouped — one
+        transaction, so a failure leaves both tables untouched. Runs are
+        NEVER deleted. False when the group doesn't exist / isn't the
+        caller's."""
+        with self._pool.connection() as conn:
+            cur = conn.execute(
+                "DELETE FROM run_groups WHERE group_id = %s AND user_id = %s",
+                (group_id, user_id),
+            )
+            if cur.rowcount != 1:
+                return False
+            conn.execute(
+                "UPDATE test_runs SET group_id = NULL WHERE group_id = %s",
+                (group_id,),
+            )
+            return True
+
+    def count_ungrouped(self, user_id: str) -> int:
+        """How many of the user's runs are in no group — the Ungrouped chip's
+        live count on the History page."""
+        with self._pool.connection() as conn:
+            row = conn.execute(
+                "SELECT COUNT(*) AS n FROM test_runs "
+                "WHERE user_id = %s AND group_id IS NULL",
+                (user_id,),
+            ).fetchone()
+        return row["n"]
+
+    def assign_runs(
+        self, user_id: str, run_ids: List[str], group_id: Optional[str]
+    ) -> bool:
+        """Atomically set group_id on the caller's runs (None = ungroup).
+        All-or-nothing: unless the target group (when non-null) AND every
+        run id belong to user_id, nothing is written and False is returned —
+        an org-admin can SEE members' runs in history but can never file
+        someone else's run into a group."""
+        with self._pool.connection() as conn:
+            if group_id is not None:
+                owned = conn.execute(
+                    "SELECT 1 FROM run_groups WHERE group_id = %s AND user_id = %s",
+                    (group_id, user_id),
+                ).fetchone()
+                if not owned:
+                    return False
+            cur = conn.execute(
+                "UPDATE test_runs SET group_id = %s "
+                "WHERE run_id = ANY(%s) AND user_id = %s",
+                (group_id, run_ids, user_id),
+            )
+            if cur.rowcount != len(set(run_ids)):
+                conn.rollback()
+                return False
+            return True
+
     def list_runs(
         self,
         user_id: Optional[str] = None,
@@ -166,6 +299,7 @@ class RunRegistry:
         offset: int = 0,
         status: Optional[str] = None,
         q: Optional[str] = None,
+        group: Optional[str] = None,
     ) -> Tuple[List[Dict[str, Any]], int]:
         """Most-recent-first run rows + total count. user_id=None lists all
         users' runs (admin scope); otherwise only that user's rows. status
@@ -173,37 +307,49 @@ class RunRegistry:
         tabs paginate and count within their own filter. q is a case-insensitive
         substring match over the description, owner email and run id — applied
         server-side so it spans ALL of a user's runs, not just the loaded page,
-        and so rows/total/pagination stay consistent with the active search."""
+        and so rows/total/pagination stay consistent with the active search.
+        group narrows to one personal group (a run_groups id) or, with the
+        literal "ungrouped", to rows with no group; rows carry group_id and
+        group_name (LEFT JOIN) so the History table renders folder tags
+        without extra requests."""
         clauses: list = []
         params: list = []
         if user_id is not None:
-            clauses.append("user_id = %s")
+            clauses.append("t.user_id = %s")
             params.append(user_id)
         if org_id is not None:
-            clauses.append("org_id = %s")
+            clauses.append("t.org_id = %s")
             params.append(org_id)
         if status is not None:
-            clauses.append("status = %s")
+            clauses.append("t.status = %s")
             params.append(status)
+        if group == "ungrouped":
+            clauses.append("t.group_id IS NULL")
+        elif group is not None:
+            clauses.append("t.group_id = %s")
+            params.append(group)
         if q:
             # Escape LIKE wildcards so a typed % / _ matches literally (default
             # ESCAPE is backslash); the search box is substring, not glob.
             like = "%" + q.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_") + "%"
             clauses.append(
-                "(user_query ILIKE %s OR user_email ILIKE %s OR run_id ILIKE %s)"
+                "(t.user_query ILIKE %s OR t.user_email ILIKE %s OR t.run_id ILIKE %s)"
             )
             params.extend([like, like, like])
         where = f" WHERE {' AND '.join(clauses)}" if clauses else ""
         try:
             with self._pool.connection() as conn:
                 total = conn.execute(
-                    f"SELECT COUNT(*) AS n FROM test_runs{where}", params
+                    f"SELECT COUNT(*) AS n FROM test_runs t{where}", params
                 ).fetchone()["n"]
                 rows = conn.execute(
-                    f"SELECT run_id, user_id, user_email, user_query, rerun_of, "
-                    f"       status, created_at, updated_at "
-                    f"FROM test_runs{where} "
-                    f"ORDER BY created_at DESC LIMIT %s OFFSET %s",
+                    f"SELECT t.run_id, t.user_id, t.user_email, t.user_query, "
+                    f"       t.rerun_of, t.status, t.created_at, t.updated_at, "
+                    f"       t.group_id, g.name AS group_name "
+                    f"FROM test_runs t "
+                    f"LEFT JOIN run_groups g ON g.group_id = t.group_id"
+                    f"{where} "
+                    f"ORDER BY t.created_at DESC LIMIT %s OFFSET %s",
                     params + [limit, offset],
                 ).fetchall()
             out = []
@@ -269,9 +415,13 @@ class RunRegistry:
         try:
             with self._pool.connection() as conn:
                 row = conn.execute(
-                    "SELECT run_id, user_id, user_email, user_query, robot_code, "
-                    "       rerun_of, status, org_id, created_at, updated_at "
-                    "FROM test_runs WHERE run_id = %s",
+                    "SELECT t.run_id, t.user_id, t.user_email, t.user_query, "
+                    "       t.robot_code, t.rerun_of, t.status, t.org_id, "
+                    "       t.created_at, t.updated_at, "
+                    "       t.group_id, g.name AS group_name "
+                    "FROM test_runs t "
+                    "LEFT JOIN run_groups g ON g.group_id = t.group_id "
+                    "WHERE t.run_id = %s",
                     (run_id,),
                 ).fetchone()
             if not row:

--- a/src/backend/main.py
+++ b/src/backend/main.py
@@ -126,6 +126,10 @@ app.include_router(api_router)
 from src.backend.api.history_endpoints import router as history_router
 app.include_router(history_router, prefix="/api")
 
+# Personal run groups — the History page's folder feature.
+from src.backend.api.groups_endpoints import router as groups_router
+app.include_router(groups_router, prefix="/api")
+
 # Metrics dashboards — routes self-guard via is_dashboard_viewer (org-admin+).
 from src.backend.api.workflow_metrics_endpoints import router as workflow_metrics_router
 app.include_router(workflow_metrics_router, prefix="/api")

--- a/src/frontend-react/src/App.tsx
+++ b/src/frontend-react/src/App.tsx
@@ -6,6 +6,7 @@ import { RequireAuth } from '@/auth/guards'
 import { SidebarProvider, SidebarInset } from '@/components/ui/sidebar'
 import { AppSidebar } from '@/components/app-sidebar'
 import { AppHeader } from '@/components/app-header'
+import { RunGroupsProvider } from '@/components/history/RunGroupsContext'
 import GeneratePage from '@/pages/GeneratePage'
 import HistoryPage from '@/pages/HistoryPage'
 import MetricsPage from '@/pages/MetricsPage'
@@ -80,22 +81,28 @@ function KeepAlivePages() {
   )
 }
 
-/** Full app layout: sidebar + topbar + keep-alive page content */
+/** Full app layout: sidebar + topbar + keep-alive page content.
+ *
+ * RunGroupsProvider sits above BOTH the sidebar and the pages: the sidebar's
+ * group quick-access and the Test Runs page filter the same runs, so they read
+ * and write one shared filter instead of two copies that could disagree. */
 function AppLayout() {
   return (
-    <SidebarProvider>
-      <AppSidebar />
-      <SidebarInset>
-        <AppHeader />
-        {/* Page content — SidebarInset provides the responsive padding offset.
-            KeepAlivePages renders the actual pages; the Outlet only carries
-            the index / catch-all redirects (page routes are element={null}). */}
-        <div className="flex flex-1 flex-col p-6 pt-4 overflow-auto">
-          <KeepAlivePages />
-          <Outlet />
-        </div>
-      </SidebarInset>
-    </SidebarProvider>
+    <RunGroupsProvider>
+      <SidebarProvider>
+        <AppSidebar />
+        <SidebarInset>
+          <AppHeader />
+          {/* Page content — SidebarInset provides the responsive padding offset.
+              KeepAlivePages renders the actual pages; the Outlet only carries
+              the index / catch-all redirects (page routes are element={null}). */}
+          <div className="flex flex-1 flex-col p-6 pt-4 overflow-auto">
+            <KeepAlivePages />
+            <Outlet />
+          </div>
+        </SidebarInset>
+      </SidebarProvider>
+    </RunGroupsProvider>
   )
 }
 

--- a/src/frontend-react/src/components/app-header.tsx
+++ b/src/frontend-react/src/components/app-header.tsx
@@ -15,7 +15,7 @@ import { cn } from '@/lib/utils'
 
 const PAGE_LABELS: Record<string, string> = {
   '/generate':  'Generate',
-  '/history':   'History',
+  '/history':   'Test Runs',
   '/metrics':   'Metrics',
   '/learning':  'Learning',
   '/settings':  'Settings',

--- a/src/frontend-react/src/components/app-sidebar.tsx
+++ b/src/frontend-react/src/components/app-sidebar.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { Link, useLocation, useNavigate } from 'react-router-dom'
 import {
   Sidebar,
@@ -8,8 +8,12 @@ import {
   SidebarGroupLabel,
   SidebarHeader,
   SidebarMenu,
+  SidebarMenuAction,
   SidebarMenuButton,
   SidebarMenuItem,
+  SidebarMenuSub,
+  SidebarMenuSubButton,
+  SidebarMenuSubItem,
   SidebarRail,
 } from '@/components/ui/sidebar'
 import {
@@ -29,11 +33,14 @@ import {
   LogOut,
   MonitorSmartphone,
   Loader2,
+  ChevronDown,
   ChevronsUpDown,
+  Folder,
   ShieldCheck,
   Users,
 } from 'lucide-react'
 import { useAuth } from '@/auth/AuthContext'
+import { useRunGroups } from '@/components/history/RunGroupsContext'
 
 /* ── Logo mark ── */
 const LogoMark = () => (
@@ -52,11 +59,13 @@ interface NavItem {
   icon: typeof Zap
   admin: boolean
   orgAdmin?: boolean
+  /** Renders the expandable run-group quick-access list under this item. */
+  groups?: boolean
 }
 
 const NAV_PLATFORM: NavItem[] = [
   { title: 'Generate', url: '/generate', icon: Zap, admin: false },
-  { title: 'History', url: '/history', icon: History, admin: false },
+  { title: 'Test Runs', url: '/history', icon: History, admin: false, groups: true },
   { title: 'Metrics', url: '/metrics', icon: BarChart2, admin: true },
   { title: 'Learning', url: '/learning', icon: Brain, admin: true },
   { title: 'Access', url: '/access', icon: ShieldCheck, admin: true },
@@ -167,6 +176,101 @@ function NavUser() {
   )
 }
 
+/* ── Test Runs + its run-group quick access ──
+ *
+ * The row keeps its normal behaviour: the label navigates to the page. The
+ * chevron beside it is a separate control that expands the user's groups, so
+ * jumping straight to one group's runs takes a single click from anywhere in
+ * the app.
+ *
+ * The list is read-only on purpose — creating, renaming and deleting groups
+ * all live on the page itself. A nav sidebar answers "where do I go", and
+ * mixing management controls into it would give those actions two homes.
+ *
+ * The active group comes from RunGroupsContext, the same value the page's chip
+ * row writes, so picking a group here or there always agrees. */
+function GroupsNavItem({ item, pathname }: { item: NavItem; pathname: string }) {
+  const navigate = useNavigate()
+  const { groups, groupFilter, setGroupFilter } = useRunGroups()
+  const [open, setOpen] = useState(false)
+
+  // Reveal the active group the way a file tree opens to the selected file:
+  // when a group is chosen on the PAGE, the sidebar expands to show where you
+  // are. Keyed on the filter alone so a background refresh of the group list
+  // never re-opens a list the user deliberately collapsed.
+  useEffect(() => {
+    if (groupFilter && groupFilter !== 'ungrouped') setOpen(true)
+  }, [groupFilter])
+
+  const subId = 'sidebar-run-groups'
+
+  const pick = (groupId: string) => {
+    setGroupFilter(groupId)
+    // Already on the page? Only the filter changes — no navigation, so the
+    // page keeps its scroll position and open drawer.
+    if (pathname !== item.url) navigate(item.url)
+  }
+
+  return (
+    <SidebarMenuItem>
+      <SidebarMenuButton asChild isActive={pathname === item.url} tooltip={item.title}>
+        <Link to={item.url}>
+          <item.icon />
+          <span>{item.title}</span>
+        </Link>
+      </SidebarMenuButton>
+
+      {/* The chevron shows even with no groups: a user who has never made one
+          would otherwise get no hint anywhere in the nav that groups exist,
+          and they are exactly who needs to find the feature. */}
+      <SidebarMenuAction
+        onClick={() => setOpen(o => !o)}
+        aria-expanded={open}
+        aria-controls={subId}
+        aria-label={open ? 'Hide groups' : 'Show groups'}
+        title={open ? 'Hide groups' : 'Show groups'}
+      >
+        <ChevronDown
+          className={`transition-transform duration-200 ${open ? 'rotate-180' : ''}`}
+        />
+      </SidebarMenuAction>
+
+      {open && (
+        <SidebarMenuSub id={subId} className="max-h-[40vh] overflow-y-auto">
+          {groups.length === 0 ? (
+            // Empty states point somewhere. Naming where groups come from
+            // turns this click into how the feature gets discovered — and it
+            // stays a signpost, not a second place to create them.
+            <li className="px-2 py-1.5 text-xs leading-snug text-sidebar-foreground/60">
+              No groups yet — create one on Test Runs.
+            </li>
+          ) : groups.map(g => (
+            <SidebarMenuSubItem key={g.group_id}>
+              <SidebarMenuSubButton
+                asChild
+                size="sm"
+                isActive={groupFilter === g.group_id}
+              >
+                <button
+                  type="button"
+                  onClick={() => pick(g.group_id)}
+                  title={`Show only ${g.name}`}
+                >
+                  <Folder />
+                  <span className="truncate">{g.name}</span>
+                  <span className="ml-auto shrink-0 text-xs tabular-nums text-sidebar-foreground/60">
+                    {g.run_count}
+                  </span>
+                </button>
+              </SidebarMenuSubButton>
+            </SidebarMenuSubItem>
+          ))}
+        </SidebarMenuSub>
+      )}
+    </SidebarMenuItem>
+  )
+}
+
 /* ── Renders one nav group, hiding admin-only items from regular users ── */
 function NavGroup({ label, items, isAdmin, isOrgAdmin, pathname }: {
   label: string
@@ -182,14 +286,18 @@ function NavGroup({ label, items, isAdmin, isOrgAdmin, pathname }: {
       <SidebarGroupLabel>{label}</SidebarGroupLabel>
       <SidebarMenu>
         {visible.map(item => (
-          <SidebarMenuItem key={item.title}>
-            <SidebarMenuButton asChild isActive={pathname === item.url} tooltip={item.title}>
-              <Link to={item.url}>
-                <item.icon />
-                <span>{item.title}</span>
-              </Link>
-            </SidebarMenuButton>
-          </SidebarMenuItem>
+          item.groups ? (
+            <GroupsNavItem key={item.title} item={item} pathname={pathname} />
+          ) : (
+            <SidebarMenuItem key={item.title}>
+              <SidebarMenuButton asChild isActive={pathname === item.url} tooltip={item.title}>
+                <Link to={item.url}>
+                  <item.icon />
+                  <span>{item.title}</span>
+                </Link>
+              </SidebarMenuButton>
+            </SidebarMenuItem>
+          )
         ))}
       </SidebarMenu>
     </SidebarGroup>

--- a/src/frontend-react/src/components/history/GroupChipsRow.tsx
+++ b/src/frontend-react/src/components/history/GroupChipsRow.tsx
@@ -1,0 +1,275 @@
+/**
+ * Group filter row — the Test Runs page's folder bar.
+ *
+ * Deliberately fixed-width: the row never grows with the number of groups.
+ * It carries at most three controls — Ungrouped, the groups control, and
+ * "＋ New" — so creating twenty groups cannot push the page's toolbar down.
+ *
+ * The groups control is the whole taxonomy behind one button: it reads
+ * "All Groups" while no group is filtered, and becomes the selected group's
+ * own chip (with an ✕ to clear) once one is. Clicking it either way opens the
+ * browse dialog, which lists every group with its run count and is also where
+ * rename/delete live — so group management has one obvious home instead of
+ * icons that only appear beside an active chip.
+ */
+import { useState } from 'react'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import {
+  Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle,
+} from '@/components/ui/dialog'
+import { Folder, FolderOpen, Pencil, Plus, Trash2, X } from 'lucide-react'
+import type { RunGroup } from './useGroups'
+// The filter type lives with the shared state it describes — the sidebar's
+// quick-access list writes the same value this row does.
+import type { GroupFilter } from './RunGroupsContext'
+
+interface Props {
+  groups: RunGroup[]
+  ungroupedCount: number
+  active: GroupFilter
+  onSelect: (value: GroupFilter) => void
+  onCreate: (name: string) => Promise<unknown>
+  onRename: (groupId: string, name: string) => Promise<unknown>
+  onDelete: (groupId: string) => Promise<unknown>
+}
+
+/** One overlay at a time. `from: 'browse'` returns there after a successful
+ *  rename/delete, so managing several groups doesn't mean reopening the list. */
+type Overlay =
+  | { kind: 'browse' }
+  | { kind: 'create' }
+  | { kind: 'rename'; group: RunGroup; from?: 'browse' }
+  | { kind: 'delete'; group: RunGroup; from?: 'browse' }
+  | null
+
+export function GroupChipsRow({
+  groups, ungroupedCount, active, onSelect, onCreate, onRename, onDelete,
+}: Props) {
+  const [overlay, setOverlay] = useState<Overlay>(null)
+  const [name, setName] = useState('')
+  const [error, setError] = useState('')
+  const [busy, setBusy] = useState(false)
+
+  const activeGroup = groups.find(g => g.group_id === active) ?? null
+
+  const open = (next: Overlay, initialName = '') => {
+    setName(initialName)
+    setError('')
+    setBusy(false)
+    setOverlay(next)
+  }
+
+  /** Close, or fall back to the browse list the action was launched from. */
+  const dismiss = () => {
+    setBusy(false)
+    setOverlay(prev =>
+      prev && (prev.kind === 'rename' || prev.kind === 'delete') && prev.from === 'browse'
+        ? { kind: 'browse' }
+        : null,
+    )
+  }
+
+  const submit = async () => {
+    if (!overlay) return
+    setBusy(true)
+    setError('')
+    try {
+      if (overlay.kind === 'create') await onCreate(name.trim())
+      else if (overlay.kind === 'rename') await onRename(overlay.group.group_id, name.trim())
+      else if (overlay.kind === 'delete') await onDelete(overlay.group.group_id)
+      dismiss()
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Something went wrong')
+      setBusy(false)
+    }
+  }
+
+  const pickGroup = (groupId: string) => {
+    onSelect(groupId)
+    setOverlay(null)
+  }
+
+  const nameDialogOpen = overlay?.kind === 'create' || overlay?.kind === 'rename'
+
+  return (
+    <div className="flex flex-wrap items-center gap-1.5">
+      <Button
+        size="sm"
+        variant={active === 'ungrouped' ? 'secondary' : 'ghost'}
+        className={`h-7 gap-1.5 rounded-full text-xs ${active === 'ungrouped' ? '' : 'text-muted-foreground'}`}
+        title={active === 'ungrouped' ? 'Clear the filter' : 'Show only runs that are in no group'}
+        onClick={() => onSelect(active === 'ungrouped' ? null : 'ungrouped')}
+      >
+        Ungrouped
+        <span className="text-muted-foreground">· {ungroupedCount}</span>
+      </Button>
+
+      {/* The whole taxonomy behind one control — "All Groups" until a group is
+          filtered, then that group's own chip. Either way it opens the list. */}
+      {groups.length > 0 && (
+        activeGroup ? (
+          <span className="inline-flex items-center">
+            <Button
+              size="sm"
+              variant="secondary"
+              className="h-7 gap-1.5 rounded-full rounded-r-none pr-2 text-xs"
+              title="Switch or manage groups"
+              onClick={() => open({ kind: 'browse' })}
+            >
+              <Folder className="h-3 w-3" />
+              {activeGroup.name}
+              <span className="text-muted-foreground">· {activeGroup.run_count}</span>
+            </Button>
+            <Button
+              size="sm"
+              variant="secondary"
+              className="h-7 rounded-full rounded-l-none border-l border-background px-1.5"
+              title="Clear the group filter"
+              aria-label="Clear the group filter"
+              onClick={() => onSelect(null)}
+            >
+              <X className="h-3 w-3" />
+            </Button>
+          </span>
+        ) : (
+          <Button
+            size="sm"
+            variant="ghost"
+            className="h-7 gap-1.5 rounded-full text-xs text-muted-foreground"
+            title="Browse and manage your groups"
+            onClick={() => open({ kind: 'browse' })}
+          >
+            <FolderOpen className="h-3 w-3" />
+            All Groups
+            <span className="text-muted-foreground">· {groups.length}</span>
+          </Button>
+        )
+      )}
+
+      <Button
+        size="sm"
+        variant="outline"
+        className="h-7 gap-1 rounded-full border-dashed text-xs text-muted-foreground"
+        onClick={() => open({ kind: 'create' })}
+      >
+        <Plus className="h-3 w-3" /> New
+      </Button>
+
+      {/* Browse: pick a group to filter, or rename/delete it in place. */}
+      <Dialog open={overlay?.kind === 'browse'} onOpenChange={o => { if (!o) setOverlay(null) }}>
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle>All Groups</DialogTitle>
+            <DialogDescription>
+              Pick a group to filter the runs, or rename and delete them here.
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="-mx-1 max-h-[320px] overflow-y-auto">
+            {groups.length === 0 ? (
+              <p className="px-1 py-6 text-center text-xs text-muted-foreground">
+                No groups yet — close this and use ＋ New to create one.
+              </p>
+            ) : groups.map(g => (
+              <div
+                key={g.group_id}
+                className={`group flex items-center gap-2 rounded-md px-2 py-2 text-sm hover:bg-muted/60 ${
+                  g.group_id === active ? 'bg-muted' : ''
+                }`}
+              >
+                <button
+                  type="button"
+                  className="flex min-w-0 flex-1 items-center gap-2 text-left"
+                  title={`Show only ${g.name}`}
+                  onClick={() => pickGroup(g.group_id)}
+                >
+                  <Folder className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+                  <span className="truncate">{g.name}</span>
+                  <span className="shrink-0 text-xs text-muted-foreground">
+                    · {g.run_count} run{g.run_count === 1 ? '' : 's'}
+                  </span>
+                </button>
+                <Button
+                  variant="ghost" size="icon" className="h-7 w-7 shrink-0"
+                  title="Rename group" aria-label={`Rename ${g.name}`}
+                  onClick={() => open({ kind: 'rename', group: g, from: 'browse' }, g.name)}
+                >
+                  <Pencil className="h-3.5 w-3.5" />
+                </Button>
+                <Button
+                  variant="ghost" size="icon" className="h-7 w-7 shrink-0"
+                  title="Delete group (runs are kept)" aria-label={`Delete ${g.name}`}
+                  onClick={() => open({ kind: 'delete', group: g, from: 'browse' })}
+                >
+                  <Trash2 className="h-3.5 w-3.5" />
+                </Button>
+              </div>
+            ))}
+          </div>
+
+          <DialogFooter className="sm:justify-between">
+            {active && activeGroup ? (
+              <Button
+                size="sm" variant="outline"
+                onClick={() => { onSelect(null); setOverlay(null) }}
+              >
+                Clear filter
+              </Button>
+            ) : <span />}
+            <Button size="sm" variant="outline" onClick={() => setOverlay(null)}>Close</Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Create / Rename share one name form. */}
+      <Dialog open={nameDialogOpen} onOpenChange={o => { if (!o) dismiss() }}>
+        <DialogContent className="sm:max-w-sm">
+          <DialogHeader>
+            <DialogTitle>{overlay?.kind === 'rename' ? 'Rename group' : 'New group'}</DialogTitle>
+            <DialogDescription>
+              Groups are personal folders for your runs — only you see them.
+            </DialogDescription>
+          </DialogHeader>
+          <form onSubmit={e => { e.preventDefault(); void submit() }} className="flex flex-col gap-2">
+            <Input
+              autoFocus
+              value={name}
+              maxLength={60}
+              onChange={e => setName(e.target.value)}
+              placeholder="e.g. Checkout flows"
+            />
+            {error && <p className="text-xs text-destructive">{error}</p>}
+            <DialogFooter className="mt-2">
+              <Button type="button" size="sm" variant="outline" onClick={dismiss}>Cancel</Button>
+              <Button type="submit" size="sm" disabled={busy || !name.trim()}>
+                {overlay?.kind === 'rename' ? 'Rename' : 'Create'}
+              </Button>
+            </DialogFooter>
+          </form>
+        </DialogContent>
+      </Dialog>
+
+      {/* Delete confirmation — runs survive, they just return to Ungrouped. */}
+      <Dialog open={overlay?.kind === 'delete'} onOpenChange={o => { if (!o) dismiss() }}>
+        <DialogContent className="sm:max-w-sm">
+          <DialogHeader>
+            <DialogTitle>
+              Delete “{overlay?.kind === 'delete' ? overlay.group.name : ''}”?
+            </DialogTitle>
+            <DialogDescription>
+              Runs in this group are NOT deleted — they return to Ungrouped.
+            </DialogDescription>
+          </DialogHeader>
+          {error && <p className="text-xs text-destructive">{error}</p>}
+          <DialogFooter>
+            <Button size="sm" variant="outline" onClick={dismiss}>Cancel</Button>
+            <Button size="sm" variant="destructive" disabled={busy} onClick={() => void submit()}>
+              Delete group
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  )
+}

--- a/src/frontend-react/src/components/history/MoveToGroupMenu.tsx
+++ b/src/frontend-react/src/components/history/MoveToGroupMenu.tsx
@@ -1,0 +1,119 @@
+/**
+ * "Move to group…" dropdown — the single filing control used by the History
+ * row actions, the detail drawer, and the bulk-select toolbar. Lists the
+ * user's groups (check-marks the run's current one), offers Remove from
+ * group, and can create-and-move in one gesture via the New group… item.
+ */
+import { useState, type ReactNode } from 'react'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import {
+  Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle,
+} from '@/components/ui/dialog'
+import {
+  DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuLabel,
+  DropdownMenuSeparator, DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu'
+import { Check, Folder, FolderMinus, Plus } from 'lucide-react'
+import type { RunGroup } from './useGroups'
+
+interface Props {
+  groups: RunGroup[]
+  /** The run's current group — check-marked; pass undefined for bulk moves. */
+  currentGroupId?: string | null
+  /** Always show "Remove from group" — for bulk moves, where there is no
+      single currentGroupId but the selection may contain grouped runs. */
+  showRemove?: boolean
+  onMove: (groupId: string | null) => void
+  onCreateGroup: (name: string) => Promise<RunGroup>
+  /** The button that opens the menu (wrapped with asChild). */
+  trigger: ReactNode
+}
+
+export function MoveToGroupMenu({ groups, currentGroupId, showRemove, onMove, onCreateGroup, trigger }: Props) {
+  const [creating, setCreating] = useState(false)
+  const [name, setName] = useState('')
+  const [error, setError] = useState('')
+  const [busy, setBusy] = useState(false)
+
+  const createAndMove = async () => {
+    setBusy(true)
+    setError('')
+    try {
+      const g = await onCreateGroup(name.trim())
+      setCreating(false)
+      onMove(g.group_id)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Something went wrong')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>{trigger}</DropdownMenuTrigger>
+        <DropdownMenuContent align="end" className="w-52">
+          <DropdownMenuLabel className="text-xs">Move to group</DropdownMenuLabel>
+          {groups.map(g => (
+            <DropdownMenuItem
+              key={g.group_id}
+              className="gap-2 text-xs"
+              onClick={() => onMove(g.group_id)}
+            >
+              <Folder className="h-3.5 w-3.5" />
+              <span className="flex-1 truncate">{g.name}</span>
+              {currentGroupId === g.group_id && <Check className="h-3.5 w-3.5" />}
+            </DropdownMenuItem>
+          ))}
+          {groups.length === 0 && (
+            <p className="px-2 py-1.5 text-xs text-muted-foreground">No groups yet.</p>
+          )}
+          {(currentGroupId || showRemove) && (
+            <DropdownMenuItem className="gap-2 text-xs" onClick={() => onMove(null)}>
+              <FolderMinus className="h-3.5 w-3.5" /> Remove from group
+            </DropdownMenuItem>
+          )}
+          <DropdownMenuSeparator />
+          <DropdownMenuItem
+            className="gap-2 text-xs"
+            onClick={() => { setName(''); setError(''); setBusy(false); setCreating(true) }}
+          >
+            <Plus className="h-3.5 w-3.5" /> New group…
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+
+      <Dialog open={creating} onOpenChange={o => { if (!o) { setCreating(false); setBusy(false) } }}>
+        <DialogContent className="sm:max-w-sm">
+          <DialogHeader>
+            <DialogTitle>New group</DialogTitle>
+            <DialogDescription>The selected runs move into it right away.</DialogDescription>
+          </DialogHeader>
+          <form
+            onSubmit={e => { e.preventDefault(); void createAndMove() }}
+            className="flex flex-col gap-2"
+          >
+            <Input
+              autoFocus
+              value={name}
+              maxLength={60}
+              onChange={e => setName(e.target.value)}
+              placeholder="e.g. Checkout flows"
+            />
+            {error && <p className="text-xs text-destructive">{error}</p>}
+            <DialogFooter className="mt-2">
+              <Button type="button" size="sm" variant="outline" onClick={() => setCreating(false)}>
+                Cancel
+              </Button>
+              <Button type="submit" size="sm" disabled={busy || !name.trim()}>
+                Create &amp; move
+              </Button>
+            </DialogFooter>
+          </form>
+        </DialogContent>
+      </Dialog>
+    </>
+  )
+}

--- a/src/frontend-react/src/components/history/RunGroupsContext.tsx
+++ b/src/frontend-react/src/components/history/RunGroupsContext.tsx
@@ -1,0 +1,80 @@
+/**
+ * Run groups — ONE source of truth shared by the sidebar and the Test Runs page.
+ *
+ * Both surfaces can change the active group (the sidebar's quick-access list,
+ * the page's chip row and browse dialog) and both must reflect what the other
+ * did. Two independent copies of that state would drift the moment a user
+ * picked a group in one place and a different one in the other, so the filter
+ * and the group list live here instead — mounted above both consumers, so
+ * there is exactly one value and no synchronisation to get wrong.
+ *
+ * It also owns the single /api/groups fetch: one list means a rename made on
+ * the page relabels the sidebar entry immediately, with no second request and
+ * no stale copy.
+ *
+ * Deliberately NOT in the URL. This app keeps every page mounted (see the
+ * keep-alive note in App.tsx) so page state survives navigation; a ?group=
+ * param would be dropped the moment the user visited another page, silently
+ * clearing their filter and firing a refetch on a hidden page.
+ *
+ * Referenced by: App.tsx (provider), app-sidebar.tsx, pages/HistoryPage.tsx.
+ * Depends on: ./useGroups.
+ */
+import {
+  createContext, useContext, useEffect, useMemo, useState, type ReactNode,
+} from 'react'
+import { useGroups, type RunGroup } from './useGroups'
+
+/** null = no group filter; 'ungrouped' = runs in no group; otherwise a group_id. */
+export type GroupFilter = string | null
+
+interface RunGroupsValue {
+  groups: RunGroup[]
+  ungroupedCount: number
+  error: string
+  loaded: boolean
+  refresh: () => Promise<void>
+  createGroup: (name: string) => Promise<RunGroup>
+  renameGroup: (groupId: string, name: string) => Promise<void>
+  deleteGroup: (groupId: string) => Promise<void>
+  assignRuns: (runIds: string[], groupId: string | null) => Promise<void>
+  groupFilter: GroupFilter
+  setGroupFilter: (value: GroupFilter) => void
+}
+
+const RunGroupsContext = createContext<RunGroupsValue | null>(null)
+
+export function RunGroupsProvider({ children }: { children: ReactNode }) {
+  const {
+    groups, ungroupedCount, error, loaded,
+    refresh, createGroup, renameGroup, deleteGroup, assignRuns,
+  } = useGroups()
+  const [groupFilter, setGroupFilter] = useState<GroupFilter>(null)
+
+  // A filter can outlive its group — deleted in a second tab, or by another
+  // session. Left alone it would show an empty table under a group chip that
+  // no longer resolves to a name. Wait for the list to actually load (an empty
+  // list mid-fetch is not proof of absence), then drop the dangling id.
+  useEffect(() => {
+    if (!loaded || !groupFilter || groupFilter === 'ungrouped') return
+    if (!groups.some(g => g.group_id === groupFilter)) setGroupFilter(null)
+  }, [loaded, groups, groupFilter])
+
+  const value = useMemo<RunGroupsValue>(() => ({
+    groups, ungroupedCount, error, loaded,
+    refresh, createGroup, renameGroup, deleteGroup, assignRuns,
+    groupFilter, setGroupFilter,
+  }), [
+    groups, ungroupedCount, error, loaded,
+    refresh, createGroup, renameGroup, deleteGroup, assignRuns,
+    groupFilter,
+  ])
+
+  return <RunGroupsContext.Provider value={value}>{children}</RunGroupsContext.Provider>
+}
+
+export function useRunGroups(): RunGroupsValue {
+  const ctx = useContext(RunGroupsContext)
+  if (!ctx) throw new Error('useRunGroups must be used inside <RunGroupsProvider>')
+  return ctx
+}

--- a/src/frontend-react/src/components/history/useGroups.ts
+++ b/src/frontend-react/src/components/history/useGroups.ts
@@ -1,0 +1,74 @@
+/**
+ * Personal run-groups state for the History page.
+ *
+ * Owns the /api/groups list (with live run counts) and every group mutation.
+ * Each mutation re-fetches the list so chip counts stay honest without the
+ * callers having to know what changed. Server errors (409 duplicate name,
+ * 404 foreign group/run) surface as thrown ApiError with the server's
+ * human-readable detail — dialogs display e.message directly.
+ */
+import { useCallback, useEffect, useState } from 'react'
+import { api } from '@/lib/api'
+
+export interface RunGroup {
+  group_id: string
+  name: string
+  run_count: number
+}
+
+export function useGroups() {
+  const [groups, setGroups] = useState<RunGroup[]>([])
+  const [ungroupedCount, setUngroupedCount] = useState(0)
+  const [error, setError] = useState('')
+  // First fetch settled (success OR failure). Consumers need this to tell
+  // "no groups exist" apart from "the list hasn't arrived yet" — without it
+  // they would act on an empty list during the initial render.
+  const [loaded, setLoaded] = useState(false)
+
+  const refresh = useCallback(async () => {
+    try {
+      const data = await api<{ groups: RunGroup[]; ungrouped_count: number }>('/api/groups')
+      setGroups(data.groups)
+      setUngroupedCount(data.ungrouped_count)
+      setError('')
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to load groups')
+    } finally {
+      setLoaded(true)
+    }
+  }, [])
+
+  useEffect(() => { void refresh() }, [refresh])
+
+  const createGroup = useCallback(async (name: string): Promise<RunGroup> => {
+    const g = await api<RunGroup>('/api/groups', {
+      method: 'POST', body: JSON.stringify({ name }),
+    })
+    await refresh()
+    return g
+  }, [refresh])
+
+  const renameGroup = useCallback(async (groupId: string, name: string) => {
+    await api(`/api/groups/${groupId}`, {
+      method: 'PATCH', body: JSON.stringify({ name }),
+    })
+    await refresh()
+  }, [refresh])
+
+  const deleteGroup = useCallback(async (groupId: string) => {
+    await api(`/api/groups/${groupId}`, { method: 'DELETE' })
+    await refresh()
+  }, [refresh])
+
+  const assignRuns = useCallback(async (runIds: string[], groupId: string | null) => {
+    await api('/api/groups/assignments', {
+      method: 'PUT', body: JSON.stringify({ run_ids: runIds, group_id: groupId }),
+    })
+    await refresh()
+  }, [refresh])
+
+  return {
+    groups, ungroupedCount, error, loaded,
+    refresh, createGroup, renameGroup, deleteGroup, assignRuns,
+  }
+}

--- a/src/frontend-react/src/components/ui/dialog.tsx
+++ b/src/frontend-react/src/components/ui/dialog.tsx
@@ -1,0 +1,108 @@
+import * as React from "react"
+import * as DialogPrimitive from "@radix-ui/react-dialog"
+import { X } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+const Dialog = DialogPrimitive.Root
+const DialogTrigger = DialogPrimitive.Trigger
+const DialogPortal = DialogPrimitive.Portal
+const DialogClose = DialogPrimitive.Close
+
+const DialogOverlay = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Overlay
+    ref={ref}
+    className={cn(
+      "fixed inset-0 z-50 bg-black/80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      className
+    )}
+    {...props}
+  />
+))
+DialogOverlay.displayName = DialogPrimitive.Overlay.displayName
+
+const DialogContent = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
+>(({ className, children, ...props }, ref) => (
+  <DialogPortal>
+    <DialogOverlay />
+    <DialogPrimitive.Content
+      ref={ref}
+      className={cn(
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 sm:rounded-lg",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
+        <X className="h-4 w-4" />
+        <span className="sr-only">Close</span>
+      </DialogPrimitive.Close>
+    </DialogPrimitive.Content>
+  </DialogPortal>
+))
+DialogContent.displayName = DialogPrimitive.Content.displayName
+
+const DialogHeader = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn("flex flex-col space-y-1.5 text-center sm:text-left", className)}
+    {...props}
+  />
+)
+DialogHeader.displayName = "DialogHeader"
+
+const DialogFooter = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn("flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2", className)}
+    {...props}
+  />
+)
+DialogFooter.displayName = "DialogFooter"
+
+const DialogTitle = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Title
+    ref={ref}
+    className={cn("text-lg font-semibold leading-none tracking-tight", className)}
+    {...props}
+  />
+))
+DialogTitle.displayName = DialogPrimitive.Title.displayName
+
+const DialogDescription = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Description
+    ref={ref}
+    className={cn("text-sm text-muted-foreground", className)}
+    {...props}
+  />
+))
+DialogDescription.displayName = DialogPrimitive.Description.displayName
+
+export {
+  Dialog,
+  DialogPortal,
+  DialogOverlay,
+  DialogTrigger,
+  DialogClose,
+  DialogContent,
+  DialogHeader,
+  DialogFooter,
+  DialogTitle,
+  DialogDescription,
+}

--- a/src/frontend-react/src/pages/HistoryPage.tsx
+++ b/src/frontend-react/src/pages/HistoryPage.tsx
@@ -11,7 +11,7 @@
  * already recorded the query→code evidence). "Regenerate" prefills Generate
  * instead, for when the site changed and the stored locators went stale.
  */
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
@@ -22,11 +22,15 @@ import {
   Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle,
 } from '@/components/ui/sheet'
 import {
-  Check, ChevronRight, Copy, Download, Play, RefreshCw, Repeat2, RotateCw, FileTerminal, Search,
+  Check, ChevronRight, Copy, Download, Folder, FolderInput, ListChecks,
+  Play, RefreshCw, Repeat2, RotateCw, FileTerminal, Search,
 } from 'lucide-react'
 import { api } from '@/lib/api'
 import { streamSSE } from '@/lib/sse'
 import { useFetch } from '@/lib/useFetch'
+import { GroupChipsRow } from '@/components/history/GroupChipsRow'
+import { MoveToGroupMenu } from '@/components/history/MoveToGroupMenu'
+import { useRunGroups } from '@/components/history/RunGroupsContext'
 
 type RunStatus = 'generated' | 'running' | 'passed' | 'failed' | 'error'
 
@@ -38,6 +42,8 @@ interface Run {
   // Original run this row was re-run from (root-flattened server-side).
   // Feedback on a re-run is applied to that original run's learning record.
   rerun_of?: string | null
+  group_id?: string | null
+  group_name?: string | null
   created_at: string
   updated_at: string
   has_report: boolean
@@ -109,12 +115,27 @@ export default function HistoryPage() {
   const [debouncedSearch, setDebouncedSearch] = useState('')
   const [selected, setSelected] = useState<string | null>(null)
 
+  // Select mode drives the bulk "Move N runs to…" flow (checkbox column +
+  // toolbar). The group filter itself is NOT local state — it lives in
+  // RunGroupsContext because the sidebar's quick-access list sets the same
+  // value, and two copies would drift apart.
+  const [selectMode, setSelectMode] = useState(false)
+  const [checkedIds, setCheckedIds] = useState<Set<string>>(new Set())
+  const [moveError, setMoveError] = useState('')
+
   // Re-run bookkeeping, keyed by the SOURCE run id: which reruns are in
   // flight (disables their Play buttons) and the latest live status line
   // (shown in the drawer).
   const [inFlight, setInFlight] = useState<Set<string>>(new Set())
   const [rerunNote, setRerunNote] = useState<Record<string, string>>({})
   const [copied, setCopied] = useState<string | null>(null)
+
+  // Shared with the sidebar's group quick-access: whichever surface the user
+  // picks a group from, both render the same active group.
+  const {
+    groups, ungroupedCount, createGroup, renameGroup, deleteGroup, assignRuns,
+    groupFilter, setGroupFilter,
+  } = useRunGroups()
 
   // Status AND text search are both SERVER-side: each tab fetches, counts and
   // paginates only its matching rows, so "Load more (N older)" and the "N of M"
@@ -123,16 +144,25 @@ export default function HistoryPage() {
   const queryString = useCallback((offset: number) => {
     const statusParam = filter === 'all' ? '' : `&status=${filter}`
     const qParam = debouncedSearch ? `&q=${encodeURIComponent(debouncedSearch)}` : ''
-    return `/api/history?limit=${PAGE}&offset=${offset}${statusParam}${qParam}`
-  }, [filter, debouncedSearch])
+    const groupParam = groupFilter ? `&group=${encodeURIComponent(groupFilter)}` : ''
+    return `/api/history?limit=${PAGE}&offset=${offset}${statusParam}${qParam}${groupParam}`
+  }, [filter, debouncedSearch, groupFilter])
+
+  // Every list fetch takes a ticket; only the newest one may write to state.
+  // Switching groups quickly (sidebar → chip → sidebar) fires overlapping
+  // requests, and without this the SLOWER response can land last and repaint
+  // the table with the previous group's runs.
+  const listSeq = useRef(0)
 
   // silent: refresh the rows in place without the "Loading runs…" placeholder
   // (background refetches while the table is already populated).
   const loadRuns = useCallback(async (offset: number, append: boolean, silent = false) => {
+    const seq = ++listSeq.current
     if (!append && !silent) setLoading(true)
     setError('')
     try {
       const page = await api<HistoryResponse>(queryString(offset))
+      if (seq !== listSeq.current) return  // superseded — a newer filter won
       setScope(page.scope)
       setTotal(page.total)
       setRuns(prev => {
@@ -142,9 +172,11 @@ export default function HistoryPage() {
         return [...prev, ...page.runs.filter(r => !seen.has(r.run_id))]
       })
     } catch (e) {
+      if (seq !== listSeq.current) return
       setError(e instanceof Error ? e.message : 'Failed to load history')
     } finally {
-      setLoading(false)
+      // A superseded request must not clear the spinner the newer one raised.
+      if (seq === listSeq.current) setLoading(false)
     }
   }, [queryString])
 
@@ -152,8 +184,10 @@ export default function HistoryPage() {
   // zero, merge fresh rows over the loaded set (updating statuses, surfacing
   // the new run at the top) and keep any older pages the user had loaded.
   const refreshLoaded = useCallback(async () => {
+    const seq = ++listSeq.current
     try {
       const page = await api<HistoryResponse>(queryString(0))
+      if (seq !== listSeq.current) return  // superseded — a newer filter won
       setScope(page.scope)
       setTotal(page.total)
       setRuns(prev => {
@@ -164,6 +198,54 @@ export default function HistoryPage() {
     } catch { /* a transient refresh failure leaves the existing rows in place */ }
   }, [queryString])
 
+  // Deleting the active group falls back to All groups; renames/deletes can
+  // change row tags, so refresh the loaded rows in place afterwards.
+  const handleRenameGroup = useCallback(async (groupId: string, name: string) => {
+    await renameGroup(groupId, name)
+    void refreshLoaded()
+  }, [renameGroup, refreshLoaded])
+
+  const handleDeleteGroup = useCallback(async (groupId: string) => {
+    await deleteGroup(groupId)
+    if (groupFilter === groupId) {
+      // The filter reset re-fetches via the queryString effect — an extra
+      // refreshLoaded here would race it with the stale deleted-group query.
+      setGroupFilter(null)
+    } else {
+      void refreshLoaded()
+    }
+  }, [deleteGroup, groupFilter, setGroupFilter, refreshLoaded])
+
+  // fromBulk: the toolbar's multi-select move — only that path exits select
+  // mode, and only on success. A failed move keeps the selection so the user
+  // can retry; the error shows above the table.
+  const moveRuns = useCallback(async (runIds: string[], groupId: string | null, fromBulk = false) => {
+    setMoveError('')
+    try {
+      await assignRuns(runIds, groupId)
+      if (fromBulk) {
+        setCheckedIds(new Set())
+        setSelectMode(false)
+      }
+      // Under an active group filter a moved run must LEAVE the view —
+      // refreshLoaded's keep-tail merge would leave phantom rows, so do a
+      // silent page-zero reload instead.
+      if (groupFilter) void loadRuns(0, false, true)
+      else void refreshLoaded()
+    } catch (e) {
+      setMoveError(e instanceof Error ? e.message : 'Failed to move runs')
+    }
+  }, [assignRuns, groupFilter, loadRuns, refreshLoaded])
+
+  const toggleChecked = useCallback((runId: string) => {
+    setCheckedIds(prev => {
+      const next = new Set(prev)
+      if (next.has(runId)) next.delete(runId)
+      else next.add(runId)
+      return next
+    })
+  }, [])
+
   // Debounce the search box into the server query (and reset to page zero).
   useEffect(() => {
     const t = setTimeout(() => setDebouncedSearch(search.trim()), 300)
@@ -172,6 +254,17 @@ export default function HistoryPage() {
 
   // Initial load + refetch from page zero whenever the tab or search changes.
   useEffect(() => { void loadRuns(0, false) }, [loadRuns])
+
+  // Any filter change replaces the visible rows, so a selection made against
+  // the PREVIOUS list is no longer something the user can see or reason about
+  // — keeping it would let a bulk move act on rows that scrolled out of
+  // existence when they switched groups from the sidebar. Select mode itself
+  // stays on; only the now-invisible picks are dropped, along with a move
+  // error that belonged to the old view.
+  useEffect(() => {
+    setCheckedIds(new Set())
+    setMoveError('')
+  }, [groupFilter, filter, debouncedSearch])
 
   const detailPath = selected ? `/api/history/${selected}` : null
   const { data: detail, error: detailError } = useFetch<RunDetail>(detailPath)
@@ -182,6 +275,21 @@ export default function HistoryPage() {
 
   const isAdminScope = scope === 'all'
   const visible = runs  // filtering is server-side now
+
+  // Header select-all works over the VISIBLE (loaded) rows only, so stray ids
+  // checked under a previous filter neither satisfy "all selected" nor get
+  // swept along by the header toggle.
+  const allVisibleSelected = visible.length > 0 && visible.every(r => checkedIds.has(r.run_id))
+  const someVisibleSelected = visible.some(r => checkedIds.has(r.run_id))
+
+  const toggleAllVisible = useCallback(() => {
+    setCheckedIds(prev => {
+      const next = new Set(prev)
+      if (visible.every(r => next.has(r.run_id))) visible.forEach(r => next.delete(r.run_id))
+      else visible.forEach(r => next.add(r.run_id))
+      return next
+    })
+  }, [visible])
 
   const runAgain = useCallback(async (sourceId: string) => {
     setSelected(sourceId) // feedback lives in the drawer
@@ -231,7 +339,7 @@ export default function HistoryPage() {
     <div className="mx-auto max-w-6xl">
       <div className="mb-5 flex items-end justify-between">
         <div>
-          <h1 className="text-xl font-bold tracking-tight">Test History</h1>
+          <h1 className="text-xl font-bold tracking-tight">Test Runs</h1>
           <p className="mt-0.5 text-sm text-muted-foreground">
             {isAdminScope
               ? 'All users’ test runs (admin view) — click any run to view its script and details'
@@ -244,34 +352,85 @@ export default function HistoryPage() {
       </div>
 
       <Card>
-        <CardHeader className="gap-3 space-y-0 pb-3 px-5 sm:flex-row sm:items-center sm:justify-between">
-          <div className="flex flex-wrap items-center gap-1.5">
-            {FILTERS.map(f => (
-              <Button
-                key={f}
-                size="sm"
-                variant={filter === f ? 'default' : 'outline'}
-                className="h-7 w-24 text-xs capitalize"
-                onClick={() => setFilter(f)}
-              >
-                {f === 'all' ? 'All Runs' : f}
-              </Button>
-            ))}
+        <CardHeader className="gap-3 space-y-0 pb-3 px-5">
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+            <div className="flex flex-wrap items-center gap-1.5">
+              {FILTERS.map(f => (
+                <Button
+                  key={f}
+                  size="sm"
+                  variant={filter === f ? 'default' : 'outline'}
+                  className="h-7 w-24 text-xs capitalize"
+                  onClick={() => setFilter(f)}
+                >
+                  {f === 'all' ? 'All Runs' : f}
+                </Button>
+              ))}
+            </div>
+            <div className="flex items-center gap-3">
+              <div className="relative">
+                <Search className="absolute left-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground" />
+                <Input
+                  value={search}
+                  onChange={e => setSearch(e.target.value)}
+                  placeholder={isAdminScope ? 'Search description, user or id…' : 'Search description or id…'}
+                  className="h-7 w-56 pl-8 text-xs"
+                />
+              </div>
+              <span className="whitespace-nowrap text-xs text-muted-foreground">
+                {visible.length} of {total} run{total === 1 ? '' : 's'}
+              </span>
+            </div>
           </div>
-          <div className="flex items-center gap-3">
-            <div className="relative">
-              <Search className="absolute left-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground" />
-              <Input
-                value={search}
-                onChange={e => setSearch(e.target.value)}
-                placeholder={isAdminScope ? 'Search description, user or id…' : 'Search description or id…'}
-                className="h-7 w-56 pl-8 text-xs"
+          {/* Group chips row (design option C) + the bulk-move toolbar. The
+              toolbar is pinned top-right: only the CHIPS wrap onto new lines
+              (min-w-0 flex-1), so Select/Move never drift down as groups grow. */}
+          <div className="flex items-start justify-between gap-3 border-t pt-2.5">
+            <div className="min-w-0 flex-1">
+              <GroupChipsRow
+                groups={groups}
+                ungroupedCount={ungroupedCount}
+                active={groupFilter}
+                onSelect={setGroupFilter}
+                onCreate={async name => { await createGroup(name) }}
+                onRename={handleRenameGroup}
+                onDelete={handleDeleteGroup}
               />
             </div>
-            <span className="whitespace-nowrap text-xs text-muted-foreground">
-              {visible.length} of {total} run{total === 1 ? '' : 's'}
-            </span>
+            <div className="flex shrink-0 items-center gap-1.5">
+              {selectMode ? (
+                <>
+                  <MoveToGroupMenu
+                    groups={groups}
+                    showRemove
+                    onMove={gid => { if (checkedIds.size) void moveRuns([...checkedIds], gid, true) }}
+                    onCreateGroup={createGroup}
+                    trigger={
+                      <Button size="sm" className="h-7 text-xs gap-1.5" disabled={checkedIds.size === 0}>
+                        <FolderInput className="h-3 w-3" />
+                        Move {checkedIds.size || ''} to…
+                      </Button>
+                    }
+                  />
+                  <Button
+                    size="sm" variant="outline" className="h-7 text-xs"
+                    onClick={() => { setSelectMode(false); setCheckedIds(new Set()) }}
+                  >
+                    Cancel
+                  </Button>
+                </>
+              ) : (
+                <Button
+                  size="sm" variant="outline" className="h-7 text-xs gap-1.5"
+                  title="Select multiple runs to move them into a group"
+                  onClick={() => setSelectMode(true)}
+                >
+                  <ListChecks className="h-3 w-3" /> Select
+                </Button>
+              )}
+            </div>
           </div>
+          {moveError && <p className="text-xs text-destructive">{moveError}</p>}
         </CardHeader>
 
         <CardContent className="p-0">
@@ -281,7 +440,7 @@ export default function HistoryPage() {
               collapsing the card. Column geometry is constant (table-fixed),
               so switching filters only changes the values. */}
           <div className="min-h-[420px]">
-          {loading && (
+          {loading && visible.length === 0 && (
             <p className="flex min-h-[420px] items-center justify-center text-sm text-muted-foreground">Loading runs…</p>
           )}
           {!loading && error && (
@@ -291,20 +450,41 @@ export default function HistoryPage() {
             <p className="flex min-h-[420px] items-center justify-center text-sm text-muted-foreground">
               {debouncedSearch
                 ? 'No runs match your search.'
-                : filter === 'all'
-                  ? 'No test runs yet — generate your first test from the Generate page.'
-                  : `No ${filter} runs yet.`}
+                : groupFilter === 'ungrouped'
+                  ? 'No ungrouped runs — everything is filed.'
+                  : groupFilter
+                    ? 'No runs in this group yet — move runs here with the folder button on any row.'
+                    : filter === 'all'
+                      ? 'No test runs yet — generate your first test from the Generate page.'
+                      : `No ${filter} runs yet.`}
             </p>
           )}
 
-          {!loading && !error && visible.length > 0 && (
-            <>
+          {/* Filter/search changes keep the PREVIOUS rows on screen and dim
+              them while the refetch is in flight, then swap in place — no
+              unmount, no "Loading runs…" flash between filters. The full
+              placeholder only ever shows on the very first load. */}
+          {!error && visible.length > 0 && (
+            <div className={`transition-opacity duration-200 ${loading ? 'pointer-events-none opacity-50' : 'opacity-100'}`}>
               {/* table-fixed: column widths are set here once and never
                   recomputed from row content, so switching status filters
                   keeps the exact same grid — only the values change. */}
               <table className="w-full table-fixed text-sm">
                 <thead className="sticky top-0 z-10 bg-background shadow-[inset_0_-1px_0_hsl(var(--border))]">
                   <tr className="bg-muted/40">
+                    {selectMode && (
+                      <th className="w-10 py-2.5 pl-4">
+                        <input
+                          type="checkbox"
+                          className="h-3.5 w-3.5 cursor-pointer accent-primary align-middle"
+                          title="Select all loaded runs"
+                          aria-label="Select all loaded runs"
+                          checked={allVisibleSelected}
+                          ref={el => { if (el) el.indeterminate = someVisibleSelected && !allVisibleSelected }}
+                          onChange={toggleAllVisible}
+                        />
+                      </th>
+                    )}
                     <th className="w-28 py-2.5 px-4 text-left text-xs font-semibold uppercase tracking-wider text-muted-foreground">Status</th>
                     <th className="py-2.5 px-4 text-left text-xs font-semibold uppercase tracking-wider text-muted-foreground">Description</th>
                     {isAdminScope && (
@@ -321,8 +501,18 @@ export default function HistoryPage() {
                     <tr
                       key={row.run_id}
                       className="group cursor-pointer border-b last:border-0 hover:bg-muted/30 transition-colors"
-                      onClick={() => setSelected(row.run_id)}
+                      onClick={() => (selectMode ? toggleChecked(row.run_id) : setSelected(row.run_id))}
                     >
+                      {selectMode && (
+                        <td className="py-3 pl-4" onClick={e => e.stopPropagation()}>
+                          <input
+                            type="checkbox"
+                            className="h-3.5 w-3.5 cursor-pointer accent-primary"
+                            checked={checkedIds.has(row.run_id)}
+                            onChange={() => toggleChecked(row.run_id)}
+                          />
+                        </td>
+                      )}
                       <td className="py-3 px-4">{STATUS_BADGE[row.status] ?? row.status}</td>
                       <td className="py-3 px-4">
                         <div className="flex items-center gap-2">
@@ -344,6 +534,15 @@ export default function HistoryPage() {
                           <span className="line-clamp-1 text-sm" title={row.user_query ?? undefined}>
                             {row.user_query || <span className="text-muted-foreground italic">Pasted code run</span>}
                           </span>
+                          {!groupFilter && row.group_name && (
+                            <span
+                              className="hidden shrink-0 items-center gap-1 rounded bg-muted px-1.5 py-0.5 text-[10px] text-muted-foreground lg:inline-flex"
+                              title={`In group ${row.group_name}`}
+                            >
+                              <Folder className="h-3 w-3" />
+                              {row.group_name}
+                            </span>
+                          )}
                         </div>
                       </td>
                       {isAdminScope && (
@@ -378,6 +577,21 @@ export default function HistoryPage() {
                       </td>
                       <td className="py-3 px-4">
                         <div className="flex gap-1 justify-end">
+                          <MoveToGroupMenu
+                            groups={groups}
+                            currentGroupId={row.group_id}
+                            onMove={gid => void moveRuns([row.run_id], gid)}
+                            onCreateGroup={createGroup}
+                            trigger={
+                              <Button
+                                variant="ghost" size="icon" className="h-7 w-7"
+                                title="Move to group…"
+                                onClick={e => e.stopPropagation()}
+                              >
+                                <FolderInput className="h-3.5 w-3.5" />
+                              </Button>
+                            }
+                          />
                           <Button
                             variant="ghost"
                             size="icon"
@@ -422,7 +636,7 @@ export default function HistoryPage() {
                   </Button>
                 </div>
               )}
-            </>
+            </div>
           )}
           </div>
         </CardContent>
@@ -511,6 +725,20 @@ export default function HistoryPage() {
               >
                 <RotateCw className="h-3.5 w-3.5" /> Regenerate
               </Button>
+            )}
+            {d && (
+              <MoveToGroupMenu
+                groups={groups}
+                currentGroupId={d.group_id}
+                onMove={gid => void moveRuns([d.run_id], gid)}
+                onCreateGroup={createGroup}
+                trigger={
+                  <Button size="sm" variant="outline" className="h-8 gap-1.5 text-xs">
+                    <FolderInput className="h-3.5 w-3.5" />
+                    {d.group_name ? `Group: ${d.group_name}` : 'Move to group…'}
+                  </Button>
+                }
+              />
             )}
           </div>
 

--- a/tests/test_api/test_groups.py
+++ b/tests/test_api/test_groups.py
@@ -1,0 +1,430 @@
+"""Personal run groups: registry CRUD/assignment + /api/groups + history filter.
+
+Groups are personal (user_id-scoped) folders for test_runs rows: one group per
+run, cross-user access is always 404, deleting a group ungroups (never deletes)
+its runs. Mirrors the fixture patterns of test_history_org_scope.py.
+
+Referenced by: src/backend/core/run_registry.py,
+               src/backend/api/groups_endpoints.py,
+               src/backend/api/history_endpoints.py.
+Depends on: tests/test_auth/conftest.py (auth_isolated_schema),
+            tests/test_api/conftest.py (register_active).
+"""
+
+import uuid
+
+import pytest
+
+pytestmark = [pytest.mark.integration, pytest.mark.usefixtures("auth_isolated_schema")]
+
+
+@pytest.fixture(scope="module")
+def client():
+    from fastapi.testclient import TestClient
+    from src.backend.main import app
+    return TestClient(app)
+
+
+def _register(client, email):
+    from tests.test_api.conftest import register_active
+    return register_active(client, email)
+
+
+# ---------------------------------------------------------------------------
+# Unit: RunRegistry group CRUD on an isolated schema
+# ---------------------------------------------------------------------------
+
+class TestGroupRegistryCrud:
+    """Direct RunRegistry unit tests for the run_groups table.
+
+    RED gate before implementation: AttributeError ('RunRegistry' object has
+    no attribute 'create_group')."""
+
+    @pytest.fixture(scope="class")
+    def reg(self):
+        """Isolated RunRegistry on its own schema."""
+        import psycopg
+        from src.backend.core.config import settings
+        from src.backend.core.run_registry import RunRegistry
+
+        schema = "run_groups_test"
+        admin = psycopg.connect(settings.DATABASE_URL, autocommit=True)
+        admin.execute(f"DROP SCHEMA IF EXISTS {schema} CASCADE")
+        admin.execute(f"CREATE SCHEMA {schema}")
+        sep = "&" if "?" in settings.DATABASE_URL else "?"
+        dsn = settings.DATABASE_URL + f"{sep}options=-c%20search_path%3D{schema},public"
+        r = RunRegistry(dsn=dsn)
+        yield r
+        r.close()
+        admin.execute(f"DROP SCHEMA IF EXISTS {schema} CASCADE")
+        admin.close()
+
+    @pytest.fixture(autouse=True)
+    def _clean(self, reg):
+        import psycopg
+        from src.backend.core.config import settings
+        admin = psycopg.connect(settings.DATABASE_URL, autocommit=True)
+        admin.execute("TRUNCATE run_groups_test.test_runs")
+        admin.execute("TRUNCATE run_groups_test.run_groups")
+        admin.close()
+
+    def test_create_and_list_groups(self, reg):
+        g = reg.create_group("u1", "Checkout")
+        assert g["name"] == "Checkout" and g["run_count"] == 0 and g["group_id"]
+        listed = reg.list_groups("u1")
+        assert [x["name"] for x in listed] == ["Checkout"]
+
+    def test_list_groups_is_per_user_and_name_sorted(self, reg):
+        reg.create_group("u1", "smoke")
+        reg.create_group("u1", "Checkout")
+        reg.create_group("u2", "Other")
+        assert [x["name"] for x in reg.list_groups("u1")] == ["Checkout", "smoke"]
+        assert [x["name"] for x in reg.list_groups("u2")] == ["Other"]
+
+    def test_duplicate_name_case_insensitive(self, reg):
+        from src.backend.core.run_registry import DuplicateGroupName
+        reg.create_group("u1", "Smoke")
+        with pytest.raises(DuplicateGroupName):
+            reg.create_group("u1", "smoke")
+        # Same name for a DIFFERENT user is fine.
+        assert reg.create_group("u2", "smoke")["name"] == "smoke"
+
+    def test_rename_group(self, reg):
+        gid = reg.create_group("u1", "Old")["group_id"]
+        assert reg.rename_group("u1", gid, "New") is True
+        assert [x["name"] for x in reg.list_groups("u1")] == ["New"]
+
+    def test_rename_to_existing_name_raises(self, reg):
+        from src.backend.core.run_registry import DuplicateGroupName
+        reg.create_group("u1", "Keep")
+        gid = reg.create_group("u1", "Other")["group_id"]
+        with pytest.raises(DuplicateGroupName):
+            reg.rename_group("u1", gid, "keep")
+
+    def test_rename_foreign_or_unknown_is_false(self, reg):
+        gid = reg.create_group("u1", "Mine")["group_id"]
+        assert reg.rename_group("u2", gid, "Stolen") is False
+        assert reg.rename_group("u1", str(uuid.uuid4()), "Ghost") is False
+        assert [x["name"] for x in reg.list_groups("u1")] == ["Mine"]
+
+    def test_delete_group(self, reg):
+        gid = reg.create_group("u1", "Gone")["group_id"]
+        assert reg.delete_group("u1", gid) is True
+        assert reg.list_groups("u1") == []
+
+    def test_delete_foreign_or_unknown_is_false(self, reg):
+        gid = reg.create_group("u1", "Mine")["group_id"]
+        assert reg.delete_group("u2", gid) is False
+        assert reg.delete_group("u1", str(uuid.uuid4())) is False
+        assert [x["name"] for x in reg.list_groups("u1")] == ["Mine"]
+
+    def test_count_ungrouped(self, reg):
+        r1, r2, r3 = str(uuid.uuid4()), str(uuid.uuid4()), str(uuid.uuid4())
+        for rid, uid in ((r1, "u1"), (r2, "u1"), (r3, "u2")):
+            reg.record_start(rid, {"user_id": uid, "email": f"{uid}@e.com"}, "q", "passed")
+        assert reg.count_ungrouped("u1") == 2
+        assert reg.count_ungrouped("u2") == 1
+
+
+class TestGroupAssignmentAndFilter:
+    """assign_runs atomicity + the group filter / group_name join in
+    list_runs and get_run. Reuses TestGroupRegistryCrud's isolated-schema
+    pattern via the same fixtures."""
+
+    # Same isolated registry as TestGroupRegistryCrud (class-scoped copy —
+    # tests may run per-class, so each class owns its schema lifecycle).
+    @pytest.fixture(scope="class")
+    def reg(self):
+        import psycopg
+        from src.backend.core.config import settings
+        from src.backend.core.run_registry import RunRegistry
+
+        schema = "run_groups_assign_test"
+        admin = psycopg.connect(settings.DATABASE_URL, autocommit=True)
+        admin.execute(f"DROP SCHEMA IF EXISTS {schema} CASCADE")
+        admin.execute(f"CREATE SCHEMA {schema}")
+        sep = "&" if "?" in settings.DATABASE_URL else "?"
+        dsn = settings.DATABASE_URL + f"{sep}options=-c%20search_path%3D{schema},public"
+        r = RunRegistry(dsn=dsn)
+        yield r
+        r.close()
+        admin.execute(f"DROP SCHEMA IF EXISTS {schema} CASCADE")
+        admin.close()
+
+    @pytest.fixture(autouse=True)
+    def _clean(self, reg):
+        import psycopg
+        from src.backend.core.config import settings
+        admin = psycopg.connect(settings.DATABASE_URL, autocommit=True)
+        admin.execute("TRUNCATE run_groups_assign_test.test_runs")
+        admin.execute("TRUNCATE run_groups_assign_test.run_groups")
+        admin.close()
+
+    @staticmethod
+    def _seed(reg, run_id, user_id, query="q", status="passed"):
+        reg.record_start(
+            run_id, {"user_id": user_id, "email": f"{user_id}@e.com"}, query, status
+        )
+
+    def test_assign_sets_group_and_filter_returns_rows(self, reg):
+        r1, r2 = str(uuid.uuid4()), str(uuid.uuid4())
+        self._seed(reg, r1, "u1")
+        self._seed(reg, r2, "u1")
+        gid = reg.create_group("u1", "Checkout")["group_id"]
+
+        assert reg.assign_runs("u1", [r1, r2], gid) is True
+
+        rows, total = reg.list_runs(user_id="u1", group=gid)
+        assert total == 2
+        assert all(r["group_id"] == gid and r["group_name"] == "Checkout" for r in rows)
+        assert reg.list_groups("u1")[0]["run_count"] == 2
+        assert reg.count_ungrouped("u1") == 0
+
+    def test_unassign_with_none_and_ungrouped_filter(self, reg):
+        r1 = str(uuid.uuid4())
+        self._seed(reg, r1, "u1")
+        gid = reg.create_group("u1", "G")["group_id"]
+        reg.assign_runs("u1", [r1], gid)
+
+        assert reg.assign_runs("u1", [r1], None) is True
+        rows, total = reg.list_runs(user_id="u1", group="ungrouped")
+        assert total == 1 and rows[0]["run_id"] == r1 and rows[0]["group_id"] is None
+
+    def test_assign_foreign_run_rejected_atomically(self, reg):
+        mine, theirs = str(uuid.uuid4()), str(uuid.uuid4())
+        self._seed(reg, mine, "u1")
+        self._seed(reg, theirs, "u2")
+        gid = reg.create_group("u1", "G")["group_id"]
+
+        assert reg.assign_runs("u1", [mine, theirs], gid) is False
+        # Atomic: my run was NOT grouped either.
+        _, total = reg.list_runs(user_id="u1", group=gid)
+        assert total == 0
+
+    def test_assign_into_foreign_group_rejected(self, reg):
+        mine = str(uuid.uuid4())
+        self._seed(reg, mine, "u1")
+        foreign_gid = reg.create_group("u2", "Theirs")["group_id"]
+
+        assert reg.assign_runs("u1", [mine], foreign_gid) is False
+        _, total = reg.list_runs(user_id="u1", group="ungrouped")
+        assert total == 1
+
+    def test_group_filter_combines_with_status(self, reg):
+        r1, r2 = str(uuid.uuid4()), str(uuid.uuid4())
+        self._seed(reg, r1, "u1", status="passed")
+        self._seed(reg, r2, "u1", status="failed")
+        gid = reg.create_group("u1", "G")["group_id"]
+        reg.assign_runs("u1", [r1, r2], gid)
+
+        rows, total = reg.list_runs(user_id="u1", group=gid, status="failed")
+        assert total == 1 and rows[0]["run_id"] == r2
+
+    def test_delete_group_ungroups_members(self, reg):
+        r1 = str(uuid.uuid4())
+        self._seed(reg, r1, "u1")
+        gid = reg.create_group("u1", "Doomed")["group_id"]
+        reg.assign_runs("u1", [r1], gid)
+
+        assert reg.delete_group("u1", gid) is True
+        run = reg.get_run(r1)
+        assert run is not None and run["group_id"] is None  # run survived, ungrouped
+
+    def test_get_run_carries_group_name(self, reg):
+        r1 = str(uuid.uuid4())
+        self._seed(reg, r1, "u1")
+        gid = reg.create_group("u1", "Named")["group_id"]
+        reg.assign_runs("u1", [r1], gid)
+
+        run = reg.get_run(r1)
+        assert run["group_id"] == gid and run["group_name"] == "Named"
+
+
+# ---------------------------------------------------------------------------
+# Integration: /api/groups endpoints — real JWT tokens, personal scoping
+# ---------------------------------------------------------------------------
+
+def _auth(tok):
+    return {"Authorization": f"Bearer {tok}"}
+
+
+def _seed_run_for(client, tok, query="seed query", status="passed") -> str:
+    """Insert a test_runs row owned by the token's user; returns the run id."""
+    from src.backend.auth.jwt_utils import decode_token
+    from src.backend.core.run_registry import get_run_registry
+
+    claims = decode_token(tok)
+    rid = str(uuid.uuid4())
+    get_run_registry().record_start(
+        rid,
+        {"user_id": claims["user_id"], "email": claims["email"],
+         "org_id": claims["org_id"]},
+        query,
+        status,
+    )
+    return rid
+
+
+def test_groups_crud_roundtrip(client):
+    tok = _register(client, f"gc-{uuid.uuid4().hex[:8]}@e.com")
+
+    r = client.post("/api/groups", json={"name": "  Checkout  "}, headers=_auth(tok))
+    assert r.status_code == 201, r.text
+    gid = r.json()["group_id"]
+    assert r.json()["name"] == "Checkout"  # trimmed
+
+    listed = client.get("/api/groups", headers=_auth(tok)).json()["groups"]
+    assert [g["group_id"] for g in listed] == [gid]
+
+    r = client.post("/api/groups", json={"name": "checkout"}, headers=_auth(tok))
+    assert r.status_code == 409
+    assert r.json()["detail"] == 'You already have a group named "checkout"'
+
+    r = client.patch(f"/api/groups/{gid}", json={"name": "Payments"}, headers=_auth(tok))
+    assert r.status_code == 200 and r.json()["name"] == "Payments"
+
+    assert client.delete(f"/api/groups/{gid}", headers=_auth(tok)).status_code == 204
+    assert client.get("/api/groups", headers=_auth(tok)).json()["groups"] == []
+
+
+def test_rename_onto_existing_name_is_409(client):
+    """Rename has its OWN duplicate guard — create's 409 does not cover it.
+    The collision is case-insensitive and must leave both names untouched."""
+    tok = _register(client, f"gn-{uuid.uuid4().hex[:8]}@e.com")
+    client.post("/api/groups", json={"name": "Alpha"}, headers=_auth(tok))
+    gid = client.post("/api/groups", json={"name": "Beta"},
+                      headers=_auth(tok)).json()["group_id"]
+
+    r = client.patch(f"/api/groups/{gid}", json={"name": "alpha"}, headers=_auth(tok))
+    assert r.status_code == 409, r.text
+    assert r.json()["detail"] == 'You already have a group named "alpha"'
+    listed = client.get("/api/groups", headers=_auth(tok)).json()["groups"]
+    assert sorted(g["name"] for g in listed) == ["Alpha", "Beta"]
+
+
+def test_group_name_validation(client):
+    tok = _register(client, f"gv-{uuid.uuid4().hex[:8]}@e.com")
+    assert client.post("/api/groups", json={"name": "   "}, headers=_auth(tok)).status_code == 400
+    assert client.post("/api/groups", json={"name": "x" * 61}, headers=_auth(tok)).status_code == 400
+
+
+def test_groups_are_invisible_and_immutable_across_users(client):
+    tok_a = _register(client, f"ga-{uuid.uuid4().hex[:8]}@e.com")
+    tok_b = _register(client, f"gb-{uuid.uuid4().hex[:8]}@e.com")
+
+    gid = client.post("/api/groups", json={"name": "Private"},
+                      headers=_auth(tok_a)).json()["group_id"]
+
+    assert all(g["group_id"] != gid
+               for g in client.get("/api/groups", headers=_auth(tok_b)).json()["groups"])
+    assert client.patch(f"/api/groups/{gid}", json={"name": "Hax"},
+                        headers=_auth(tok_b)).status_code == 404
+    assert client.delete(f"/api/groups/{gid}", headers=_auth(tok_b)).status_code == 404
+    # A's group untouched.
+    mine = client.get("/api/groups", headers=_auth(tok_a)).json()["groups"]
+    assert [g["name"] for g in mine] == ["Private"]
+
+
+def test_assignments_endpoint(client):
+    tok = _register(client, f"as-{uuid.uuid4().hex[:8]}@e.com")
+    rid = _seed_run_for(client, tok)
+    gid = client.post("/api/groups", json={"name": "Filed"},
+                      headers=_auth(tok)).json()["group_id"]
+
+    r = client.put("/api/groups/assignments",
+                   json={"run_ids": [rid], "group_id": gid}, headers=_auth(tok))
+    assert r.status_code == 200 and r.json()["assigned"] == 1
+
+    body = client.get("/api/groups", headers=_auth(tok)).json()
+    assert body["groups"][0]["run_count"] == 1
+    assert body["ungrouped_count"] == 0  # the user's only run is filed
+
+    # Unassign with group_id null.
+    r = client.put("/api/groups/assignments",
+                   json={"run_ids": [rid], "group_id": None}, headers=_auth(tok))
+    assert r.status_code == 200
+    body = client.get("/api/groups", headers=_auth(tok)).json()
+    assert body["groups"][0]["run_count"] == 0 and body["ungrouped_count"] == 1
+
+
+def test_assignments_reject_foreign_run_atomically(client):
+    tok_a = _register(client, f"fa-{uuid.uuid4().hex[:8]}@e.com")
+    tok_b = _register(client, f"fb-{uuid.uuid4().hex[:8]}@e.com")
+    mine = _seed_run_for(client, tok_a)
+    theirs = _seed_run_for(client, tok_b)
+    gid = client.post("/api/groups", json={"name": "Mine"},
+                      headers=_auth(tok_a)).json()["group_id"]
+
+    r = client.put("/api/groups/assignments",
+                   json={"run_ids": [mine, theirs], "group_id": gid},
+                   headers=_auth(tok_a))
+    assert r.status_code == 404
+    # Atomic: A's own run was not grouped either.
+    assert client.get("/api/groups", headers=_auth(tok_a)).json()["groups"][0]["run_count"] == 0
+
+
+def test_assignments_validation(client):
+    tok = _register(client, f"av-{uuid.uuid4().hex[:8]}@e.com")
+    assert client.put("/api/groups/assignments",
+                      json={"run_ids": [], "group_id": None},
+                      headers=_auth(tok)).status_code == 400
+    assert client.put("/api/groups/assignments",
+                      json={"run_ids": ["not-a-uuid"], "group_id": None},
+                      headers=_auth(tok)).status_code == 400
+
+
+def test_anonymous_caller(client):
+    """AUTH_ENFORCED is off in this suite (autouse fixture), so token-less
+    require_user yields None: reads are empty, mutations are 401."""
+    assert client.get("/api/groups").json() == {"groups": [], "ungrouped_count": 0}
+    r = client.post("/api/groups", json={"name": "X"})
+    assert r.status_code == 401
+    assert r.json()["detail"] == "Sign-in required for groups"
+    assert client.put("/api/groups/assignments",
+                      json={"run_ids": [str(uuid.uuid4())], "group_id": None}).status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# Integration: /api/history group filtering + group fields on rows
+# ---------------------------------------------------------------------------
+
+def test_history_group_filter_and_fields(client):
+    tok = _register(client, f"hf-{uuid.uuid4().hex[:8]}@e.com")
+    grouped = _seed_run_for(client, tok, query="in the group")
+    loose = _seed_run_for(client, tok, query="left out")
+    gid = client.post("/api/groups", json={"name": "Filter me"},
+                      headers=_auth(tok)).json()["group_id"]
+    client.put("/api/groups/assignments",
+               json={"run_ids": [grouped], "group_id": gid}, headers=_auth(tok))
+
+    page = client.get(f"/api/history?group={gid}", headers=_auth(tok)).json()
+    assert page["total"] == 1
+    assert page["runs"][0]["run_id"] == grouped
+    assert page["runs"][0]["group_name"] == "Filter me"
+
+    page = client.get("/api/history?group=ungrouped", headers=_auth(tok)).json()
+    ids = [r["run_id"] for r in page["runs"]]
+    assert loose in ids and grouped not in ids
+
+    detail = client.get(f"/api/history/{grouped}", headers=_auth(tok)).json()
+    assert detail["group_id"] == gid and detail["group_name"] == "Filter me"
+
+
+def test_history_group_filter_combines_with_status(client):
+    tok = _register(client, f"hc-{uuid.uuid4().hex[:8]}@e.com")
+    passed = _seed_run_for(client, tok, status="passed")
+    failed = _seed_run_for(client, tok, status="failed")
+    gid = client.post("/api/groups", json={"name": "Mixed"},
+                      headers=_auth(tok)).json()["group_id"]
+    client.put("/api/groups/assignments",
+               json={"run_ids": [passed, failed], "group_id": gid}, headers=_auth(tok))
+
+    page = client.get(f"/api/history?group={gid}&status=failed",
+                      headers=_auth(tok)).json()
+    assert page["total"] == 1 and page["runs"][0]["run_id"] == failed
+
+
+def test_history_invalid_group_param_is_400(client):
+    tok = _register(client, f"hb-{uuid.uuid4().hex[:8]}@e.com")
+    r = client.get("/api/history?group=not-a-uuid", headers=_auth(tok))
+    assert r.status_code == 400


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added personal groups for organizing test runs.
  * Create, rename, delete, and assign or unassign runs from groups.
  * Added group filtering, including an Ungrouped view.
  * Added group navigation, run counts, bulk moves, and per-run assignment controls.
  * Renamed History to Test Runs with improved loading and empty states.
* **Bug Fixes**
  * Improved protection against stale results during filtering and refreshes.
  * Deleting a group now preserves its runs as ungrouped.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->