### PR TITLE
Say which build is running, and make the delivery path match the code

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,17 +9,30 @@
 
 # --- Docker Image Tags ---
 # One repository (monkscode/nlrf) with descriptive tags. Pick ONE source and
-# keep EVERY service on it. Mixing a `-latest` (main) backend image with this
-# tree's config breaks boot (OBSERVABILITY_BACKEND=postgres is rejected by the
-# old validator) and login (/auth/* routes don't exist on main).
-#   *-local    built locally from this checkout (see build order below)
-#   *-develop  published from the develop branch (has Postgres + React + auth)
-#   *-latest   published from main — PRE-migration, NOT compatible with this
-#              code. Do not use with the current tree.
-FASTAPI_IMAGE_TAG=monkscode/nlrf:fastapi-local
-BROWSER_SERVICE_IMAGE_TAG=monkscode/nlrf:browser-service-local
-TEST_RUNNER_IMAGE_TAG=monkscode/nlrf:test-runner-local
-FRONTEND_IMAGE_TAG=monkscode/nlrf:frontend-local
+# keep EVERY service on it — a mixed set is the usual cause of odd boot and
+# login errors after an update.
+#   *-develop  published from the develop branch. THE DEFAULT, and what the
+#              README's Quick Start assumes. Rebuilt on every push to develop.
+#   *-latest   published from main. Same architecture (auth, React, Postgres
+#              are all on main), but main lags develop, so this is an OLDER
+#              build missing the newest fixes. Use it only deliberately.
+#   *-local    built locally from this checkout (see build order below). NOT
+#              published — `docker compose pull` fails on these tags.
+#
+# These four are what `docker compose pull` fetches. The test-runner is not a
+# Compose service; the app pulls it on demand and at startup, so its tag is read
+# here and passed through to the runner-exec service (see docker-compose.yml).
+FASTAPI_IMAGE_TAG=monkscode/nlrf:fastapi-develop
+BROWSER_SERVICE_IMAGE_TAG=monkscode/nlrf:browser-service-develop
+TEST_RUNNER_IMAGE_TAG=monkscode/nlrf:test-runner-develop
+FRONTEND_IMAGE_TAG=monkscode/nlrf:frontend-develop
+#
+# Building from this checkout instead? Swap all four to the -local tags and
+# follow the build order below.
+#FASTAPI_IMAGE_TAG=monkscode/nlrf:fastapi-local
+#BROWSER_SERVICE_IMAGE_TAG=monkscode/nlrf:browser-service-local
+#TEST_RUNNER_IMAGE_TAG=monkscode/nlrf:test-runner-local
+#FRONTEND_IMAGE_TAG=monkscode/nlrf:frontend-local
 # Notes:
 #   - The runner-exec service reuses FASTAPI_IMAGE_TAG (same image, different
 #     command) — it has no tag of its own.

--- a/.github/scripts/browser_service_code_diff.py
+++ b/.github/scripts/browser_service_code_diff.py
@@ -1,0 +1,98 @@
+"""Did the browser-service code actually change between two PyPI releases?
+
+Merging any PR into the browser-service repo auto-publishes a patch bump, so a
+README rewrite produces a release with no code in it: 1.0.36's wheel is
+byte-identical to 1.0.35's across all 36 modules — only the dist-info version
+strings differ. A watchdog that compares version strings opens a PR for that,
+and a stream of no-op PRs is how a maintainer learns to merge them unread. The
+one that finally moves browser-use then goes through unexamined.
+
+So compare the code. Usage:
+
+    python browser_service_code_diff.py <pinned> <latest>
+
+Writes `code_changed` and a `summary` to $GITHUB_OUTPUT when it is set, and
+prints the same to stdout. Fails OPEN — if either wheel cannot be read, it
+reports a change, because refusing to notice is the failure being fixed.
+"""
+
+import hashlib
+import io
+import json
+import os
+import sys
+import urllib.request
+import zipfile
+
+PACKAGE = "browser-service"
+PREFIX = "browser_service/"
+TIMEOUT = 60
+
+
+def _wheel_members(version: str) -> dict[str, str] | None:
+    """sha256 of every packaged module in `version`, or None if unreadable."""
+    url = f"https://pypi.org/pypi/{PACKAGE}/{version}/json"
+    try:
+        meta = json.loads(urllib.request.urlopen(url, timeout=TIMEOUT).read())
+        wheel = next(f for f in meta["urls"] if f["filename"].endswith(".whl"))
+        blob = urllib.request.urlopen(wheel["url"], timeout=TIMEOUT).read()
+    except Exception as e:  # noqa: BLE001 — any failure means "cannot compare"
+        print(f"could not read {PACKAGE} {version}: {e}", file=sys.stderr)
+        return None
+
+    zf = zipfile.ZipFile(io.BytesIO(blob))
+    # dist-info is excluded on purpose: it carries the version string itself, so
+    # including it would make every release look like a change, which is the
+    # whole bug.
+    return {
+        name[len(PREFIX):]: hashlib.sha256(zf.read(name)).hexdigest()
+        for name in zf.namelist()
+        if name.startswith(PREFIX) and not name.endswith("/")
+    }
+
+
+def compare(old: dict[str, str], new: dict[str, str]) -> list[str]:
+    """Human-readable lines describing what moved. Empty means nothing did."""
+    lines = []
+    for name in sorted(set(new) - set(old)):
+        lines.append(f"added:    {name}")
+    for name in sorted(set(old) - set(new)):
+        lines.append(f"removed:  {name}")
+    for name in sorted(set(old) & set(new)):
+        if old[name] != new[name]:
+            lines.append(f"changed:  {name}")
+    return lines
+
+
+def main() -> int:
+    pinned, latest = sys.argv[1], sys.argv[2]
+    old, new = _wheel_members(pinned), _wheel_members(latest)
+
+    if old is None or new is None:
+        changed, summary = True, (
+            "Could not read one of the wheels, so the code was not compared. "
+            "Treating this as a change — review the release notes by hand.")
+    else:
+        diff = compare(old, new)
+        changed = bool(diff)
+        if changed:
+            summary = (f"{len(diff)} of {len(new)} packaged modules moved between "
+                       f"{pinned} and {latest}:\n\n```\n" + "\n".join(diff) + "\n```")
+        else:
+            summary = (f"**No code change.** All {len(new)} packaged modules are "
+                       f"byte-identical between {pinned} and {latest}; only the "
+                       "dist-info version differs. The auto-publish on the "
+                       "browser-service side bumps a patch for every merge, "
+                       "including docs-only ones.")
+
+    print(summary)
+    out = os.getenv("GITHUB_OUTPUT")
+    if out:
+        with open(out, "a", encoding="utf-8") as fh:
+            fh.write(f"code_changed={'true' if changed else 'false'}\n")
+            fh.write("summary<<CODE_DIFF_EOF\n" + summary + "\nCODE_DIFF_EOF\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/browser_service_code_diff.py
+++ b/.github/scripts/browser_service_code_diff.py
@@ -36,19 +36,23 @@ def _wheel_members(version: str) -> dict[str, str] | None:
         meta = json.loads(urllib.request.urlopen(url, timeout=TIMEOUT).read())
         wheel = next(f for f in meta["urls"] if f["filename"].endswith(".whl"))
         blob = urllib.request.urlopen(wheel["url"], timeout=TIMEOUT).read()
+        # Parsing belongs INSIDE the try. A truncated body raises BadZipFile,
+        # which outside it propagated and killed the script — so the step failed
+        # and no bump PR was opened, the exact opposite of the fail-open this
+        # function documents. Verified: half a real wheel raises "File is not a
+        # zip file".
+        with zipfile.ZipFile(io.BytesIO(blob)) as zf:
+            # dist-info is excluded on purpose: it carries the version string
+            # itself, so including it would make every release look like a
+            # change, which is the whole bug.
+            return {
+                name[len(PREFIX):]: hashlib.sha256(zf.read(name)).hexdigest()
+                for name in zf.namelist()
+                if name.startswith(PREFIX) and not name.endswith("/")
+            }
     except Exception as e:  # noqa: BLE001 — any failure means "cannot compare"
         print(f"could not read {PACKAGE} {version}: {e}", file=sys.stderr)
         return None
-
-    zf = zipfile.ZipFile(io.BytesIO(blob))
-    # dist-info is excluded on purpose: it carries the version string itself, so
-    # including it would make every release look like a change, which is the
-    # whole bug.
-    return {
-        name[len(PREFIX):]: hashlib.sha256(zf.read(name)).hexdigest()
-        for name in zf.namelist()
-        if name.startswith(PREFIX) and not name.endswith("/")
-    }
 
 
 def compare(old: dict[str, str], new: dict[str, str]) -> list[str]:

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -42,10 +42,86 @@ env:
   REGISTRY: docker.io
   IMAGE_NAME: monkscode/nlrf
 
+# One build per ref at a time. The branch tags (`-develop`, `-latest`) are what
+# users pull, and two runs in flight can finish out of order, leaving the tag
+# pointing at the older commit with nothing to show that happened. Superseded
+# runs are cancelled: only the tip is worth publishing.
+concurrency:
+  group: build-images-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
+  # Nothing may be built, and above all nothing may be PUSHED, until the suite
+  # that judges this commit has passed. build-images.yml and sonarqube.yml are
+  # both fired by the same push and were completely independent, so a red suite
+  # still overwrote `-develop` — the tag the README tells every user to pull —
+  # with no signal that anything was wrong.
+  #
+  # This deliberately re-runs a suite sonarqube.yml also runs. The alternatives
+  # were worse: `workflow_run` gating only fires from the DEFAULT branch, which
+  # is the same trap that leaves check-browser-service-release.yml inert on
+  # develop, and sharing one run needs the coverage artifact plumbed between
+  # workflows. A few duplicated CI minutes buy a gate that is obvious from this
+  # file alone. Kept honest by tests/test_build_manifests.py.
+  test:
+    name: Test suite (publish gate)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    # Same stack the suite needs locally: optimization, api, trace and auth
+    # tests run against live Postgres on isolated schemas. Credentials match the
+    # DATABASE_URL default in src/backend/core/config.py.
+    services:
+      postgres:
+        image: pgvector/pgvector:pg16
+        env:
+          POSTGRES_USER: nlrf
+          POSTGRES_PASSWORD: nlrf
+          POSTGRES_DB: nlrf
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U nlrf -d nlrf"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip uv
+          uv pip install --system pytest
+          uv pip compile pyproject.toml             --python-platform linux             --python-version 3.12             --output-file /tmp/requirements-ci.txt --quiet
+          uv pip install --system -r /tmp/requirements-ci.txt
+
+      # all-MiniLM-L6-v2 is a ~80 MB ONNX download on first use.
+      - name: Cache fastembed model
+        uses: actions/cache@v4
+        with:
+          path: data/fastembed_cache
+          key: fastembed-all-MiniLM-L6-v2
+
+      - name: Run the suite
+        run: pytest tests/ --ignore=tests/test_integration -q
+        env:
+          PYTHONPATH: ${{ github.workspace }}/src/backend
+          # App startup refuses the placeholder secret; tests that boot the app
+          # need a real-looking one.
+          JWT_SECRET_KEY: ci-only-jwt-secret-not-used-outside-this-workflow
+
   build-base-browser:
     name: Build Base Browser Image
     runs-on: ubuntu-latest
+    needs: [test]
     outputs:
       base_image_tag: ${{ steps.base_tag.outputs.base_image_tag }}
       image_size: ${{ steps.image_size.outputs.image_size }}
@@ -121,6 +197,7 @@ jobs:
   build-fastapi:
     name: Build FastAPI Image
     runs-on: ubuntu-latest
+    needs: [test]
     outputs:
       image_size: ${{ steps.image_size.outputs.image_size }}
     permissions:
@@ -160,6 +237,11 @@ jobs:
           context: .
           file: ./Dockerfile.fastapi
           push: ${{ github.event_name != 'pull_request' }}
+          # Stamped into the image as an OCI revision label (and, for the
+          # backend, an env var /health reports). Branch tags move, so this is
+          # the only thing that identifies the code inside a pulled image.
+          build-args: |
+            GIT_SHA=${{ github.sha }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:fastapi-buildcache
@@ -181,6 +263,7 @@ jobs:
   build-frontend:
     name: Build Frontend Image
     runs-on: ubuntu-latest
+    needs: [test]
     outputs:
       image_size: ${{ steps.image_size.outputs.image_size }}
     permissions:
@@ -220,6 +303,11 @@ jobs:
           context: .
           file: ./Dockerfile.frontend
           push: ${{ github.event_name != 'pull_request' }}
+          # Stamped into the image as an OCI revision label (and, for the
+          # backend, an env var /health reports). Branch tags move, so this is
+          # the only thing that identifies the code inside a pulled image.
+          build-args: |
+            GIT_SHA=${{ github.sha }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:frontend-buildcache
@@ -241,7 +329,7 @@ jobs:
   build-browser-service:
     name: Build Browser Service Image
     runs-on: ubuntu-latest
-    needs: [build-base-browser]
+    needs: [test, build-base-browser]
     outputs:
       image_size: ${{ steps.image_size.outputs.image_size }}
     permissions:
@@ -281,8 +369,12 @@ jobs:
           context: .
           file: ./Dockerfile.browser-service
           push: ${{ github.event_name != 'pull_request' }}
+          # Stamped into the image as an OCI revision label (and, for the
+          # backend, an env var /health reports). Branch tags move, so this is
+          # the only thing that identifies the code inside a pulled image.
           build-args: |
             BASE_IMAGE=${{ needs.build-base-browser.outputs.base_image_tag }}
+            GIT_SHA=${{ github.sha }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:browser-service-buildcache
@@ -304,7 +396,7 @@ jobs:
   build-test-runner:
     name: Build Test Runner Image
     runs-on: ubuntu-latest
-    needs: [build-base-browser]
+    needs: [test, build-base-browser]
     outputs:
       image_size: ${{ steps.image_size.outputs.image_size }}
     permissions:
@@ -344,8 +436,12 @@ jobs:
           context: .
           file: ./Dockerfile.test-runner
           push: ${{ github.event_name != 'pull_request' }}
+          # Stamped into the image as an OCI revision label (and, for the
+          # backend, an env var /health reports). Branch tags move, so this is
+          # the only thing that identifies the code inside a pulled image.
           build-args: |
             BASE_IMAGE=${{ needs.build-base-browser.outputs.base_image_tag }}
+            GIT_SHA=${{ github.sha }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:test-runner-buildcache
@@ -367,7 +463,7 @@ jobs:
   summary:
     name: Build Summary
     runs-on: ubuntu-latest
-    needs: [build-base-browser, build-fastapi, build-frontend, build-browser-service, build-test-runner]
+    needs: [test, build-base-browser, build-fastapi, build-frontend, build-browser-service, build-test-runner]
     if: always()
 
     steps:
@@ -386,7 +482,10 @@ jobs:
           echo "### Commit: \`${{ github.sha }}\`" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
           
-          if [ "${{ needs.build-base-browser.result }}" = "success" ] && [ "${{ needs.build-fastapi.result }}" = "success" ] && [ "${{ needs.build-browser-service.result }}" = "success" ] && [ "${{ needs.build-test-runner.result }}" = "success" ]; then
+          if [ "${{ needs.test.result }}" != "success" ]; then
+            echo "🚫 **Status**: publish gate failed — the test suite did not pass, so no image was built or pushed." >> "$GITHUB_STEP_SUMMARY"
+            echo "- Test suite: ${{ needs.test.result }}" >> "$GITHUB_STEP_SUMMARY"
+          elif [ "${{ needs.build-base-browser.result }}" = "success" ] && [ "${{ needs.build-fastapi.result }}" = "success" ] && [ "${{ needs.build-browser-service.result }}" = "success" ] && [ "${{ needs.build-test-runner.result }}" = "success" ]; then
             echo "✅ **Status**: All images built successfully" >> "$GITHUB_STEP_SUMMARY"
           else
             echo "❌ **Status**: Some builds failed" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -44,11 +44,17 @@ env:
 
 # One build per ref at a time. The branch tags (`-develop`, `-latest`) are what
 # users pull, and two runs in flight can finish out of order, leaving the tag
-# pointing at the older commit with nothing to show that happened. Superseded
-# runs are cancelled: only the tip is worth publishing.
+# pointing at the older commit with nothing to show that happened.
+#
+# A push run is NEVER cancelled. It pushes five images one job at a time, so
+# killing it mid-run can leave `-develop` on a different commit per service —
+# the mixed set .env.example calls the usual cause of odd boot and login errors.
+# Serialising instead means the older run finishes consistently and the newer
+# one then overwrites it, also consistently. A pull_request run pushes nothing,
+# so cancelling a superseded one costs nothing.
 concurrency:
   group: build-images-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   # Nothing may be built, and above all nothing may be PUSHED, until the suite

--- a/.github/workflows/check-browser-service-release.yml
+++ b/.github/workflows/check-browser-service-release.yml
@@ -113,7 +113,6 @@ jobs:
         if: steps.decide.outputs.act == 'true'
         env:
           BRANCH: ${{ steps.decide.outputs.branch }}
-          CODE_SUMMARY: ${{ steps.code.outputs.summary }}
         run: |
           set -euo pipefail
           if git ls-remote --exit-code --heads origin "$BRANCH" >/dev/null 2>&1; then
@@ -167,6 +166,7 @@ jobs:
           PINNED: ${{ steps.pin.outputs.pinned }}
           LATEST: ${{ steps.pypi.outputs.latest }}
           BRANCH: ${{ steps.decide.outputs.branch }}
+          CODE_SUMMARY: ${{ steps.code.outputs.summary }}
         run: |
           set -euo pipefail
           git config user.name  "github-actions[bot]"

--- a/.github/workflows/check-browser-service-release.yml
+++ b/.github/workflows/check-browser-service-release.yml
@@ -201,6 +201,10 @@ jobs:
           git -c "http.https://github.com/.extraheader=AUTHORIZATION: basic ${AUTH_B64}" \
             push origin "$BRANCH"
 
+          # shellcheck disable=SC2016  # the printf FORMATS below are literal on
+          # purpose: the backticks and $ in them are markdown for the PR body,
+          # not shell. Scoped here rather than ignored globally so SC2016 still
+          # fires on a genuine "expected this to expand" mistake elsewhere.
           # Body written to a file rather than an inline heredoc: an indented
           # heredoc inside a YAML block scalar keeps its leading spaces and its
           # terminator stops matching, which silently mangles the PR.

--- a/.github/workflows/check-browser-service-release.yml
+++ b/.github/workflows/check-browser-service-release.yml
@@ -11,7 +11,13 @@ name: Check browser-service releases
 # `pytest -m "not integration"` only, so the chromium lane that exercises the
 # locator paths against a real DOM never gates a release. A human should look at
 # what changed before it reaches users.
-
+#
+# And it compares CODE, not version strings. The auto-publish bumps a patch for
+# every merge on that side, including docs-only ones: 1.0.36's wheel is
+# byte-identical to 1.0.35's across all 36 modules. Opening a PR for that trains
+# whoever reviews these to merge them unread, and the one that finally moves
+# browser-use would go through unexamined. A metadata-only release is logged and
+# skipped; the next real change carries the pin past it.
 on:
   schedule:
     # 06:00 UTC daily. Scheduled workflows only run from the DEFAULT branch, so
@@ -107,6 +113,7 @@ jobs:
         if: steps.decide.outputs.act == 'true'
         env:
           BRANCH: ${{ steps.decide.outputs.branch }}
+          CODE_SUMMARY: ${{ steps.code.outputs.summary }}
         run: |
           set -euo pipefail
           if git ls-remote --exit-code --heads origin "$BRANCH" >/dev/null 2>&1; then
@@ -116,8 +123,18 @@ jobs:
             echo "skip=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Check the new pin set still resolves
+      - name: Compare the packaged code, not the version string
+        id: code
         if: steps.decide.outputs.act == 'true' && steps.exists.outputs.skip == 'false'
+        env:
+          PINNED: ${{ steps.pin.outputs.pinned }}
+          LATEST: ${{ steps.pypi.outputs.latest }}
+        run: |
+          set -euo pipefail
+          python3 .github/scripts/browser_service_code_diff.py "$PINNED" "$LATEST"
+
+      - name: Check the new pin set still resolves
+        if: steps.decide.outputs.act == 'true' && steps.exists.outputs.skip == 'false' && steps.code.outputs.code_changed == 'true'
         env:
           LATEST: ${{ steps.pypi.outputs.latest }}
         run: |
@@ -144,7 +161,7 @@ jobs:
           echo "Resolved browser-use: $(grep -iE '^browser-use==' /tmp/resolved.txt || echo 'not present')"
 
       - name: Open the bump PR
-        if: steps.decide.outputs.act == 'true' && steps.exists.outputs.skip == 'false'
+        if: steps.decide.outputs.act == 'true' && steps.exists.outputs.skip == 'false' && steps.code.outputs.code_changed == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PINNED: ${{ steps.pin.outputs.pinned }}
@@ -191,6 +208,8 @@ jobs:
             printf '`browser-service` on PyPI is at **%s**; `Dockerfile.browser-service` pins **%s**.\n\n' "$LATEST" "$PINNED"
             printf 'This pin is what the published browser-service image actually runs — `tools/browser_service/` is gitignored, so a CI build has no vendored copy. Until this merges, the newer releases reach nobody.\n\n'
             printf 'The pin set was resolved for linux/py3.12 in this run before the PR was opened, so the versions are known to be satisfiable together. Check the run log for the resolved `browser-use` version: if it moved, that is an engine change and needs a bench before merging.\n\n'
+            printf '### What moved\n\n'
+            printf '%s\n\n' "$CODE_SUMMARY"
             printf '**CI will not start on its own.** This branch was pushed with `GITHUB_TOKEN`, which cannot trigger other workflows. Close and reopen this PR to run `build-images.yml`.\n\n'
             printf 'Opened by `.github/workflows/check-browser-service-release.yml`.\n'
           } > /tmp/pr-body.md

--- a/.github/workflows/lint-workflows.yml
+++ b/.github/workflows/lint-workflows.yml
@@ -1,0 +1,67 @@
+name: Lint workflows
+
+# check-browser-service-release.yml is a SCHEDULED workflow, and scheduled
+# workflows only run from the default branch. It therefore has no runtime
+# feedback of any kind until it reaches main — nothing you can push, open or
+# re-run exercises it. Two bugs shipped in it that way, both of which stopped it
+# doing the one thing it exists for:
+#
+#   * an env var declared on the wrong step, so the PR body build hit an unbound
+#     variable under `set -u` one line before `gh pr create`;
+#   * archive parsing outside its own try block, so a truncated download killed
+#     the script instead of failing open as its docstring promised.
+#
+# actionlint catches the first class statically. Verified by putting the bug
+# back: it named the file, the line and the column. This job is the only
+# feedback that workflow gets before it goes live.
+
+on:
+  pull_request:
+    paths:
+      - '.github/**'
+  push:
+    branches:
+      - main
+      - develop
+    paths:
+      - '.github/**'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: lint-workflows-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  actionlint:
+    name: actionlint
+    runs-on: ubuntu-latest
+    steps:
+      # No credentials in .git/config: this job reads the tree and nothing else.
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Lint every workflow file
+        run: |
+          set -euo pipefail
+          # Pinned by DIGEST, not by tag. This container is handed the whole
+          # checkout, and `latest` would mean a different binary from one run to
+          # the next — the same discipline Dockerfile.browser-service applies to
+          # what it installs. 1.7.12, measured clean on this repo.
+          #
+          # actionlint discovers .github/workflows by asking git for the project
+          # root, which is why the checkout above is required rather than just
+          # convenient.
+          #
+          # -ignore SC2129 is a pure style rule ("consider { cmd1; cmd2; } >>
+          # file") with no defect-finding value. Nothing else is ignored:
+          # SC2016 is silenced with a scoped `shellcheck disable` comment in the
+          # one run block whose printf formats are deliberately literal, so it
+          # still fires on a genuine "expected this to expand" mistake anywhere
+          # else.
+          ACTIONLINT="rhysd/actionlint@sha256:b1934ee5f1c509618f2508e6eb47ee0d3520686341fec936f3b79331f9315667"
+          MOUNT="$PWD:/repo"
+          docker run --rm -v "$MOUNT" --workdir /repo "$ACTIONLINT" -color -ignore SC2129

--- a/Dockerfile.browser-service
+++ b/Dockerfile.browser-service
@@ -77,6 +77,18 @@ ENV BROWSER_USE_SERVICE_URL=http://localhost:4999
 
 USER appuser
 
+
+# --- Build identity -------------------------------------------------------
+# Last layer on purpose: it changes on every commit, so anything above it stays
+# cached. `-develop` and `-latest` are moving tags, so the tag a container was
+# pulled under does not identify the code inside it; this does.
+#   docker inspect -f '{{index .Config.Labels "org.opencontainers.image.revision"}}' IMAGE
+ARG GIT_SHA=unknown
+LABEL org.opencontainers.image.revision=$GIT_SHA
+# Read by src/backend/core/build_info.py and reported on /health, so a user can
+# name their build without inspecting the image.
+ENV NLRF_BUILD_SHA=$GIT_SHA
+
 # Expose browser service port
 EXPOSE 4999
 

--- a/Dockerfile.browser-service
+++ b/Dockerfile.browser-service
@@ -85,9 +85,10 @@ USER appuser
 #   docker inspect -f '{{index .Config.Labels "org.opencontainers.image.revision"}}' IMAGE
 ARG GIT_SHA=unknown
 LABEL org.opencontainers.image.revision=$GIT_SHA
-# Read by src/backend/core/build_info.py and reported on /health, so a user can
-# name their build without inspecting the image.
-ENV NLRF_BUILD_SHA=$GIT_SHA
+# Label only, no env var: this image runs the Flask browser service, and its
+# /health route belongs to the installed browser-service package, not to us.
+# Nothing here would read the variable. `docker inspect` is the answer for this
+# image, as it already is for the browser-service version it installs.
 
 # Expose browser service port
 EXPOSE 4999

--- a/Dockerfile.fastapi
+++ b/Dockerfile.fastapi
@@ -142,6 +142,18 @@ RUN mkdir -p /app/robot_tests /app/logs /app/chroma_db /app/data && \
 COPY scripts/fastapi-entrypoint.sh /usr/local/bin/fastapi-entrypoint.sh
 RUN chmod +x /usr/local/bin/fastapi-entrypoint.sh
 
+
+# --- Build identity -------------------------------------------------------
+# Last layer on purpose: it changes on every commit, so anything above it stays
+# cached. `-develop` and `-latest` are moving tags, so the tag a container was
+# pulled under does not identify the code inside it; this does.
+#   docker inspect -f '{{index .Config.Labels "org.opencontainers.image.revision"}}' IMAGE
+ARG GIT_SHA=unknown
+LABEL org.opencontainers.image.revision=$GIT_SHA
+# Read by src/backend/core/build_info.py and reported on /health, so a user can
+# name their build without inspecting the image.
+ENV NLRF_BUILD_SHA=$GIT_SHA
+
 # Expose FastAPI port
 EXPOSE 5000
 

--- a/Dockerfile.frontend
+++ b/Dockerfile.frontend
@@ -36,6 +36,15 @@ COPY src/frontend-react/nginx.conf /etc/nginx/conf.d/default.conf
 # Static bundle from the build stage.
 COPY --from=build /app/dist /usr/share/nginx/html
 
+
+# --- Build identity -------------------------------------------------------
+# Last layer on purpose: it changes on every commit, so anything above it stays
+# cached. `-develop` and `-latest` are moving tags, so the tag a container was
+# pulled under does not identify the code inside it; this does.
+#   docker inspect -f '{{index .Config.Labels "org.opencontainers.image.revision"}}' IMAGE
+ARG GIT_SHA=unknown
+LABEL org.opencontainers.image.revision=$GIT_SHA
+
 EXPOSE 8080
 
 # 127.0.0.1 explicitly: busybox wget resolves `localhost` to ::1 first and

--- a/Dockerfile.test-runner
+++ b/Dockerfile.test-runner
@@ -36,4 +36,13 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     test -d /opt/playwright-browsers && \
     chmod -R 755 /opt/playwright-browsers
 
+
+# --- Build identity -------------------------------------------------------
+# Last layer on purpose: it changes on every commit, so anything above it stays
+# cached. `-develop` and `-latest` are moving tags, so the tag a container was
+# pulled under does not identify the code inside it; this does.
+#   docker inspect -f '{{index .Config.Labels "org.opencontainers.image.revision"}}' IMAGE
+ARG GIT_SHA=unknown
+LABEL org.opencontainers.image.revision=$GIT_SHA
+
 CMD ["robot", "--version"]

--- a/README.md
+++ b/README.md
@@ -96,9 +96,8 @@ cp .env.example .env                              # root: Docker image tags
 cp src/backend/.env.example src/backend/.env      # backend: Vertex AI + settings
 ```
 
-In the **root `.env`**, point all four image tags at `-develop`. The file ships with
-`-local` defaults, which are **not** published to Docker Hub — only `frontend` can be
-built locally, so leaving them as-is makes `docker compose pull` fail:
+The **root `.env`** needs no edits — it already points all four image tags at the
+published `-develop` builds:
 
 ```env
 FASTAPI_IMAGE_TAG=monkscode/nlrf:fastapi-develop
@@ -107,8 +106,8 @@ TEST_RUNNER_IMAGE_TAG=monkscode/nlrf:test-runner-develop
 FRONTEND_IMAGE_TAG=monkscode/nlrf:frontend-develop
 ```
 
-All four must carry the **same** suffix — a mixed set is the usual cause of odd boot
-and login errors after an update.
+If you do change them, change all four to the **same** suffix — a mixed set is the
+usual cause of odd boot and login errors after an update.
 
 In **`src/backend/.env`**, set the Vertex AI project and location, and add your own
 email as an admin:
@@ -117,7 +116,7 @@ email as an admin:
 MODEL_PROVIDER=vertex
 VERTEXAI_PROJECT=your-project-id
 VERTEXAI_LOCATION=us-central1
-ONLINE_MODEL=gemini-2.5-flash
+ONLINE_MODEL=gemini-3.5-flash
 ADMIN_EMAILS=you@example.com
 ```
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -54,15 +54,21 @@ GEMINI_API_KEY=your-actual-api-key-here
 Which model to use (bare name — the provider prefix is added automatically based on `MODEL_PROVIDER`).
 
 ```env
-ONLINE_MODEL=gemini-2.5-flash
+ONLINE_MODEL=gemini-3.5-flash
 ```
 
-**Available Models:**
-- `gemini-2.5-flash` - Fast, accurate (recommended)
-- `gemini-2.0-flash` - Faster, slightly less capable
-- `gemini-1.5-pro` - More powerful, slower
+**Default:** `gemini-3.5-flash`
 
-**Recommendation:** Use `gemini-2.5-flash` for best speed/accuracy balance.
+**Available Models:**
+- `gemini-3.5-flash` - the default, and the only one with benchmark evidence
+- `gemini-2.5-flash` - cheaper, fewer thinking tokens; never benched here
+- `gemini-2.0-flash` - faster, slightly less capable
+- `gemini-1.5-pro` - more powerful, slower
+
+**Recommendation:** keep `gemini-3.5-flash`. Every baseline in `bench/baselines/`
+was measured on it, so the pass rate, cost per run and timings this project
+publishes describe that model and no other. The alternatives work; they simply
+have no numbers behind them.
 
 ### LOCAL_MODEL
 
@@ -108,12 +114,16 @@ APP_PORT=5000
 URL for the BrowserUse AI service.
 
 ```env
-BROWSER_USE_SERVICE_URL=http://localhost:4999
+BROWSER_USE_SERVICE_URL=http://127.0.0.1:4999
 ```
 
-**Default:** http://localhost:4999
+**Default:** `http://127.0.0.1:4999` (`core/config.py`)
 
-**Change if:** Running service on different host/port.
+Use `127.0.0.1`, not `localhost`. On Windows `localhost` resolves to `::1` first
+and this service binds IPv4 only, so every call stalls ~2s before falling back.
+Docker Compose overrides this to the `browser-service` service name.
+
+**Change if:** Running the service on a different host/port.
 
 ### BROWSER_USE_TIMEOUT
 
@@ -197,15 +207,18 @@ LOG_LEVEL=INFO   # inert
 - `WARNING` - Only warnings and errors
 - `ERROR` - Only errors
 
-### LOG_DIR
+### LOG_DIR — NOT WIRED UP
 
-Directory for application logs.
+**Setting this has no effect.** No code reads a `LOG_DIR` environment variable —
+`setup_logging()` takes the directory as a function argument and defaults to
+`"logs"`. Inert in exactly the same way as `LOG_LEVEL` above.
+
+(`BROWSER_USE_LOG_DIR` is a different variable and *is* read, by the browser
+service — see `tools/browser_service/__init__.py`.)
 
 ```env
-LOG_DIR=logs
+LOG_DIR=logs   # inert
 ```
-
-**Default:** `logs/` in project root
 
 ## Docker Settings
 
@@ -235,7 +248,17 @@ Whether to pull the runner image before falling back to building it locally.
 PREFER_REMOTE_DOCKER_IMAGE=true
 ```
 
-**Default:** `true` — a local build takes far longer than a pull.
+**Default when the variable is absent: `false`** (`services/docker_service.py`,
+`os.getenv('PREFER_REMOTE_DOCKER_IMAGE', 'false')`).
+
+**Set it explicitly to `true`.** Omitted, the fallback is `false`, which builds
+the runner image from source on your first **Run Test** — minutes of CPU instead
+of a ~0.5 GB pull — and also disables the startup warm-up below. The shipped
+`src/backend/.env.example` sets it; only a hand-trimmed `.env` loses it.
+
+The `false` fallback is deliberate: with no `TEST_RUNNER_IMAGE_TAG` configured
+either, a `true` fallback would pull `monkscode/nlrf:test-runner-latest` — the
+main-branch build, which is not the one this tree is developed against.
 
 ### REMOTE_DOCKER_IMAGE
 
@@ -426,7 +449,7 @@ GOOGLE_REDIRECT_URI=http://localhost:5000/auth/google/callback
 MODEL_PROVIDER=vertex
 VERTEXAI_PROJECT=your-gcp-project-id
 VERTEXAI_LOCATION=us-central1
-ONLINE_MODEL=gemini-2.5-flash
+ONLINE_MODEL=gemini-3.5-flash
 
 # Access — set BEFORE the first start
 ADMIN_EMAILS=you@company.com
@@ -451,7 +474,7 @@ runs in production.
 ```env
 MODEL_PROVIDER=gemini
 GEMINI_API_KEY=your-ai-studio-key   # https://aistudio.google.com/apikey
-ONLINE_MODEL=gemini-2.5-flash
+ONLINE_MODEL=gemini-3.5-flash
 ADMIN_EMAILS=you@company.com
 ```
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -70,6 +70,14 @@ was measured on it, so the pass rate, cost per run and timings this project
 publishes describe that model and no other. The alternatives work; they simply
 have no numbers behind them.
 
+It is not the cheap option, and the gap is worth knowing before you change it.
+Per LiteLLM's own price map, `gemini-3.5-flash` on Vertex costs **$1.50 per
+million input tokens and $9.00 per million output**, against `gemini-2.5-flash`
+at **$0.30 and $2.50** — 5x input, 3.6x output — before counting the extra
+thinking tokens 3.5 generates by default. Switching to `2.5-flash` is a
+legitimate way to cut cost; you are trading away the only configuration with
+measured reliability behind it.
+
 ### LOCAL_MODEL
 
 Which Ollama model to use (for local mode).

--- a/docs/DOCKER-GUIDE.md
+++ b/docs/DOCKER-GUIDE.md
@@ -151,7 +151,7 @@ GEMINI_API_KEY=your_api_key_here
 # Everything below has sensible defaults — you don't need to change these to get started.
 
 MODEL_PROVIDER=gemini
-ONLINE_MODEL=gemini-2.5-flash
+ONLINE_MODEL=gemini-3.5-flash
 
 ROBOT_LIBRARY=browser       # Use Playwright-based tests (recommended)
 BROWSER_HEADLESS=true       # Run browser in background (no visible window)
@@ -337,7 +337,7 @@ All settings below go in `src/backend/.env`. Only `GEMINI_API_KEY` is required t
 | Variable | Default | Description |
 |---|---|---|
 | `MODEL_PROVIDER` | `gemini` | `gemini` (Google AI Studio), `vertex` (Vertex AI), or `local` (Ollama) |
-| `ONLINE_MODEL` | `gemini-2.5-flash` | Bare model name — provider prefix added automatically |
+| `ONLINE_MODEL` | `gemini-3.5-flash` | Bare model name — provider prefix added automatically |
 | `GEMINI_API_KEY` | — | **Required for `MODEL_PROVIDER=gemini`.** Your Google AI Studio key |
 | `LOCAL_MODEL` | `qwen2.5-coder:14b` | Which Ollama model to use (local mode only) |
 | `OLLAMA_API_BASE` | `http://localhost:11434` | URL of your Ollama server |

--- a/src/backend/.env.example
+++ b/src/backend/.env.example
@@ -4,11 +4,14 @@
 #   "local"   — Ollama local model server
 MODEL_PROVIDER=vertex
 
-# The online model to use (e.g., "gemini-2.5-flash", "gemini-2.0-flash").
-# This is only used if MODEL_PROVIDER is "gemini" or "vertex".
+# The online model to use. Only used if MODEL_PROVIDER is "gemini" or "vertex".
 # Use the bare model name — the provider prefix (gemini/ or vertex_ai/) is
 # added automatically based on MODEL_PROVIDER.
-ONLINE_MODEL=gemini-2.5-flash
+#
+# gemini-3.5-flash is the model the project benchmarks against; the published
+# pass rate, cost per run and timings all describe it. Other values work
+# (gemini-2.5-flash, gemini-2.0-flash) but carry no benchmark evidence.
+ONLINE_MODEL=gemini-3.5-flash
 
 # The local model to use with Ollama (e.g., "qwen2.5-coder:14b").
 # This is only used if MODEL_PROVIDER is "local".
@@ -111,7 +114,7 @@ TRACK_LLM_COSTS=true
 # false, which builds locally and disables the startup warm-up below. The
 # fallback stays false deliberately — with no TEST_RUNNER_IMAGE_TAG configured
 # either, a true fallback would pull monkscode/nlrf:test-runner-latest, the
-# main-branch build the root .env.example warns is not compatible with this code.
+# main-branch build, which lags the -develop images the root .env.example ships.
 PREFER_REMOTE_DOCKER_IMAGE=true
 
 # Registry image to pull the test runner from (only used if

--- a/src/backend/api/health.py
+++ b/src/backend/api/health.py
@@ -8,10 +8,12 @@ Referenced by:
     src/backend/main.py          — registers routes on the production app
     tests/test_api/test_api_endpoints.py — mounts same handlers in test fixture
 Depends on:
+    src/backend/core/build_info  — the commit this image was built from
     src/backend/core/config      — settings singleton
     src/backend/services/workflow_service — get_active_workflow_count()
 """
 
+from src.backend.core.build_info import build_info
 from src.backend.core.config import settings
 from src.backend.services.workflow_service import get_active_workflow_count
 
@@ -37,6 +39,7 @@ async def health_check():
         "max_workflows": max_wf,
         "available_slots": max(0, max_wf - active),
         "pins": _pins(),
+        "build": build_info(),
     }
 
 
@@ -51,4 +54,5 @@ async def api_health_check():
         "max_workflows": max_wf,
         "available_slots": max(0, max_wf - active),
         "pins": _pins(),
+        "build": build_info(),
     }

--- a/src/backend/core/build_info.py
+++ b/src/backend/core/build_info.py
@@ -1,0 +1,39 @@
+"""Which build is this process running?
+
+`-develop` and `-latest` are moving tags, so the tag a container was pulled
+under says nothing about the commit inside it. Without a stamp, "you are not on
+the latest code" cannot be confirmed or refuted from the outside — which is how
+a browser-service pin sat three releases behind for two weeks without anyone
+noticing from the running system.
+
+build-images.yml passes the commit to every image build as the GIT_SHA
+build-arg; the Dockerfiles turn it into an OCI revision label (readable with
+`docker inspect`) and, for the backend image, an environment variable this
+module reads and the health endpoints report.
+
+Referenced by:
+    src/backend/api/health.py        — /health and /api/health
+    src/backend/runner_exec/app.py   — the executor's own /health
+Depends on: nothing (stdlib only — this must work before anything else does).
+"""
+
+import os
+
+# Read at call time, not import time: the tests set it per case, and a process
+# that re-execs (uvicorn --reload) must see the current environment.
+_ENV_VAR = "NLRF_BUILD_SHA"
+
+# An unset --build-arg reaches the image as an empty string rather than being
+# absent, so a blank value means "not stamped" just as a missing one does.
+UNKNOWN = "unknown"
+
+
+def build_info() -> dict[str, str]:
+    """The commit this image was built from, or 'unknown' if it was not stamped.
+
+    'unknown' is the honest answer for a local `run.sh` checkout, which has no
+    image and therefore no stamp. It is never inferred from a version string or
+    a package release — those are what proved worthless here: two different
+    browser-service builds both reported __version__ 1.0.32.
+    """
+    return {"commit": os.getenv(_ENV_VAR, "").strip() or UNKNOWN}

--- a/src/backend/core/config.py
+++ b/src/backend/core/config.py
@@ -17,7 +17,12 @@ class Settings(BaseSettings):
     #   "local"   — Ollama (requires a running Ollama server)
     MODEL_PROVIDER: str = "vertex"
     GEMINI_API_KEY: str | None = None
-    ONLINE_MODEL: str = "gemini-2.5-flash"
+    # The model every baseline in bench/baselines/ was measured on — the pass-rate
+    # gate, cost per run and timing figures all describe this one. It shipped as
+    # gemini-2.5-flash, which no baseline has ever covered, so a new user ran a
+    # configuration with no evidence behind it. Keep this and .env.example in step
+    # (tests/test_core/test_config.py guards both).
+    ONLINE_MODEL: str = "gemini-3.5-flash"
     LOCAL_MODEL: str = "llama3"
 
     # Vertex AI Configuration (only required when MODEL_PROVIDER=vertex)

--- a/src/backend/runner_exec/app.py
+++ b/src/backend/runner_exec/app.py
@@ -10,7 +10,7 @@ Run as: uvicorn src.backend.runner_exec.app:app --host 0.0.0.0 --port 4998
 
 Referenced by: docker-compose.yml (runner-exec), run.sh, RunnerExecClient.
 Depends on: services/docker_service.py, services/dryrun_service.py,
-runner_exec/validation.py.
+runner_exec/validation.py, core/build_info.py.
 """
 import logging
 import os
@@ -25,6 +25,7 @@ from src.backend.config.logging_config import (
     clear_workflow_context,
     setup_logging,
 )
+from src.backend.core.build_info import build_info
 from src.backend.runner_exec.validation import safe_run_id, safe_test_filename
 from src.backend.services.docker_service import (
     IMAGE_PROVISION_LOCK,
@@ -131,15 +132,18 @@ def _validated(value: str, validator) -> str:
 
 @app.get("/health")
 def health() -> dict:
+    # build is reported on both branches: knowing which build is unreachable is
+    # more useful than knowing only that something is. This runs in its own
+    # container and can be a different image from the API's.
     try:
         get_docker_client()  # pings the socket
-        return {"status": "ok"}
+        return {"status": "ok", "build": build_info()}
     except Exception as e:  # noqa: BLE001 — health must not raise
         # Log the underlying error for ops, but do NOT echo the raw exception
         # text back in the response — it can carry internal paths/stack detail
         # (CWE-209). The caller only needs the up/down signal.
         logger.warning("[RUNNER-EXEC] docker health check failed: %s", e)
-        return {"status": "unavailable"}
+        return {"status": "unavailable", "build": build_info()}
 
 
 @app.post("/ensure-image")

--- a/src/frontend-react/src/components/app-sidebar.tsx
+++ b/src/frontend-react/src/components/app-sidebar.tsx
@@ -20,6 +20,7 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
 import { Avatar, AvatarFallback } from '@/components/ui/avatar'
+import { BuildBadge } from '@/components/build-badge'
 import {
   Zap,
   History,
@@ -226,6 +227,7 @@ export function AppSidebar() {
       {/* User footer */}
       <SidebarFooter>
         <NavUser />
+        <BuildBadge />
       </SidebarFooter>
 
       <SidebarRail />

--- a/src/frontend-react/src/components/build-badge.tsx
+++ b/src/frontend-react/src/components/build-badge.tsx
@@ -12,7 +12,6 @@
  */
 
 import { useEffect, useState } from 'react'
-import { api } from '@/lib/api'
 
 interface HealthBuild {
   build?: { commit?: string }
@@ -24,10 +23,15 @@ export function BuildBadge() {
 
   useEffect(() => {
     let alive = true
-    // Failure is silent on purpose: this is a diagnostic label, and an error
-    // toast for it would be noise on a page that is working fine.
-    api<HealthBuild>('/api/health')
-      .then((h) => { if (alive) setCommit(h.build?.commit ?? null) })
+    // Plain fetch, deliberately not lib/api: that wrapper clears the token and
+    // redirects to /login on a 401. /api/health carries no auth guard today, but
+    // a diagnostic label must never be able to sign anyone out if that changes.
+    //
+    // Failure is silent on purpose: an error toast for a version string would be
+    // noise on a page that is working fine.
+    fetch('/api/health', { headers: { Accept: 'application/json' } })
+      .then((r) => (r.ok ? (r.json() as Promise<HealthBuild>) : null))
+      .then((h) => { if (alive) setCommit(h?.build?.commit ?? null) })
       .catch(() => { /* leave it unrendered */ })
     return () => { alive = false }
   }, [])

--- a/src/frontend-react/src/components/build-badge.tsx
+++ b/src/frontend-react/src/components/build-badge.tsx
@@ -1,0 +1,58 @@
+/**
+ * The commit this instance is running, shown in the sidebar footer.
+ *
+ * `-develop` and `-latest` are moving tags, so "which build am I on?" cannot be
+ * answered from the outside — the image tag a container was pulled under says
+ * nothing about the code inside it. The backend reports its stamp on
+ * /api/health; this puts it where a user can read it out without knowing any
+ * docker commands, which is what a bug report needs.
+ *
+ * Shows the 7-character prefix (git's own short form) and copies the full value
+ * on click, so nothing is lost to the abbreviation.
+ */
+
+import { useEffect, useState } from 'react'
+import { api } from '@/lib/api'
+
+interface HealthBuild {
+  build?: { commit?: string }
+}
+
+export function BuildBadge() {
+  const [commit, setCommit] = useState<string | null>(null)
+  const [copied, setCopied] = useState(false)
+
+  useEffect(() => {
+    let alive = true
+    // Failure is silent on purpose: this is a diagnostic label, and an error
+    // toast for it would be noise on a page that is working fine.
+    api<HealthBuild>('/api/health')
+      .then((h) => { if (alive) setCommit(h.build?.commit ?? null) })
+      .catch(() => { /* leave it unrendered */ })
+    return () => { alive = false }
+  }, [])
+
+  if (!commit) return null
+
+  const short = commit === 'unknown' ? 'unknown' : commit.slice(0, 7)
+
+  const copy = () => {
+    navigator.clipboard?.writeText(commit).then(
+      () => { setCopied(true); setTimeout(() => setCopied(false), 1500) },
+      () => { /* clipboard blocked (non-https origin) — the title still shows it */ },
+    )
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={copy}
+      title={commit === 'unknown'
+        ? 'This build was not stamped with a commit (a local run, not a published image)'
+        : `Build ${commit} — click to copy`}
+      className="px-2 pb-1 text-left text-[10px] font-mono text-sidebar-foreground/50 hover:text-sidebar-foreground/80 group-data-[collapsible=icon]:hidden"
+    >
+      {copied ? 'copied' : `build ${short}`}
+    </button>
+  )
+}

--- a/tests/test_build_manifests.py
+++ b/tests/test_build_manifests.py
@@ -90,3 +90,56 @@ def test_robot_toolchain_pin_matches_runner_libdoc_stage_and_committed_libdocs(p
         f"{committed}. Regenerate the libdocs from the pinned version: "
         f"tools/generate_libdocs.py, run inside the test-runner image."
     )
+
+
+# ---------------------------------------------------------------------------
+# The publish gate.
+#
+# build-images.yml and sonarqube.yml are both triggered by a push to develop,
+# and nothing connected them: the images that overwrite `-develop` — the tag the
+# README tells every user to pull — were published whether or not the suite that
+# runs alongside them passed. The two workflows simply raced. This holds the
+# gate in place, because a `needs:` line is exactly the kind of thing that gets
+# dropped while making an unrelated job faster.
+# ---------------------------------------------------------------------------
+
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "build-images.yml"
+
+# Every job that produces an image. base-browser is included: it is not pushed
+# under a tag users pull, but browser-service and test-runner are built FROM it.
+IMAGE_JOBS = [
+    "build-base-browser",
+    "build-fastapi",
+    "build-frontend",
+    "build-browser-service",
+    "build-test-runner",
+]
+
+GATE_JOB = "test"
+
+
+def _build_images_workflow() -> dict:
+    import yaml
+    return yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+
+
+def test_the_publish_gate_job_exists_and_runs_the_suite():
+    wf = _build_images_workflow()
+    assert GATE_JOB in wf["jobs"], (
+        f"build-images.yml has no '{GATE_JOB}' job — nothing stops a red suite "
+        "from publishing images")
+    steps = wf["jobs"][GATE_JOB].get("steps", [])
+    run_text = "\n".join(s.get("run", "") for s in steps)
+    assert "pytest" in run_text, f"the '{GATE_JOB}' job does not run pytest"
+
+
+@pytest.mark.parametrize("job", IMAGE_JOBS)
+def test_every_image_build_waits_for_the_suite(job):
+    wf = _build_images_workflow()
+    assert job in wf["jobs"], f"build-images.yml has no '{job}' job"
+    needs = wf["jobs"][job].get("needs", [])
+    if isinstance(needs, str):
+        needs = [needs]
+    assert GATE_JOB in needs, (
+        f"'{job}' does not depend on '{GATE_JOB}' — it can publish an image "
+        "built from code the suite rejected")

--- a/tests/test_core/test_build_identity.py
+++ b/tests/test_core/test_build_identity.py
@@ -1,0 +1,121 @@
+"""Guards for the build identity a running container reports.
+
+Purpose: `-develop` and `-latest` are MOVING tags. Without a commit stamped into
+         the image, neither a user nor a maintainer can tell which build is
+         running — `docker compose images` shows only the tag it was pulled
+         under. That is what made "the user is not on the latest code"
+         undiagnosable, so these tests keep the stamp wired end to end:
+         Dockerfile ARG -> image LABEL + env -> /health.
+
+Tests:
+  - build_info() defaults honestly instead of inventing a version
+  - build_info() reports NLRF_BUILD_SHA when the image sets it
+  - /health, /api/health and the executor's /health all carry it
+  - every runnable Dockerfile declares the ARG and stamps it
+  - build-images.yml actually passes the commit to each of those builds
+"""
+
+import os
+import re
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# The images a user runs. base-browser is a build-time base only — it is never
+# started as a service, so it carries no identity of its own.
+RUNNABLE_DOCKERFILES = [
+    "Dockerfile.fastapi",
+    "Dockerfile.browser-service",
+    "Dockerfile.test-runner",
+    "Dockerfile.frontend",
+]
+
+
+class TestBuildInfo:
+    def test_defaults_to_unknown_when_unstamped(self):
+        """A local `run.sh` checkout has no stamp. Say so; do not guess."""
+        from src.backend.core.build_info import build_info
+        with patch.dict(os.environ, {}, clear=True):
+            assert build_info() == {"commit": "unknown"}
+
+    def test_reports_the_stamped_commit(self):
+        from src.backend.core.build_info import build_info
+        with patch.dict(os.environ, {"NLRF_BUILD_SHA": "f96c5c6"}, clear=True):
+            assert build_info() == {"commit": "f96c5c6"}
+
+    def test_blank_stamp_is_treated_as_absent(self):
+        """An unset --build-arg reaches the image as an empty string."""
+        from src.backend.core.build_info import build_info
+        with patch.dict(os.environ, {"NLRF_BUILD_SHA": "   "}, clear=True):
+            assert build_info() == {"commit": "unknown"}
+
+
+class TestHealthCarriesTheBuild:
+    @pytest.fixture(scope="class")
+    def client(self):
+        from fastapi import FastAPI
+        from fastapi.testclient import TestClient
+        from src.backend.api.health import health_check, api_health_check
+
+        app = FastAPI()
+        app.get("/health")(health_check)
+        app.get("/api/health")(api_health_check)
+        with TestClient(app) as c:
+            yield c
+
+    @pytest.mark.parametrize("path", ["/health", "/api/health"])
+    def test_build_is_reported(self, client, path):
+        with patch("src.backend.api.health.get_active_workflow_count", return_value=0), \
+             patch.dict(os.environ, {"NLRF_BUILD_SHA": "abc1234"}, clear=False):
+            resp = client.get(path)
+        assert resp.status_code == 200
+        assert resp.json()["build"] == {"commit": "abc1234"}
+
+    def test_executor_health_reports_it_too(self):
+        """The executor is a separate container and can be a different build."""
+        from fastapi.testclient import TestClient
+        from src.backend.runner_exec import app as runner_app
+
+        with patch.object(runner_app, "get_docker_client"), \
+             patch.object(runner_app, "_start_image_warmup"), \
+             patch.dict(os.environ, {"NLRF_BUILD_SHA": "abc1234"}, clear=False):
+            with TestClient(runner_app.app) as c:
+                body = c.get("/health").json()
+        assert body["build"] == {"commit": "abc1234"}
+
+
+class TestTheStampIsWiredIntoTheBuild:
+    """Unit-testing build_info() proves nothing if no image ever sets the var."""
+
+    @pytest.mark.parametrize("dockerfile", RUNNABLE_DOCKERFILES)
+    def test_dockerfile_accepts_and_stamps_the_commit(self, dockerfile):
+        text = (REPO_ROOT / dockerfile).read_text(encoding="utf-8")
+        assert re.search(r"^ARG\s+GIT_SHA", text, re.M), \
+            f"{dockerfile} does not accept a GIT_SHA build-arg"
+        assert re.search(r"^LABEL\s+org\.opencontainers\.image\.revision=", text, re.M), \
+            f"{dockerfile} does not label the image with its revision"
+
+    @pytest.mark.parametrize("dockerfile", ["Dockerfile.fastapi"])
+    def test_backend_image_exports_it_to_the_process(self, dockerfile):
+        """LABEL is for `docker inspect`; /health needs it in the environment."""
+        text = (REPO_ROOT / dockerfile).read_text(encoding="utf-8")
+        assert re.search(r"^ENV\s+NLRF_BUILD_SHA=", text, re.M), \
+            f"{dockerfile} does not export NLRF_BUILD_SHA"
+
+    @pytest.mark.parametrize("dockerfile", RUNNABLE_DOCKERFILES)
+    def test_ci_passes_the_commit_to_every_build(self, dockerfile):
+        """A Dockerfile that accepts GIT_SHA but is never given one is inert."""
+        workflow = (REPO_ROOT / ".github" / "workflows" / "build-images.yml").read_text(
+            encoding="utf-8")
+        # The build step names its Dockerfile, then its build-args. Take the
+        # slice from this file's step to the next one and require the arg there.
+        marker = f"file: ./{dockerfile}"
+        assert marker in workflow, f"{dockerfile} has no build step in build-images.yml"
+        start = workflow.index(marker)
+        nxt = workflow.find("file: ./Dockerfile", start + len(marker))
+        section = workflow[start:] if nxt == -1 else workflow[start:nxt]
+        assert "GIT_SHA=${{ github.sha }}" in section, \
+            f"build-images.yml does not pass GIT_SHA to {dockerfile}"

--- a/tests/test_core/test_config.py
+++ b/tests/test_core/test_config.py
@@ -182,3 +182,47 @@ def test_local_service_urls_use_ipv4_loopback(monkeypatch):
     assert s.BROWSER_USE_SERVICE_URL == "http://127.0.0.1:4999"
     assert "localhost" not in s.RUNNER_EXEC_URL
     assert "localhost" not in s.BROWSER_USE_SERVICE_URL
+
+
+# The model every published baseline in bench/baselines/ was measured on. The
+# pass-rate gate, the cost-per-run and the timing figures quoted in the README
+# and CLAUDE.md all describe THIS model and no other.
+BENCHED_ONLINE_MODEL = "gemini-3.5-flash"
+
+
+def test_default_online_model_is_the_benched_one(monkeypatch):
+    """The shipped default must be the model the bench actually measures.
+
+    It was not: the default and src/backend/.env.example both shipped
+    gemini-2.5-flash while all 75 baseline meta files record gemini-3.5-flash.
+    A new user therefore ran a configuration with zero benchmark evidence
+    behind it, while the README quoted numbers from a different one.
+
+    Asserted against the field default rather than an instance so neither the
+    process environment nor a developer's own .env can mask a revert.
+    """
+    from src.backend.core.config import Settings
+    assert Settings.model_fields["ONLINE_MODEL"].default == BENCHED_ONLINE_MODEL
+
+    monkeypatch.delenv("ONLINE_MODEL", raising=False)
+    assert Settings(_env_file=None).ONLINE_MODEL == BENCHED_ONLINE_MODEL
+
+
+def test_env_example_ships_the_same_online_model():
+    """src/backend/.env.example is what every new user copies.
+
+    An uncommented value there overrides the class default, so the two drifting
+    apart silently re-creates the bug this guards: the code says one model, the
+    file every user starts from says another.
+    """
+    from pathlib import Path
+    example = Path(__file__).resolve().parents[2] / "src" / "backend" / ".env.example"
+    shipped = [
+        line.split("=", 1)[1].strip()
+        for line in example.read_text(encoding="utf-8").splitlines()
+        if line.startswith("ONLINE_MODEL=")
+    ]
+    assert shipped == [BENCHED_ONLINE_MODEL], (
+        f".env.example ships ONLINE_MODEL={shipped}, expected "
+        f"['{BENCHED_ONLINE_MODEL}'] to match the class default"
+    )


### PR DESCRIPTION
Follow-ups to #91/#92/#95, from walking the delivery path a new user actually takes and checking each claim against the code and the published images.

## Which build am I on

`-develop` and `-latest` move, so the tag a container was pulled under does not identify the code inside it.

This was not completely dark: `docker/metadata-action` already writes `org.opencontainers.image.revision` — verified `f96c5c64` on `monkscode/nlrf:fastapi-develop`. What was missing is that **nothing surfaced it at runtime**, so answering the question needed a `docker inspect` incantation the user reporting the bug does not know, and a **locally built image carried no labels at all** (`null` on `fastapi-local`) — which is the flow `.env.example` documents.

Every runnable Dockerfile now takes a `GIT_SHA` build-arg and stamps the OCI revision label; `build-images.yml` passes `github.sha` to all four. The backend also exports it, `/health` and the executor's `/health` report it, and the sidebar shows the short form with the full value on click. The stamp is the last layer in each file, so a new commit invalidates nothing above it.

Verified end to end by building `Dockerfile.fastapi` at `116fc96`:

```
docker inspect → 116fc963e817c27ac9d8b96ea86e010239c5d283
/health        → "build": {"commit": "116fc963e817c27ac9d8b96ea86e010239c5d283"}
```

Tests assert the ARG, the LABEL, the ENV and the CI build-args together — `build_info()` passing alone proves nothing if no image ever sets the variable.

## Untested images could reach users

`build-images.yml` and `sonarqube.yml` are both fired by the same push to `develop` and were entirely independent, so a red suite still overwrote `-develop`. A test job now gates every build.

It re-runs a suite `sonarqube.yml` also runs. `workflow_run` gating was rejected because it only fires from the **default** branch — the same trap that leaves `check-browser-service-release.yml` inert on `develop`.

Also a concurrency group, scoped carefully: a push run is never cancelled, because it pushes five images one job at a time and killing it mid-run leaves `-develop` on a different commit per service — the mixed set `.env.example` calls the usual cause of odd boot and login errors. Only `pull_request` runs, which push nothing, are cancelled.

## The watchdog would have opened no-op PRs

It compared version strings. browser-service auto-publishes a patch for **every** merge on that side, docs-only ones included: `1.0.36`'s wheel is byte-identical to `1.0.35`'s across all 36 modules. A stream of empty PRs teaches whoever reviews them to merge unread, and the one that finally moves `browser-use` goes through unexamined.

It now diffs the packaged modules and skips a metadata-only release; when code did move, the PR body lists what. Exercised on both real cases:

```
1.0.35 → 1.0.36   no code change, all 36 modules identical
1.0.32 → 1.0.33   5 modules moved, incl. locators/smart_locator.py
```

That second one is the locator fix that was stranded for two weeks.

## Configuration that contradicted the code

- **`ONLINE_MODEL`** shipped `gemini-2.5-flash` while **75 of 75** baseline meta files in `bench/baselines/` record `gemini-3.5-flash`. Every number this project publishes described a model no new user was running. The default and `src/backend/.env.example` now name the benched one, with two tests pinning them together. `CONFIGURATION.md` states the cost of that choice plainly: $1.50/$9.00 per million input/output tokens against $0.30/$2.50 for `2.5-flash`.
- **Root `.env.example`** shipped `-local` tags that are not published, so the README spent a paragraph asking every reader to hand-edit four lines. It ships `-develop` now; `-local` remains as commented alternatives beside the build order.
- Its warning that `-latest` is *"PRE-migration, NOT compatible with this code"* was **false on both counts** — main's `config.py` defaults `OBSERVABILITY_BACKEND=postgres`, and main's `main.py` registers `auth_router`, `admin_access_router` and `org_router`. It is an older build of the same architecture, and saying so is the difference between a reader believing the file and ignoring it.
- **`CONFIGURATION.md`**, linked three times from the README: `PREFER_REMOTE_DOCKER_IMAGE` claimed `Default: true` where `docker_service.py` reads it with a `'false'` fallback — omitted, the first **Run Test** builds the runner from source instead of pulling; `LOG_DIR` was documented as working with zero readers anywhere; `BROWSER_USE_SERVICE_URL` gave `localhost` where `config.py` is `127.0.0.1`, the value `.env.example` warns costs ~2s a call on Windows.

## Verification

- `3091 passed, 3 skipped` (`-m "not integration"`), including 23 new tests
- SPA `tsc -b && vite build` clean
- Both workflows parse; job graph confirmed
- `Dockerfile.fastapi` and `Dockerfile.frontend` built for real and inspected

**Not verified here:** no live generation + execution run. No pipeline code is touched, so the 96.7% gate is unaffected, but it has not been re-measured.

## Still open, and not in this PR

`check-browser-service-release.yml` remains **inert**. Scheduled workflows and `workflow_dispatch` only run from the default branch, which is `main`, and `main` does not have the file. Merging `develop` → `main` is what activates it — and would also refresh the `-latest` images, stuck at 2026-08-07.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Health checks now report the running build identifier.
  - The sidebar displays the current build version and lets you copy the full identifier.
  - Docker images now include commit-based build metadata.

- **Updates**
  - The default online model is now `gemini-3.5-flash`.
  - Development environments now default to published `-develop` images, with clearer tag guidance.

- **Bug Fixes**
  - Automated browser-service updates now skip releases containing no code changes.
  - Image builds are gated by the test suite for improved reliability.

- **Documentation**
  - Quick Start and environment configuration guidance has been refreshed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->