### PR TITLE
Show whether a correction's hint is still active, in the panel and in History

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -271,8 +271,9 @@ jobs:
   # and are backend-only, and the only frontend gate was `tsc -b` inside
   # Dockerfile.frontend's `npm run build`. That catches a type error and
   # nothing else, so a React behavioural regression published a green frontend
-  # image. sonar-project.properties excludes src/frontend-react entirely, so
-  # SonarQube did not cover it either.
+  # image. sonar-project.properties excluded src/frontend-react entirely back
+  # then, so SonarQube did not cover it either; that exclusion has since been
+  # removed and the SPA is analysed.
   #
   # Gates build-frontend only, not the other four image jobs: this suite judges
   # src/frontend-react and nothing else, and a red React test is no reason to

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -291,8 +291,8 @@ jobs:
     steps:
       # persist-credentials: false keeps GITHUB_TOKEN out of .git/config. The
       # steps below run code this pull request authored - `npm ci` executes its
-      # package.json lifecycle scripts, `npm test` runs its test files - and no
-      # step here needs git authentication afterwards.
+      # package.json lifecycle scripts, `npm run test:coverage` runs its test
+      # files - and no step here needs git authentication afterwards.
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
@@ -310,8 +310,14 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      # vite.config.ts's coverage thresholds are only evaluated when vitest
+      # runs with --coverage - plain `npm test` never checks them. This is the
+      # job that gates build-frontend, so the thresholds must be evaluated
+      # HERE and not only in sonarqube.yml: that workflow races build-images.yml
+      # on the same push rather than gating it, so a coverage collapse there
+      # would not stop this job from publishing an image.
       - name: Run the frontend suite
-        run: npm test
+        run: npm run test:coverage
 
       # `npm run build` runs `tsc -b` too, but only inside the Docker build this
       # job gates. Running it here fails in seconds rather than partway through

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -289,8 +289,14 @@ jobs:
         working-directory: src/frontend-react
 
     steps:
+      # persist-credentials: false keeps GITHUB_TOKEN out of .git/config. The
+      # steps below run code this pull request authored - `npm ci` executes its
+      # package.json lifecycle scripts, `npm test` runs its test files - and no
+      # step here needs git authentication afterwards.
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       # Same major as Dockerfile.frontend's `node:22-alpine` build stage, so a
       # failure here means the same thing a failure in the image build does.

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -266,10 +266,57 @@ jobs:
             echo "image_size=unknown" >> "$GITHUB_OUTPUT"
           fi
 
+  # The frontend suite. Until this job existed NOTHING in CI ran it: both
+  # pytest lanes here and in sonarqube.yml pass --ignore=tests/test_integration
+  # and are backend-only, and the only frontend gate was `tsc -b` inside
+  # Dockerfile.frontend's `npm run build`. That catches a type error and
+  # nothing else, so a React behavioural regression published a green frontend
+  # image. sonar-project.properties excludes src/frontend-react entirely, so
+  # SonarQube did not cover it either.
+  #
+  # Gates build-frontend only, not the other four image jobs: this suite judges
+  # src/frontend-react and nothing else, and a red React test is no reason to
+  # hold back a FastAPI fix. Kept honest by tests/test_build_manifests.py, the
+  # same way the backend gate is.
+  test-frontend:
+    name: Frontend suite (publish gate)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    defaults:
+      run:
+        working-directory: src/frontend-react
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      # Same major as Dockerfile.frontend's `node:22-alpine` build stage, so a
+      # failure here means the same thing a failure in the image build does.
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: npm
+          cache-dependency-path: src/frontend-react/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run the frontend suite
+        run: npm test
+
+      # `npm run build` runs `tsc -b` too, but only inside the Docker build this
+      # job gates. Running it here fails in seconds rather than partway through
+      # an image build, and keeps the whole frontend verdict in one job.
+      - name: Typecheck
+        run: npx tsc --noEmit
+
   build-frontend:
     name: Build Frontend Image
     runs-on: ubuntu-latest
-    needs: [test]
+    needs: [test, test-frontend]
     outputs:
       image_size: ${{ steps.image_size.outputs.image_size }}
     permissions:

--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -81,6 +81,40 @@ jobs:
           files: coverage.xml
           fail_ci_if_error: true
 
+      # sonar-project.properties points sonar.javascript.lcov.reportPaths at
+      # src/frontend-react/coverage/lcov.info. Nothing else in CI produces it,
+      # and Sonar does not fail when an lcov path is missing - it silently
+      # reports the whole SPA as 0% covered, which fails the new-code gate on
+      # every frontend PR for a reason that looks nothing like the cause. So
+      # this runs BEFORE the scan, and its failure is not suppressed.
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: npm
+          cache-dependency-path: src/frontend-react/package-lock.json
+
+      - name: Frontend coverage (produces lcov for SonarQube)
+        working-directory: src/frontend-react
+        run: |
+          npm ci
+          npx vitest run --coverage
+          # vitest writes lcov paths relative to ITS root, so every record reads
+          # `SF:src/App.tsx`. Sonar resolves those against the repo root, where
+          # `src/` is the PYTHON backend — so every path would miss, and Sonar
+          # would report the SPA as 0% covered without erroring. Rewrite them to
+          # repo-root-relative. Verified by the grep below, which fails the job
+          # rather than letting a silent 0% through.
+          sed -i 's|^SF:src/|SF:src/frontend-react/src/|' coverage/lcov.info
+          # Fail loudly if the rewrite did not take: every record must now be
+          # repo-root-relative, and none may still be bare `SF:src/...`.
+          grep -q '^SF:src/frontend-react/src/' coverage/lcov.info
+          if grep -c '^SF:' coverage/lcov.info | grep -qv "^$(grep -c '^SF:src/frontend-react/src/' coverage/lcov.info)$"; then
+            echo "lcov path rewrite incomplete — Sonar would report 0% coverage" >&2
+            grep '^SF:' coverage/lcov.info | grep -v '^SF:src/frontend-react/src/' >&2
+            exit 1
+          fi
+
       - name: SonarQube Scan
         uses: SonarSource/sonarqube-scan-action@v6
         env:

--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -98,7 +98,7 @@ jobs:
         working-directory: src/frontend-react
         run: |
           npm ci
-          npx vitest run --coverage
+          npm run test:coverage
           # vitest writes lcov paths relative to ITS root, so every record reads
           # `SF:src/App.tsx`. Sonar resolves those against the repo root, where
           # `src/` is the PYTHON backend — so every path would miss, and Sonar

--- a/.gitignore
+++ b/.gitignore
@@ -77,6 +77,12 @@ docs/superpowers/specs/
 docs/superpowers/*.md
 .agents/workflows/development-workflow.md
 logs/crewai.log.txt
+# The deferred-work register: an index of technical debt that was found and
+# consciously not fixed. Gitignored for the same reason CLAUDE.md is - it is the
+# owner's working state, and it points at follow-up docs that are not committed
+# (one of which names a client).
+docs/TODO.md
+
 CLAUDE.md
 credentials.json
 

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -5,7 +5,9 @@ sonar.projectName=Natural-Language-to-Robot-Framework
 sonar.projectVersion=1.0
 
 sonar.sources=src
-sonar.tests=tests
+# The frontend suite lives beside the code it tests, so its root overlaps
+# sonar.sources. sonar.test.inclusions below is what separates them per file.
+sonar.tests=tests,src/frontend-react/src
 sonar.python.version=3.11
 
 sonar.python.coverage.reportPaths=coverage.xml
@@ -26,7 +28,16 @@ sonar.sourceEncoding=UTF-8
 # ships to users either way.
 sonar.exclusions=**/venv/**,**/__pycache__/**,**/node_modules/**,src/frontend-react/dist/**,src/frontend-react/coverage/**
 sonar.coverage.exclusions=src/frontend-react/src/components/ui/**,src/frontend-react/src/main.tsx,src/frontend-react/**/*.d.ts,src/frontend-react/src/test/**
-sonar.test.inclusions=**/*.test.ts,**/*.test.tsx
+# sonar.test.inclusions NARROWS sonar.tests - it does not add to it - and a
+# file it matches is never indexed as source either. So `**/*.test.ts,**/*.test
+# .tsx` on its own did two wrong things at once: it filtered the whole tests/
+# tree out of the test scope, because no Python file matches those patterns,
+# and it removed every frontend test from the source scope without any
+# sonar.tests root to catch them. Measured on PR #100 before the fix:
+# tests/test_build_manifests.py and app-header.test.tsx are both in the diff
+# and NEITHER is indexed, while GeneratePage.tsx and useFetch.ts from the same
+# diff are indexed as FIL. tests/** is what puts the Python suite back.
+sonar.test.inclusions=tests/**,**/*.test.ts,**/*.test.tsx
 sonar.test.exclusions=**/venv/**
 
 # python:S5443 ("publicly writable directory") fires on the "/tmp" literal in

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -18,9 +18,10 @@ sonar.sourceEncoding=UTF-8
 # had no test harness (every TSX line counted as uncovered "new code" and failed
 # the >=80% gate) and that half of it is vendored shadcn/ui. The note left here
 # said to re-include it "when a frontend test harness (vitest) lands, and move
-# the exclusion to sonar.coverage.exclusions". Both are now done: the suite is
-# 653 tests at 95.5% lines / 83.9% functions, over its own 80/80/80/80
-# thresholds in vite.config.ts, and lcov is produced above.
+# the exclusion to sonar.coverage.exclusions". Both are now done: the suite
+# enforces its own 80/80/80/80 thresholds in vite.config.ts and lcov is produced
+# above. It stood at 687 tests, 95.8% lines / 85.1% functions on 2026-09-06 —
+# a snapshot, not a gate; vite.config.ts is what actually holds the floor.
 #
 # The vendored half is excluded from COVERAGE only, not from analysis: it is
 # generated shadcn/ui that is never edited here, so testing it would measure the

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -9,14 +9,24 @@ sonar.tests=tests
 sonar.python.version=3.11
 
 sonar.python.coverage.reportPaths=coverage.xml
+sonar.javascript.lcov.reportPaths=src/frontend-react/coverage/lcov.info
 sonar.sourceEncoding=UTF-8
 
-# src/frontend-react is excluded from analysis for now: it has no test harness
-# yet (every TSX line counts as uncovered "new code" and fails the >=80% gate),
-# and half of it is vendored shadcn/ui components that trigger noise hotspots.
-# When a frontend test harness (vitest) lands, re-include it and move the
-# exclusion to sonar.coverage.exclusions so the code is analyzed again.
-sonar.exclusions=**/venv/**,**/__pycache__/**,**/node_modules/**,src/frontend-react/**
+# src/frontend-react WAS excluded from analysis entirely, on the grounds that it
+# had no test harness (every TSX line counted as uncovered "new code" and failed
+# the >=80% gate) and that half of it is vendored shadcn/ui. The note left here
+# said to re-include it "when a frontend test harness (vitest) lands, and move
+# the exclusion to sonar.coverage.exclusions". Both are now done: the suite is
+# 653 tests at 95.5% lines / 83.9% functions, over its own 80/80/80/80
+# thresholds in vite.config.ts, and lcov is produced above.
+#
+# The vendored half is excluded from COVERAGE only, not from analysis: it is
+# generated shadcn/ui that is never edited here, so testing it would measure the
+# upstream project - but Sonar should still report defects in it, because it
+# ships to users either way.
+sonar.exclusions=**/venv/**,**/__pycache__/**,**/node_modules/**,src/frontend-react/dist/**,src/frontend-react/coverage/**
+sonar.coverage.exclusions=src/frontend-react/src/components/ui/**,src/frontend-react/src/main.tsx,src/frontend-react/**/*.d.ts,src/frontend-react/src/test/**
+sonar.test.inclusions=**/*.test.ts,**/*.test.tsx
 sonar.test.exclusions=**/venv/**
 
 # python:S5443 ("publicly writable directory") fires on the "/tmp" literal in

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -27,8 +27,13 @@ sonar.sourceEncoding=UTF-8
 # generated shadcn/ui that is never edited here, so testing it would measure the
 # upstream project - but Sonar should still report defects in it, because it
 # ships to users either way.
+#
+# scripts/** is CI tooling, not shipped product, excluded on exactly the same
+# principle as main.tsx and test/** above - measured coverage would be
+# meaningless for a script that runs after the test run that produces the
+# coverage.
 sonar.exclusions=**/venv/**,**/__pycache__/**,**/node_modules/**,src/frontend-react/dist/**,src/frontend-react/coverage/**
-sonar.coverage.exclusions=src/frontend-react/src/components/ui/**,src/frontend-react/src/main.tsx,src/frontend-react/**/*.d.ts,src/frontend-react/src/test/**
+sonar.coverage.exclusions=src/frontend-react/src/components/ui/**,src/frontend-react/src/main.tsx,src/frontend-react/**/*.d.ts,src/frontend-react/src/test/**,src/frontend-react/scripts/**
 # sonar.test.inclusions NARROWS sonar.tests - it does not add to it - and a
 # file it matches is never indexed as source either. So `**/*.test.ts,**/*.test
 # .tsx` on its own did two wrong things at once: it filtered the whole tests/

--- a/src/backend/api/endpoints.py
+++ b/src/backend/api/endpoints.py
@@ -625,14 +625,18 @@ async def get_run_corrections(run_id: str, response: Response,
             engine.get_corrections_for_run, target_id)
 
     # Explicit projection, field by field — never the row dict with keys
-    # deleted. org_id, created_by_user_id and is_active ride along on each
-    # row only to compute can_retract; building the response any other way
-    # would let a future column added to that SELECT leak to the client
-    # silently. can_retract surfaces the Author tier: the feedback panel is
-    # the only place a plain org member ever sees their own hint text
-    # (list_hints and get_hint stay gated on is_dashboard_viewer), so it is
-    # also the only place they can be offered a control to act on it — the
-    # client never decides this, it only draws what the server permits.
+    # deleted. org_id and created_by_user_id ride along on each row only to
+    # compute can_retract; building the response any other way would let a
+    # future column added to that SELECT leak to the client silently.
+    # is_active rides along for the same can_retract computation, but it is
+    # also safe to forward as active: the caller already reads the hint's
+    # own text, and the backend already discloses the same state in the
+    # hint_inactive message. can_retract surfaces the Author tier: the
+    # feedback panel is the only place a plain org member ever sees their
+    # own hint text (list_hints and get_hint stay gated on
+    # is_dashboard_viewer), so it is also the only place they can be offered
+    # a control to act on it — the client never decides this, it only draws
+    # what the server permits.
     #
     # can_retract is an OFFER of an action, not just a permission check, so
     # it is not hint_mutation_verdict alone. get_corrections_for_run stays
@@ -649,6 +653,7 @@ async def get_run_corrections(run_id: str, response: Response,
             "hint_id": c.get("hint_id"),
             "feedback_text": c.get("feedback_text"),
             "recorded_at": c.get("recorded_at"),
+            "active": bool(c.get("is_active")),
             "can_retract": (
                 # user is not None FIRST, mirroring _require_caller: this
                 # route family does not honour the AUTH_ENFORCED-off escape

--- a/src/backend/crew_ai/optimization/nl_feedback_engine.py
+++ b/src/backend/crew_ai/optimization/nl_feedback_engine.py
@@ -814,13 +814,17 @@ class NLFeedbackEngine(LearningEngine):
         this task removes. What the LLM thought of it is not exposed here;
         that is a product decision, not a UI one.
 
-        THREE of the columns selected are permission inputs, not content:
-        org_id, created_by_user_id and is_active exist only so the API layer
-        can compute can_retract (hint_mutation_verdict AND still-active). They
-        must NEVER be forwarded to a client — api/endpoints.get_run_corrections
-        builds an explicit four-field projection rather than passing these rows
-        through, precisely so a column added here cannot leak by default. Add a
-        column to this SELECT only with that projection in mind.
+        TWO of the columns selected are permission inputs, not content: org_id
+        and created_by_user_id exist only so the API layer can compute
+        can_retract (hint_mutation_verdict AND still-active). They must NEVER
+        be forwarded to a client — api/endpoints.get_run_corrections builds an
+        explicit five-field projection rather than passing these rows through,
+        precisely so a column added here cannot leak by default. is_active is
+        also read here for that same can_retract computation, but it is no
+        longer permission-only: it is now forwarded as active too, because the
+        caller already reads the hint's text and hint_inactive already
+        discloses the same state on submission. Add a column to this SELECT
+        only with that projection in mind.
 
         Uncapped on purpose: every row here was typed by a human against this
         one run, and a silent LIMIT would under-report a user's own history.

--- a/src/frontend-react/package-lock.json
+++ b/src/frontend-react/package-lock.json
@@ -39,6 +39,7 @@
         "@types/react": "^18.3.11",
         "@types/react-dom": "^18.3.1",
         "@vitejs/plugin-react": "^4.3.3",
+        "@vitest/coverage-v8": "^2.1.9",
         "autoprefixer": "^10.4.20",
         "jsdom": "^25.0.1",
         "postcss": "^8.4.47",
@@ -65,6 +66,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@ampproject/remapping": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
+      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/@asamuzakjp/css-color": {
@@ -379,6 +394,13 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
+      "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@csstools/color-helpers": {
       "version": "5.1.0",
@@ -951,6 +973,34 @@
         "url": "https://github.com/sponsors/ayuhito"
       }
     },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.6.tgz",
+      "integrity": "sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -1030,6 +1080,17 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@radix-ui/number": {
@@ -2515,6 +2576,39 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-2.1.9.tgz",
+      "integrity": "sha512-Z2cOr0ksM00MpEfyVE8KXIYPEcBFxdbLSs56L8PO0QQMxt/6bDj45uQfxoc96v05KW3clk7vvgP0qfDit9DmfQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ampproject/remapping": "^2.3.0",
+        "@bcoe/v8-coverage": "^0.2.3",
+        "debug": "^4.3.7",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-lib-source-maps": "^5.0.6",
+        "istanbul-reports": "^3.1.7",
+        "magic-string": "^0.30.12",
+        "magicast": "^0.3.5",
+        "std-env": "^3.8.0",
+        "test-exclude": "^7.0.1",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "2.1.9",
+        "vitest": "2.1.9"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@vitest/expect": {
       "version": "2.1.9",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
@@ -2644,7 +2738,6 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -2764,6 +2857,16 @@
         "postcss": "^8.1.0"
       }
     },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.34",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.34.tgz",
@@ -2787,6 +2890,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/braces": {
@@ -2973,6 +3089,26 @@
         "node": ">=6"
       }
     },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/combined-stream": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
@@ -3001,6 +3137,21 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
     },
     "node_modules/css.escape": {
       "version": "1.5.1",
@@ -3286,12 +3437,26 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.368",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.368.tgz",
       "integrity": "sha512-7RckJJK4uESJF9PxvfMWd3TGqIiieUTG4HxnKaKuIpGbcr+r2ZEB3g2gAhCP3Fqm42vJSzLfgab9eva/C4/XVw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/entities": {
       "version": "6.0.1",
@@ -3495,6 +3660,23 @@
         "node": ">=8"
       }
     },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/form-data": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
@@ -3607,6 +3789,28 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/glob-parent": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -3617,6 +3821,39 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/glob/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/gopd": {
@@ -3630,6 +3867,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/has-symbols": {
@@ -3685,6 +3932,13 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/http-proxy-agent": {
       "version": "7.0.2",
@@ -3792,6 +4046,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-glob": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
@@ -3819,6 +4083,83 @@
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz",
+      "integrity": "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.23",
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
     },
     "node_modules/jiti": {
       "version": "1.21.7",
@@ -3979,6 +4320,47 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
+    "node_modules/magicast": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.3.5.tgz",
+      "integrity": "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.25.4",
+        "@babel/types": "^7.25.4",
+        "source-map-js": "^1.2.0"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/make-dir/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -4042,6 +4424,32 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.8"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/ms": {
@@ -4124,6 +4532,13 @@
         "node": ">= 6"
       }
     },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0"
+    },
     "node_modules/parse5": {
       "version": "7.3.0",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
@@ -4137,11 +4552,45 @@
         "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/path-parse": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "license": "MIT"
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-scurry/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/pathe": {
       "version": "1.1.2",
@@ -4822,12 +5271,48 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/siginfo": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
       "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",
@@ -4851,6 +5336,103 @@
       "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/string-width-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi/node_modules/ansi-regex": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.3.0.tgz",
+      "integrity": "sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
     },
     "node_modules/strip-indent": {
       "version": "3.0.0",
@@ -4885,6 +5467,19 @@
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/supports-preserve-symlinks-flag": {
@@ -4960,6 +5555,21 @@
       "license": "MIT",
       "peerDependencies": {
         "tailwindcss": ">=3.0.0 || insiders"
+      }
+    },
+    "node_modules/test-exclude": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.2.tgz",
+      "integrity": "sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^10.4.1",
+        "minimatch": "^10.2.2"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/thenify": {
@@ -5483,6 +6093,22 @@
         "node": ">=18"
       }
     },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/why-is-node-running": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
@@ -5498,6 +6124,107 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/ws": {

--- a/src/frontend-react/package.json
+++ b/src/frontend-react/package.json
@@ -41,6 +41,7 @@
     "@types/react": "^18.3.11",
     "@types/react-dom": "^18.3.1",
     "@vitejs/plugin-react": "^4.3.3",
+    "@vitest/coverage-v8": "^2.1.9",
     "autoprefixer": "^10.4.20",
     "jsdom": "^25.0.1",
     "postcss": "^8.4.47",

--- a/src/frontend-react/package.json
+++ b/src/frontend-react/package.json
@@ -7,7 +7,7 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "test": "vitest run",
-    "test:coverage": "vitest run --coverage",
+    "test:coverage": "vitest run --coverage && node scripts/assert-coverage-not-empty.mjs",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/src/frontend-react/package.json
+++ b/src/frontend-react/package.json
@@ -7,6 +7,7 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "test": "vitest run",
+    "test:coverage": "vitest run --coverage",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/src/frontend-react/scripts/assert-coverage-not-empty.mjs
+++ b/src/frontend-react/scripts/assert-coverage-not-empty.mjs
@@ -1,0 +1,103 @@
+// Guards against a silently empty coverage map.
+//
+// `coverage.include` in vite.config.ts can be edited into matching nothing
+// (a typo'd extension, a moved directory) and vitest still exits 0: it just
+// reports "All files | 0 | 0 | 0 | 0" and every threshold trivially "passes"
+// because there is nothing to fail it against. `npm run test:coverage` would
+// then be green in CI while measuring zero files. This script reads the
+// json-summary reporter's output (vite.config.ts's coverage.reporter, added
+// for exactly this purpose - see its comment) and fails loudly whenever the
+// map is empty, too small to be believable, or the totals are not real
+// numbers.
+//
+// Referenced by: package.json's `test:coverage` script (chained with `&&`).
+// Depends on: coverage/coverage-summary.json, produced by the `json-summary`
+// vitest coverage reporter. Nothing else reads this file.
+
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+// Resolved relative to this script's own location (not process.cwd()) so the
+// check works whether invoked from src/frontend-react or anywhere else.
+const SUMMARY_PATH = path.resolve(__dirname, '..', 'coverage', 'coverage-summary.json');
+
+// A gross-collapse tripwire, not a coverage target. The real count is 41 as
+// of 2026-09-06; 20 leaves deliberate headroom for refactors that legitimately
+// shrink the file list, while still catching an `include` pattern that
+// matches nothing (or nearly nothing).
+const MIN_COVERED_FILES = 20;
+
+// The four metrics vite.config.ts actually gates on (coverage.thresholds).
+// branchesTrue is deliberately NOT checked here: a healthy report legitimately
+// carries `branchesTrue: {total: 0, covered: 0, pct: 100}`, so checking it
+// would fail every good run.
+const GATED_METRICS = ['lines', 'statements', 'functions', 'branches'];
+
+function fail(message) {
+  console.error(`assert-coverage-not-empty: ${message}`);
+  process.exit(1);
+}
+
+let raw;
+try {
+  raw = readFileSync(SUMMARY_PATH, 'utf-8');
+} catch {
+  fail(
+    `${SUMMARY_PATH} does not exist. Check that vite.config.ts's ` +
+      "coverage.reporter still includes 'json-summary' and that vitest ran " +
+      'with --coverage.'
+  );
+}
+
+let summary;
+try {
+  summary = JSON.parse(raw);
+} catch (err) {
+  fail(`${SUMMARY_PATH} is not valid JSON (${err.message}).`);
+}
+
+const fileEntries = Object.keys(summary).filter((key) => key !== 'total');
+
+if (fileEntries.length === 0) {
+  fail(
+    'coverage-summary.json has zero file entries. This usually means ' +
+      "vite.config.ts's coverage.include matches no source file - check " +
+      'that pattern and the include/exclude globs against src/.'
+  );
+}
+
+if (fileEntries.length < MIN_COVERED_FILES) {
+  fail(
+    `coverage-summary.json only covers ${fileEntries.length} file(s), below ` +
+      `MIN_COVERED_FILES=${MIN_COVERED_FILES}. Check vite.config.ts's ` +
+      'coverage.include/exclude globs for an accidental narrowing.'
+  );
+}
+
+const total = summary.total ?? {};
+
+if (!(typeof total.lines?.total === 'number' && total.lines.total > 0)) {
+  fail(
+    'coverage-summary.json total.lines.total is not greater than 0 - no ' +
+      'lines were measured. Check coverage.include in vite.config.ts.'
+  );
+}
+
+for (const metric of GATED_METRICS) {
+  const pct = total[metric]?.pct;
+  if (!Number.isFinite(pct)) {
+    fail(
+      `coverage-summary.json total.${metric}.pct is not a finite number ` +
+        `(got ${JSON.stringify(pct)}). Check coverage.include in ` +
+        'vite.config.ts and that vitest ran with --coverage.'
+    );
+  }
+}
+
+console.log(
+  `assert-coverage-not-empty: OK - ${fileEntries.length} file(s) covered, ` +
+    `total.lines.total=${total.lines.total}`
+);

--- a/src/frontend-react/scripts/assert-coverage-not-empty.mjs
+++ b/src/frontend-react/scripts/assert-coverage-not-empty.mjs
@@ -44,9 +44,9 @@ function fail(message) {
 let raw;
 try {
   raw = readFileSync(SUMMARY_PATH, 'utf-8');
-} catch {
+} catch (err) {
   fail(
-    `${SUMMARY_PATH} does not exist. Check that vite.config.ts's ` +
+    `${SUMMARY_PATH} does not exist (${err.code}). Check that vite.config.ts's ` +
       "coverage.reporter still includes 'json-summary' and that vitest ran " +
       'with --coverage.'
   );
@@ -57,6 +57,14 @@ try {
   summary = JSON.parse(raw);
 } catch (err) {
   fail(`${SUMMARY_PATH} is not valid JSON (${err.message}).`);
+}
+
+if (summary === null || typeof summary !== 'object') {
+  fail(
+    `${SUMMARY_PATH} parsed to ${JSON.stringify(summary)}, not an object. ` +
+      "Check that vite.config.ts's coverage.reporter still includes " +
+      "'json-summary' and that vitest ran with --coverage."
+  );
 }
 
 const fileEntries = Object.keys(summary).filter((key) => key !== 'total');

--- a/src/frontend-react/src/App.test.tsx
+++ b/src/frontend-react/src/App.test.tsx
@@ -1,22 +1,230 @@
 /**
- * App — PAGES gating for /learning (Task T6).
+ * App.tsx — KeepAlivePages is the authorisation boundary between a page and
+ * the roles allowed to reach it. Every entry in PAGES carries its own gate
+ * (admin / orgAdmin / viewLearning), and KeepAlivePages is the ONLY place that
+ * turns a gate into "mount the page" or "bounce to /generate" — there is no
+ * per-route guard left (see auth/guards.tsx's own docstring, which documents
+ * the move). A caller who fails a page's gate must never see that page by
+ * navigating straight to its path, and a page already mounted must unmount
+ * the instant its caller's flags stop satisfying the gate (a session demoted
+ * mid-flight), rather than linger hidden and keep firing background requests
+ * — both are called out explicitly in App.tsx's own comments.
  *
- * The API gates the Learning routes on is_dashboard_viewer (org admin or
- * platform admin); the SPA used to gate /learning on the platform `admin`
- * role only, stranding an org admin behind a page the server would happily
- * serve. gateAllowed (auth/pageGates.ts) is the pure predicate
- * KeepAlivePages uses to decide which page mounts (and to redirect to
- * /generate otherwise) — shared with app-sidebar.test.tsx, which exercises
- * the same predicate against NAV_PLATFORM, so this is testable without
- * rendering App. Most of this package still tests predicates and
- * sub-components rather than pages (see FeedbackPanel.test.tsx);
- * LearningPage.test.tsx is the deliberate exception, where mounting the page
- * is the point (vite.config.ts).
+ * The gate values below (admin/orgAdmin/viewLearning per path) are pinned by
+ * hand from PAGES, not read from the PAGES export itself — reading them back
+ * from the same table the code under test consults would make an
+ * authorisation weakening invisible (drop `admin: true` from an entry and a
+ * test that re-derives its expectation from that same entry "passes" the
+ * weakened version too). gateAllowed is imported for real, though: it is a
+ * separately-tested pure predicate shared by design (pageGates.ts), and using
+ * it as the oracle here tests whether KeepAlivePages actually WIRES UP the
+ * gate table correctly, not whether gateAllowed's own boolean logic is right.
+ *
+ * Every real page component is replaced by a one-line stub: this file tests
+ * ONLY the PAGES table + KeepAlivePages wiring, not GeneratePage, HistoryPage,
+ * etc, which have their own test files (and their own API calls, which would
+ * otherwise fire for real here).
  */
-import { describe, expect, it } from 'vitest'
-import { PAGES } from './App'
-import { gateAllowed } from '@/auth/pageGates'
+import { fireEvent, render, screen } from '@testing-library/react'
+import { Link } from 'react-router-dom'
+import type { ReactNode } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+vi.mock('@/auth/AuthContext', () => ({
+  AuthProvider: ({ children }: { children: ReactNode }) => children,
+  useAuth: vi.fn(),
+}))
+vi.mock('@/components/history/RunGroupsContext', () => ({
+  RunGroupsProvider: ({ children }: { children: ReactNode }) => children,
+}))
+vi.mock('@/components/app-sidebar', () => ({ AppSidebar: () => <span>SIDEBAR_STUB</span> }))
+vi.mock('@/components/app-header', () => ({ AppHeader: () => <span>HEADER_STUB</span> }))
+
+vi.mock('@/pages/GeneratePage', () => ({
+  default: () => (
+    <>
+      <span>GENERATE_PAGE</span>
+      <Link to="/metrics">nav-metrics</Link>
+    </>
+  ),
+}))
+vi.mock('@/pages/HistoryPage', () => ({ default: () => <span>HISTORY_PAGE</span> }))
+vi.mock('@/pages/MetricsPage', () => ({
+  default: () => (
+    <>
+      <span>METRICS_PAGE</span>
+      <Link to="/generate">nav-generate</Link>
+    </>
+  ),
+}))
+vi.mock('@/pages/LearningPage', () => ({ default: () => <span>LEARNING_PAGE</span> }))
+vi.mock('@/pages/SettingsPage', () => ({ default: () => <span>SETTINGS_PAGE</span> }))
+vi.mock('@/pages/AccessConsolePage', () => ({ default: () => <span>ACCESS_PAGE</span> }))
+vi.mock('@/pages/TeamPage', () => ({ default: () => <span>TEAM_PAGE</span> }))
+vi.mock('@/pages/AccessGatePage', () => ({ default: () => <span>ACCESS_GATE_PAGE</span> }))
+vi.mock('@/pages/auth/LoginPage', () => ({ default: () => <span>LOGIN_PAGE</span> }))
+vi.mock('@/pages/auth/SignupPage', () => ({ default: () => <span>SIGNUP_PAGE</span> }))
+vi.mock('@/pages/auth/ForgotPasswordPage', () => ({ default: () => <span>FORGOT_PAGE</span> }))
+vi.mock('@/auth/OAuthCallback', () => ({ default: () => <span>OAUTH_PAGE</span> }))
+
+import { useAuth } from '@/auth/AuthContext'
+import { gateAllowed, type Gate, type GateFlags } from '@/auth/pageGates'
+import App, { PAGES } from './App'
+
+const mockUseAuth = vi.mocked(useAuth)
+
+// The REAL ThemeProvider and SidebarProvider both run inside App() (only the
+// PAGE components and app-sidebar/app-header are stubbed), and both read
+// window.matchMedia via a useEffect. setup.ts installs a working stub once
+// per FILE, but this file's own afterEach(vi.resetAllMocks) strips that
+// stub's implementation after the first test (resetAllMocks resets every
+// vi.fn(), including that one) — so every test after the first would
+// otherwise call matchMedia() and get back undefined. Re-install per test.
+beforeEach(() => {
+  window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+    matches: false, media: query, onchange: null,
+    addEventListener: vi.fn(), removeEventListener: vi.fn(),
+    addListener: vi.fn(), removeListener: vi.fn(), dispatchEvent: vi.fn(),
+  }))
+})
+afterEach(() => vi.resetAllMocks())
+
+function setAuth(flags: GateFlags) {
+  mockUseAuth.mockReturnValue({
+    user: { id: 'u1', email: 'a@b.com', display_name: 'A', role: flags.isAdmin ? 'admin' : 'user', status: 'active' },
+    loading: false, isAuthenticated: true, status: 'active',
+    ...flags,
+    login: vi.fn(), signup: vi.fn(), loginWithToken: vi.fn(), logout: vi.fn(), logoutAll: vi.fn(),
+  } as unknown as ReturnType<typeof useAuth>)
+}
+
+function renderAt(path: string) {
+  window.history.pushState({}, '', path)
+  return render(<App />)
+}
+
+const PLAIN: GateFlags = { isAdmin: false, isOrgAdmin: false, canViewLearning: false }
+const ADMIN: GateFlags = { isAdmin: true, isOrgAdmin: false, canViewLearning: false }
+const ORG_ADMIN: GateFlags = { isAdmin: false, isOrgAdmin: true, canViewLearning: false }
+const LEARNING_VIEWER: GateFlags = { isAdmin: false, isOrgAdmin: false, canViewLearning: true }
+
+const ROLES: Array<{ name: string; flags: GateFlags }> = [
+  { name: 'plain user', flags: PLAIN },
+  { name: 'platform admin', flags: ADMIN },
+  { name: 'org admin', flags: ORG_ADMIN },
+  { name: 'learning viewer', flags: LEARNING_VIEWER },
+]
+
+const PAGE_CASES: Array<{ path: string; marker: string; gate: Gate }> = [
+  { path: '/generate', marker: 'GENERATE_PAGE', gate: {} },
+  { path: '/history', marker: 'HISTORY_PAGE', gate: {} },
+  { path: '/metrics', marker: 'METRICS_PAGE', gate: { admin: true } },
+  { path: '/learning', marker: 'LEARNING_PAGE', gate: { viewLearning: true } },
+  { path: '/access', marker: 'ACCESS_PAGE', gate: { admin: true } },
+  { path: '/settings', marker: 'SETTINGS_PAGE', gate: { admin: true } },
+  { path: '/team', marker: 'TEAM_PAGE', gate: { orgAdmin: true } },
+]
+
+describe('KeepAlivePages — the gate table, every page x every role', () => {
+  for (const { path, marker, gate } of PAGE_CASES) {
+    describe(path, () => {
+      for (const { name, flags } of ROLES) {
+        const expected = gateAllowed(gate, flags)
+        it(`${expected ? 'renders the page' : 'redirects to /generate instead of rendering'} for a ${name}`, () => {
+          setAuth(flags)
+          renderAt(path)
+
+          if (expected) {
+            expect(screen.getByText(marker)).toBeInTheDocument()
+          } else {
+            expect(screen.queryByText(marker)).toBeNull()
+            expect(screen.getByText('GENERATE_PAGE')).toBeInTheDocument()
+          }
+        })
+      }
+    })
+  }
+})
+
+describe('KeepAlivePages — keep-alive across navigation', () => {
+  it('keeps a visited page mounted (hidden, not destroyed) after navigating away from it', () => {
+    setAuth(ADMIN)
+    renderAt('/metrics')
+    expect(screen.getByText('METRICS_PAGE')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByText('nav-generate'))
+
+    // Both pages are still in the DOM...
+    expect(screen.getByText('METRICS_PAGE')).toBeInTheDocument()
+    expect(screen.getByText('GENERATE_PAGE')).toBeInTheDocument()
+    // ...but only the active one gets the visible className; the visited,
+    // no-longer-active one gets the plain 'hidden' branch of the ternary.
+    expect(screen.getByText('METRICS_PAGE').parentElement!.className).toBe('hidden')
+    expect(screen.getByText('GENERATE_PAGE').parentElement!.className).toBe('flex flex-1 flex-col')
+  })
+})
+
+describe('GatedLayout — the access-status gate above KeepAlivePages', () => {
+  it('shows the access gate instead of any page when the caller is not active', () => {
+    // A DIFFERENT gate than KeepAlivePages' role check (pending/suspended/
+    // rejected accounts), sitting directly above it — pinned here since it is
+    // in the same file and decides whether KeepAlivePages ever runs at all.
+    mockUseAuth.mockReturnValue({
+      user: { id: 'u1', email: 'a@b.com', display_name: 'A', role: 'user', status: 'pending' },
+      loading: false, isAuthenticated: true, status: 'pending',
+      isAdmin: false, isOrgAdmin: false, canViewLearning: false,
+      login: vi.fn(), signup: vi.fn(), loginWithToken: vi.fn(), logout: vi.fn(), logoutAll: vi.fn(),
+    } as unknown as ReturnType<typeof useAuth>)
+
+    renderAt('/generate')
+
+    expect(screen.getByText('ACCESS_GATE_PAGE')).toBeInTheDocument()
+    expect(screen.queryByText('GENERATE_PAGE')).toBeNull()
+  })
+})
+
+describe('KeepAlivePages — demotion mid-flight', () => {
+  it('unmounts an already-visited admin page the instant the caller stops being admin, even while merely hidden (not the active path)', () => {
+    setAuth(ADMIN)
+    const { rerender } = renderAt('/metrics')
+    expect(screen.getByText('METRICS_PAGE')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByText('nav-generate'))
+    expect(screen.getByText('METRICS_PAGE').parentElement!.className).toBe('hidden')
+
+    setAuth(PLAIN)
+    rerender(<App />)
+
+    // Re-checked on every render, per App.tsx's own comment: a hidden admin
+    // page must disappear entirely once demoted, not linger with
+    // now-forbidden background requests still possible.
+    expect(screen.queryByText('METRICS_PAGE')).toBeNull()
+    expect(screen.getByText('GENERATE_PAGE')).toBeInTheDocument()
+  })
+
+  it('redirects away immediately when the currently ACTIVE page itself is demoted', () => {
+    setAuth(ADMIN)
+    const { rerender } = renderAt('/metrics')
+    expect(screen.getByText('METRICS_PAGE')).toBeInTheDocument()
+
+    setAuth(PLAIN)
+    rerender(<App />)
+
+    expect(screen.queryByText('METRICS_PAGE')).toBeNull()
+    expect(screen.getByText('GENERATE_PAGE')).toBeInTheDocument()
+  })
+})
+
+// --- Preserved from this file's previous version (Task T6) ---
+//
+// These inspect the REAL PAGES export directly (not the hand-pinned gate
+// literals PAGE_CASES above uses) and pin the exact historical regression:
+// the SPA used to gate /learning on the platform `admin` role only, even
+// though the API gates the Learning routes on is_dashboard_viewer (org admin
+// OR platform admin), stranding an org admin behind a page the server would
+// happily serve. Kept verbatim rather than dropped, since the table-driven
+// suite above pins the CURRENT contract but does not, by itself, document
+// which specific historical bug that contract was fixed for.
 const learningPage = PAGES.find(p => p.path === '/learning')!
 const metricsPage = PAGES.find(p => p.path === '/metrics')!
 

--- a/src/frontend-react/src/auth/OAuthCallback.test.tsx
+++ b/src/frontend-react/src/auth/OAuthCallback.test.tsx
@@ -1,0 +1,123 @@
+/**
+ * OAuthCallback — the Google OAuth landing route. The token lives only in the
+ * URL fragment (#token=...), is read once, exchanged via loginWithToken, and
+ * the fragment is stripped immediately so it never lingers in history. Its
+ * own comment says StrictMode double-invokes the effect in dev, and that the
+ * SECOND invocation would see the already-stripped hash and flash a spurious
+ * "token missing" error — the `ranOnce` ref guard exists so that second
+ * invocation is a no-op instead. A guard that only works when nobody looks is
+ * not a guard, so both the StrictMode path and a plain single invocation are
+ * pinned here.
+ */
+import { render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { StrictMode } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mockNavigate = vi.fn()
+vi.mock('react-router-dom', async importOriginal => ({
+  ...(await importOriginal<typeof import('react-router-dom')>()),
+  useNavigate: () => mockNavigate,
+}))
+vi.mock('./AuthContext', () => ({ useAuth: vi.fn() }))
+
+import { useAuth } from './AuthContext'
+import OAuthCallback from './OAuthCallback'
+
+const mockUseAuth = vi.mocked(useAuth)
+
+beforeEach(() => {
+  // Clean baseline before every test: no leftover hash from a previous case.
+  window.history.pushState({}, '', '/oauth/callback')
+})
+afterEach(() => vi.resetAllMocks())
+
+function setAuth(loginWithToken: (token: string) => Promise<void>) {
+  mockUseAuth.mockReturnValue({
+    user: null, loading: false, isAuthenticated: false, isAdmin: false, status: null,
+    isOrgAdmin: false, canViewLearning: false,
+    login: vi.fn(), signup: vi.fn(), loginWithToken,
+    logout: vi.fn(), logoutAll: vi.fn(),
+  } as unknown as ReturnType<typeof useAuth>)
+}
+
+function renderCallback(strict: boolean) {
+  const tree = (
+    <MemoryRouter>
+      <OAuthCallback />
+    </MemoryRouter>
+  )
+  return render(strict ? <StrictMode>{tree}</StrictMode> : tree)
+}
+
+describe('OAuthCallback — the StrictMode double-invocation guard', () => {
+  it('never flashes "token missing" from a second StrictMode invocation reading the already-stripped hash', async () => {
+    window.history.pushState({}, '', '/oauth/callback#token=abc123')
+    const loginWithToken = vi.fn().mockResolvedValue(undefined)
+    setAuth(loginWithToken)
+
+    renderCallback(true)
+
+    await waitFor(() => expect(mockNavigate).toHaveBeenCalledWith('/generate', { replace: true }))
+    expect(loginWithToken).toHaveBeenCalledTimes(1)
+    expect(loginWithToken).toHaveBeenCalledWith('abc123')
+    // Without the ranOnce guard, the second invocation re-reads the hash
+    // (already stripped by the first) and sets this error — pin that it never
+    // does, which is the actual bug the guard prevents (NOT a double call to
+    // loginWithToken: the second invocation takes the "no token" branch, it
+    // does not re-invoke login — verified empirically, see the task report).
+    expect(screen.queryByText('Sign-in token missing from the callback.')).toBeNull()
+  })
+
+  it('still exchanges the token correctly on a single (non-StrictMode) invocation', async () => {
+    window.history.pushState({}, '', '/oauth/callback#token=xyz789')
+    const loginWithToken = vi.fn().mockResolvedValue(undefined)
+    setAuth(loginWithToken)
+
+    renderCallback(false)
+
+    await waitFor(() => expect(mockNavigate).toHaveBeenCalledWith('/generate', { replace: true }))
+    expect(loginWithToken).toHaveBeenCalledTimes(1)
+    expect(loginWithToken).toHaveBeenCalledWith('xyz789')
+  })
+})
+
+describe('OAuthCallback — reading the token', () => {
+  it('strips the fragment from the address bar immediately, before the async exchange resolves', async () => {
+    window.history.pushState({}, '', '/oauth/callback#token=stripme')
+    let resolveLogin!: () => void
+    const loginWithToken = vi.fn(() => new Promise<void>(resolve => { resolveLogin = resolve }))
+    setAuth(loginWithToken)
+
+    renderCallback(false)
+
+    // Assert BEFORE resolving: stripping happens synchronously in the
+    // effect, not after the network call settles.
+    expect(window.location.hash).toBe('')
+
+    resolveLogin()
+    await waitFor(() => expect(mockNavigate).toHaveBeenCalledWith('/generate', { replace: true }))
+  })
+
+  it('shows an error and never calls loginWithToken when the fragment has no token', async () => {
+    // beforeEach already set a bare pathname with no hash.
+    const loginWithToken = vi.fn()
+    setAuth(loginWithToken)
+
+    renderCallback(false)
+
+    expect(await screen.findByText('Sign-in token missing from the callback.')).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'Back to sign in' })).toBeInTheDocument()
+    expect(loginWithToken).not.toHaveBeenCalled()
+  })
+
+  it('shows a generic error when the exchange rejects', async () => {
+    window.history.pushState({}, '', '/oauth/callback#token=bad')
+    setAuth(() => Promise.reject(new Error('network down')))
+
+    renderCallback(false)
+
+    expect(await screen.findByText('Could not complete sign-in. Please try again.')).toBeInTheDocument()
+    expect(mockNavigate).not.toHaveBeenCalled()
+  })
+})

--- a/src/frontend-react/src/auth/guards.test.tsx
+++ b/src/frontend-react/src/auth/guards.test.tsx
@@ -1,0 +1,86 @@
+/**
+ * RequireAuth — the route guard between an unauthenticated visitor and every
+ * page behind it.
+ *
+ * The `loading` branch is the one worth pinning. Without it a reload bounces
+ * to /login before /auth/me has answered, and the user loses whatever page
+ * they had open even though their session is perfectly valid. Two of these
+ * tests exist purely to hold that branch in place, because "if (loading)
+ * return spinner" reads like a cosmetic nicety and is not one.
+ */
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('./AuthContext', () => ({ useAuth: vi.fn() }))
+
+import { useAuth } from './AuthContext'
+import { RequireAuth } from './guards'
+
+const mockUseAuth = vi.mocked(useAuth)
+afterEach(() => vi.resetAllMocks())
+
+type AuthShape = { isAuthenticated: boolean; loading: boolean }
+
+function setAuth({ isAuthenticated, loading }: AuthShape) {
+  mockUseAuth.mockReturnValue({
+    user: isAuthenticated ? { id: 'u', email: 'a@b.com', display_name: 'A', role: 'user', status: 'active' } : null,
+    loading, isAuthenticated, isAdmin: false, status: isAuthenticated ? 'active' : null,
+    isOrgAdmin: false, canViewLearning: false,
+    login: vi.fn(), signup: vi.fn(), loginWithToken: vi.fn(), logout: vi.fn(), logoutAll: vi.fn(),
+  } as unknown as ReturnType<typeof useAuth>)
+}
+
+function renderAt(path: string) {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <Routes>
+        <Route path="/login" element={<p>LOGIN PAGE</p>} />
+        <Route path="/secret" element={<RequireAuth><p>SECRET CONTENT</p></RequireAuth>} />
+      </Routes>
+    </MemoryRouter>,
+  )
+}
+
+describe('RequireAuth', () => {
+  it('renders the guarded page for an authenticated caller', () => {
+    setAuth({ isAuthenticated: true, loading: false })
+
+    renderAt('/secret')
+
+    expect(screen.getByText('SECRET CONTENT')).toBeInTheDocument()
+  })
+
+  it('redirects an unauthenticated caller to /login', () => {
+    setAuth({ isAuthenticated: false, loading: false })
+
+    renderAt('/secret')
+
+    expect(screen.getByText('LOGIN PAGE')).toBeInTheDocument()
+    expect(screen.queryByText('SECRET CONTENT')).toBeNull()
+  })
+
+  it('shows a spinner while the session is still hydrating — it does NOT bounce to login', () => {
+    // The reload case. isAuthenticated is false here only because /auth/me has
+    // not answered yet; redirecting on it would sign out every user who
+    // pressed F5.
+    setAuth({ isAuthenticated: false, loading: true })
+
+    renderAt('/secret')
+
+    expect(screen.queryByText('LOGIN PAGE')).toBeNull()
+    expect(screen.queryByText('SECRET CONTENT')).toBeNull()
+    expect(document.querySelector('.animate-spin')).not.toBeNull()
+  })
+
+  it('waits even when the session will turn out to be valid', () => {
+    setAuth({ isAuthenticated: true, loading: true })
+
+    renderAt('/secret')
+
+    // loading wins over isAuthenticated: the guard commits to nothing until
+    // hydration settles, so there is no flash of content either way.
+    expect(screen.queryByText('SECRET CONTENT')).toBeNull()
+    expect(document.querySelector('.animate-spin')).not.toBeNull()
+  })
+})

--- a/src/frontend-react/src/components/RecordedCorrections.test.tsx
+++ b/src/frontend-react/src/components/RecordedCorrections.test.tsx
@@ -1,0 +1,49 @@
+/**
+ * RecordedCorrections — the read-only list shared by the Generate panel and
+ * the History drawer (Task 2 of feedback-visibility). Presentational only:
+ * no fetch, no mocks needed, so this is cheap to pin directly.
+ */
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { ALREADY_RECORDED_HEADING, RecordedCorrections, SWITCHED_OFF_MARKER } from './RecordedCorrections'
+
+describe('RecordedCorrections', () => {
+  it('renders nothing for an empty array', () => {
+    const { container } = render(<RecordedCorrections corrections={[]} />)
+
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('renders the heading and every correction’s text', () => {
+    render(
+      <RecordedCorrections
+        corrections={[
+          { hint_id: 7, feedback_text: 'wait for the spinner' },
+          { hint_id: 9, feedback_text: 'the search box locator was off' },
+        ]}
+      />,
+    )
+
+    expect(screen.getByText(ALREADY_RECORDED_HEADING)).toBeInTheDocument()
+    expect(screen.getByText(/wait for the spinner/)).toBeInTheDocument()
+    expect(screen.getByText(/the search box locator was off/)).toBeInTheDocument()
+  })
+
+  it('renders the switched-off marker only for a correction with active: false', () => {
+    render(
+      <RecordedCorrections
+        corrections={[
+          { hint_id: 1, feedback_text: 'switched off one', active: false },
+          { hint_id: 2, feedback_text: 'still active one', active: true },
+          { hint_id: 3, feedback_text: 'unknown-state one' },
+        ]}
+      />,
+    )
+
+    // Exactly one row carries the marker.
+    expect(screen.getAllByText(SWITCHED_OFF_MARKER)).toHaveLength(1)
+    expect(screen.getByText(/switched off one/).textContent).toContain(SWITCHED_OFF_MARKER)
+    expect(screen.getByText(/still active one/).textContent).not.toContain(SWITCHED_OFF_MARKER)
+    expect(screen.getByText(/unknown-state one/).textContent).not.toContain(SWITCHED_OFF_MARKER)
+  })
+})

--- a/src/frontend-react/src/components/RecordedCorrections.tsx
+++ b/src/frontend-react/src/components/RecordedCorrections.tsx
@@ -44,7 +44,7 @@ export interface RecordedCorrectionItem {
 /** Renders nothing for an empty list — silence claims nothing, the same
     degrade-to-silence the panel already uses for a run that contributed
     nothing (or a corrections read that failed). */
-export function RecordedCorrections({ corrections }: { corrections: RecordedCorrectionItem[] }) {
+export function RecordedCorrections({ corrections }: Readonly<{ corrections: RecordedCorrectionItem[] }>) {
   if (corrections.length === 0) return null
   return (
     <div className="rounded-md border bg-muted/40 px-3 py-2 text-xs">

--- a/src/frontend-react/src/components/RecordedCorrections.tsx
+++ b/src/frontend-react/src/components/RecordedCorrections.tsx
@@ -1,19 +1,20 @@
 /**
  * Read-only list of the corrections a run has already contributed to the
  * learning store — GET /api/feedback/{run_id}'s `corrections` array,
- * rendered. Two consumers: GeneratePage's FeedbackPanel (while the run is
- * still on screen) and HistoryPage's drawer (the same run, read days
- * later). Presentational only — no fetch, no Retract control, no error
- * slot, no props to configure a control — because only the panel offers
- * Retract, and only for the caller's own hint on the live run.
+ * rendered. Its one render consumer is HistoryPage's drawer, reading a run
+ * days after the run itself (and GeneratePage's panel with it) is gone from
+ * screen. Presentational only — no fetch, no Retract control, no error
+ * slot, no props to configure a control — because the drawer offers no
+ * action on these rows.
  *
- * The panel does NOT render through this component: it also draws the
- * Retract button, a per-row retract error and the client-only `retracted`
- * marker (this session's own click, which this component must never know
- * about). What this module owns instead is the two strings that must not
- * drift between the panel's markup and this one — the heading and the
- * switched-off marker — exported so GeneratePage.tsx imports them rather
- * than keeping its own copy.
+ * GeneratePage's FeedbackPanel does NOT render through this component — it
+ * keeps its own list markup, because it also draws the Retract button, a
+ * per-row retract error and the client-only `retracted` marker (this
+ * session's own click, which this component must never know about). What
+ * the panel imports from here instead is the two strings that must not
+ * drift between its markup and this one — the heading and the switched-off
+ * marker, both exported below — so it keeps its own render but not a
+ * second hand-typed copy of either string.
  */
 
 /** Heading above the list. Exported so GeneratePage's FeedbackPanel renders

--- a/src/frontend-react/src/components/RecordedCorrections.tsx
+++ b/src/frontend-react/src/components/RecordedCorrections.tsx
@@ -1,0 +1,63 @@
+/**
+ * Read-only list of the corrections a run has already contributed to the
+ * learning store — GET /api/feedback/{run_id}'s `corrections` array,
+ * rendered. Two consumers: GeneratePage's FeedbackPanel (while the run is
+ * still on screen) and HistoryPage's drawer (the same run, read days
+ * later). Presentational only — no fetch, no Retract control, no error
+ * slot, no props to configure a control — because only the panel offers
+ * Retract, and only for the caller's own hint on the live run.
+ *
+ * The panel does NOT render through this component: it also draws the
+ * Retract button, a per-row retract error and the client-only `retracted`
+ * marker (this session's own click, which this component must never know
+ * about). What this module owns instead is the two strings that must not
+ * drift between the panel's markup and this one — the heading and the
+ * switched-off marker — exported so GeneratePage.tsx imports them rather
+ * than keeping its own copy.
+ */
+
+/** Heading above the list. Exported so GeneratePage's FeedbackPanel renders
+    the identical string instead of a second hand-typed copy. */
+export const ALREADY_RECORDED_HEADING = 'Already recorded for this run'
+
+/** `is_active` going to 0 has four possible causes — a user's own retract,
+    an org admin's, auto-disable, or an LLM review — and the server does not
+    say which, so the marker names the STATE, never an actor. Exported for
+    the same reason as the heading above. */
+export const SWITCHED_OFF_MARKER = '— switched off'
+
+/** The subset of a correction row this read-only view needs. A structural
+    subtype of GeneratePage's PanelCorrection: this component takes whatever
+    shape supplies these three fields, whether that is the panel's
+    session-augmented rows or the drawer's plain server response. `active` is
+    optional for the same reason it is on the server response — an older
+    backend, or the learning-disabled shape, never sends it, and absence
+    must render exactly like `active: true` (no marker), never like
+    switched off. */
+export interface RecordedCorrectionItem {
+  hint_id: number
+  feedback_text: string
+  active?: boolean
+}
+
+/** Renders nothing for an empty list — silence claims nothing, the same
+    degrade-to-silence the panel already uses for a run that contributed
+    nothing (or a corrections read that failed). */
+export function RecordedCorrections({ corrections }: { corrections: RecordedCorrectionItem[] }) {
+  if (corrections.length === 0) return null
+  return (
+    <div className="rounded-md border bg-muted/40 px-3 py-2 text-xs">
+      <div className="font-medium">{ALREADY_RECORDED_HEADING}</div>
+      <ul className="mt-1 space-y-0.5 text-muted-foreground">
+        {corrections.map(c => (
+          <li key={c.hint_id}>
+            “{c.feedback_text}”
+            {c.active === false && (
+              <span className="ml-1.5 italic">{SWITCHED_OFF_MARKER}</span>
+            )}
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}

--- a/src/frontend-react/src/components/RecordedCorrections.tsx
+++ b/src/frontend-react/src/components/RecordedCorrections.tsx
@@ -28,7 +28,7 @@ export const ALREADY_RECORDED_HEADING = 'Already recorded for this run'
 export const SWITCHED_OFF_MARKER = '— switched off'
 
 /** The subset of a correction row this read-only view needs. A structural
-    subtype of GeneratePage's PanelCorrection: this component takes whatever
+    supertype of GeneratePage's PanelCorrection: this component takes whatever
     shape supplies these three fields, whether that is the panel's
     session-augmented rows or the drawer's plain server response. `active` is
     optional for the same reason it is on the server response — an older

--- a/src/frontend-react/src/components/RobotCodeEditor.tsx
+++ b/src/frontend-react/src/components/RobotCodeEditor.tsx
@@ -7,6 +7,7 @@
  * live in index.css under `.robot-editor`.
  */
 
+import type { ComponentProps, KeyboardEventHandler } from 'react'
 import Editor from 'react-simple-code-editor'
 import Prism from 'prismjs'
 import 'prismjs/components/prism-robotframework'
@@ -16,13 +17,18 @@ function highlight(code: string): string {
   return Prism.highlight(code, Prism.languages.robotframework, 'robotframework')
 }
 
-export default function RobotCodeEditor({ value, onChange, disabled, placeholder, className }: {
+export default function RobotCodeEditor({ value, onChange, disabled, placeholder, className, onKeyDown }: Readonly<{
   value: string
   onChange: (v: string) => void
   disabled?: boolean
   placeholder?: string
   className?: string
-}) {
+  // Forwarded straight to the underlying textarea. react-simple-code-editor
+  // calls this before its own key handling and honours preventDefault, so a
+  // caller's shortcut lands on the real interactive element instead of a
+  // wrapping div that would need a fake ARIA role to explain itself.
+  onKeyDown?: KeyboardEventHandler<HTMLTextAreaElement>
+}>) {
   return (
     <div className={cn('robot-editor min-h-0 overflow-auto bg-[#0d1117]', className)}>
       <Editor
@@ -35,6 +41,14 @@ export default function RobotCodeEditor({ value, onChange, disabled, placeholder
         textareaClassName="focus:outline-none"
         className="min-h-full text-[13px] leading-relaxed text-[#e6edf3] caret-white"
         style={{ fontFamily: "Consolas, Menlo, Monaco, 'Droid Sans Mono', 'Courier New', monospace" }}
+        // Editor's own .d.ts spreads unrecognised props onto its container
+        // div, so it types onKeyDown against HTMLDivElement as well as the
+        // textarea it is actually wired to at runtime (lib/index.js) — an
+        // intersection our textarea-only handler can never honestly satisfy.
+        // Casting through Editor's own declared prop type (rather than
+        // hand-writing that intersection) keeps this tied to its real type,
+        // not a guess, if the library's declarations ever change.
+        onKeyDown={onKeyDown as ComponentProps<typeof Editor>['onKeyDown']}
       />
     </div>
   )

--- a/src/frontend-react/src/components/app-header.test.tsx
+++ b/src/frontend-react/src/components/app-header.test.tsx
@@ -3,11 +3,11 @@
  * (light/dark/system mode, and the professional/neo visual toggle). Both
  * controls are built from a .map() over three/two near-identical buttons, so
  * the failure mode worth guarding is a button calling back with the WRONG
- * id/theme — a neighbour's instead of its own. PAGE_LABELS is a hand
- * -maintained path->label table; its fallback branch, and a gap in the table
- * that predates this test file, are pinned below.
+ * id/theme — a neighbour's instead of its own. The breadcrumb label is no
+ * longer a hand-maintained table: it is derived from the nav tables, and the
+ * drift guard below is what makes that derivation load-bearing.
  */
-import { fireEvent, render, screen } from '@testing-library/react'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -15,6 +15,7 @@ vi.mock('@/components/theme-provider', () => ({ useTheme: vi.fn() }))
 
 import { useTheme } from '@/components/theme-provider'
 import { SidebarProvider } from '@/components/ui/sidebar'
+import { NAV_PLATFORM, NAV_WORKSPACE } from '@/components/app-sidebar'
 import { AppHeader } from './app-header'
 
 const mockUseTheme = vi.mocked(useTheme)
@@ -58,27 +59,41 @@ describe('AppHeader — breadcrumb page label', () => {
     ['/history', 'Test Runs'],
     ['/metrics', 'Metrics'],
     ['/learning', 'Learning'],
+    ['/access', 'Access'],
+    ['/team', 'Team'],
     ['/settings', 'Settings'],
-    ['/docs', 'Documentation'],
   ])('labels %s as "%s"', (path, label) => {
     renderAt(path, 'system', 'professional')
     expect(screen.getByText('Platform')).toBeInTheDocument()
     expect(screen.getByText(label)).toBeInTheDocument()
   })
 
-  it('falls back to Overview for a path with no PAGE_LABELS entry', () => {
+  it('falls back to Overview for a path that is not a page', () => {
     renderAt('/some-unmapped-path', 'system', 'professional')
     expect(screen.getByText('Overview')).toBeInTheDocument()
   })
 
-  // PAGE_LABELS was never extended when /access and /team shipped — App.tsx's
-  // PAGES table gates both (see App.test.tsx) but neither path is a key in
-  // this component's PAGE_LABELS map. Pinning what actually happens today,
-  // not endorsing it: reported in the task write-up, not fixed here (surgical
-  // -diff / no-source-edits rule — this file only adds tests).
-  it('SURPRISING: /team has no PAGE_LABELS entry either, so it also falls back to Overview', () => {
-    renderAt('/team', 'system', 'professional')
+  /* The bug this replaced: /access and /team shipped as real gated routes and
+   * the header's own path->label table was never extended, so both rendered
+   * "Overview" on every load — while the table still carried a /docs entry for
+   * a route that was never declared. A third hand-maintained table of the same
+   * paths is what made that possible, so the fix removed the table rather than
+   * adding two rows to it. This is the guard that keeps it removed: a nav entry
+   * whose label the header cannot produce is a regression, whoever adds it. */
+  it('labels every navigable page with the SAME words the sidebar uses for it', () => {
+    for (const item of [...NAV_PLATFORM, ...NAV_WORKSPACE]) {
+      cleanup()
+      renderAt(item.url, 'system', 'professional')
+      expect(screen.queryByText('Overview'), `"${item.title}" (${item.url}) has no header label`)
+        .not.toBeInTheDocument()
+      expect(screen.getByText(item.title)).toBeInTheDocument()
+    }
+  })
+
+  it('no longer labels /docs, which is not a declared route', () => {
+    renderAt('/docs', 'system', 'professional')
     expect(screen.getByText('Overview')).toBeInTheDocument()
+    expect(screen.queryByText('Documentation')).not.toBeInTheDocument()
   })
 })
 

--- a/src/frontend-react/src/components/app-header.test.tsx
+++ b/src/frontend-react/src/components/app-header.test.tsx
@@ -1,0 +1,125 @@
+/**
+ * AppHeader — the breadcrumb page label and the two theme controls
+ * (light/dark/system mode, and the professional/neo visual toggle). Both
+ * controls are built from a .map() over three/two near-identical buttons, so
+ * the failure mode worth guarding is a button calling back with the WRONG
+ * id/theme — a neighbour's instead of its own. PAGE_LABELS is a hand
+ * -maintained path->label table; its fallback branch, and a gap in the table
+ * that predates this test file, are pinned below.
+ */
+import { fireEvent, render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/components/theme-provider', () => ({ useTheme: vi.fn() }))
+
+import { useTheme } from '@/components/theme-provider'
+import { SidebarProvider } from '@/components/ui/sidebar'
+import { AppHeader } from './app-header'
+
+const mockUseTheme = vi.mocked(useTheme)
+
+// SidebarProvider's useIsMobile() calls window.matchMedia via a plain
+// useEffect. setup.ts installs a working stub once per FILE, but this file's
+// own `afterEach(vi.resetAllMocks)` strips that stub's implementation after
+// test 1 (resetAllMocks resets every vi.fn(), including that one), so every
+// test after the first would otherwise call matchMedia() and get back
+// undefined. theme-provider.test.tsx hits the same interaction and re-installs
+// its own stub per test for the same reason — same fix here.
+beforeEach(() => {
+  window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+    matches: false, media: query, onchange: null,
+    addEventListener: vi.fn(), removeEventListener: vi.fn(),
+    addListener: vi.fn(), removeListener: vi.fn(), dispatchEvent: vi.fn(),
+  }))
+})
+afterEach(() => vi.resetAllMocks())
+
+function renderAt(path: string, mode: 'light' | 'dark' | 'system', theme: 'professional' | 'neo') {
+  const setMode = vi.fn()
+  const setTheme = vi.fn()
+  mockUseTheme.mockReturnValue({ mode, setMode, theme, setTheme })
+  render(
+    <MemoryRouter initialEntries={[path]}>
+      {/* AppHeader renders <SidebarTrigger>, which reads useSidebar() —
+          a real (not mocked) SidebarProvider is the cheapest way to satisfy
+          that without re-implementing the sidebar's own context. */}
+      <SidebarProvider>
+        <AppHeader />
+      </SidebarProvider>
+    </MemoryRouter>,
+  )
+  return { setMode, setTheme }
+}
+
+describe('AppHeader — breadcrumb page label', () => {
+  it.each([
+    ['/generate', 'Generate'],
+    ['/history', 'Test Runs'],
+    ['/metrics', 'Metrics'],
+    ['/learning', 'Learning'],
+    ['/settings', 'Settings'],
+    ['/docs', 'Documentation'],
+  ])('labels %s as "%s"', (path, label) => {
+    renderAt(path, 'system', 'professional')
+    expect(screen.getByText('Platform')).toBeInTheDocument()
+    expect(screen.getByText(label)).toBeInTheDocument()
+  })
+
+  it('falls back to Overview for a path with no PAGE_LABELS entry', () => {
+    renderAt('/some-unmapped-path', 'system', 'professional')
+    expect(screen.getByText('Overview')).toBeInTheDocument()
+  })
+
+  // PAGE_LABELS was never extended when /access and /team shipped — App.tsx's
+  // PAGES table gates both (see App.test.tsx) but neither path is a key in
+  // this component's PAGE_LABELS map. Pinning what actually happens today,
+  // not endorsing it: reported in the task write-up, not fixed here (surgical
+  // -diff / no-source-edits rule — this file only adds tests).
+  it('SURPRISING: /team has no PAGE_LABELS entry either, so it also falls back to Overview', () => {
+    renderAt('/team', 'system', 'professional')
+    expect(screen.getByText('Overview')).toBeInTheDocument()
+  })
+})
+
+describe('AppHeader — light/dark/system toggle', () => {
+  it('calls setMode with the id of the button that was clicked, not a neighbour', () => {
+    const { setMode } = renderAt('/generate', 'system', 'professional')
+
+    fireEvent.click(screen.getByLabelText('Dark mode'))
+
+    expect(setMode).toHaveBeenCalledWith('dark')
+    expect(setMode).not.toHaveBeenCalledWith('light')
+    expect(setMode).not.toHaveBeenCalledWith('system')
+  })
+
+  it('marks only the current mode button as active', () => {
+    renderAt('/generate', 'dark', 'professional')
+
+    expect(screen.getByLabelText('Dark mode').className).toContain('bg-background')
+    expect(screen.getByLabelText('Light mode').className).not.toContain('bg-background')
+    expect(screen.getByLabelText('System preference').className).not.toContain('bg-background')
+  })
+})
+
+describe('AppHeader — professional/neo toggle', () => {
+  it('offers Neo (the OTHER theme) while professional, and switches to it on click', () => {
+    const { setTheme } = renderAt('/generate', 'system', 'professional')
+    const btn = screen.getByLabelText('Toggle neobrutalism theme')
+
+    expect(btn.textContent).toContain('Neo')
+    fireEvent.click(btn)
+
+    expect(setTheme).toHaveBeenCalledWith('neo')
+  })
+
+  it('offers Pro (the OTHER theme) while neo, and switches back to professional on click', () => {
+    const { setTheme } = renderAt('/generate', 'system', 'neo')
+    const btn = screen.getByLabelText('Toggle neobrutalism theme')
+
+    expect(btn.textContent).toContain('Pro')
+    fireEvent.click(btn)
+
+    expect(setTheme).toHaveBeenCalledWith('professional')
+  })
+})

--- a/src/frontend-react/src/components/app-header.tsx
+++ b/src/frontend-react/src/components/app-header.tsx
@@ -11,16 +11,18 @@ import {
 } from '@/components/ui/breadcrumb'
 import { Sun, Moon, Monitor, Zap } from 'lucide-react'
 import { useTheme } from '@/components/theme-provider'
+import { NAV_PLATFORM, NAV_WORKSPACE } from '@/components/app-sidebar'
 import { cn } from '@/lib/utils'
 
-const PAGE_LABELS: Record<string, string> = {
-  '/generate':  'Generate',
-  '/history':   'Test Runs',
-  '/metrics':   'Metrics',
-  '/learning':  'Learning',
-  '/settings':  'Settings',
-  '/docs':      'Documentation',
-}
+// Derived from the nav tables rather than kept as a third hand-maintained copy
+// of the same paths. As a literal it drifted in both directions: /access and
+// /team shipped as real gated routes with no entry, so both rendered
+// "Overview" on every load, while a '/docs': 'Documentation' entry outlived a
+// route that was never declared. The sidebar already names every page, so the
+// header now reuses those exact words and the two cannot disagree.
+const PAGE_LABELS: Record<string, string> = Object.fromEntries(
+  [...NAV_PLATFORM, ...NAV_WORKSPACE].map(item => [item.url, item.title]),
+)
 
 export function AppHeader() {
   const { pathname } = useLocation()

--- a/src/frontend-react/src/components/app-sidebar.test.tsx
+++ b/src/frontend-react/src/components/app-sidebar.test.tsx
@@ -6,10 +6,27 @@
  * against PAGES, here exercised against NAV_PLATFORM instead, so this is
  * testable without rendering the sidebar — this package tests no page
  * components (see FeedbackPanel.test.tsx / LearningPage.test.tsx).
+ *
+ * Added later: the suite above pins the DATA (NAV_PLATFORM's flags) and the
+ * PREDICATE (gateAllowed) but never renders <AppSidebar/>, so a bug in
+ * NavGroup's own `items.filter(item => gateAllowed(item, flags))` call — the
+ * thing that actually decides what a signed-in user sees — could break and
+ * every test above would stay green. The second suite below renders the real
+ * component, table-driven over every nav item x every role, so the DOM output
+ * itself is what gets checked, not just the data feeding it.
  */
-import { describe, expect, it } from 'vitest'
-import { NAV_PLATFORM } from './app-sidebar'
-import { gateAllowed } from '@/auth/pageGates'
+import { fireEvent, render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/auth/AuthContext', () => ({ useAuth: vi.fn() }))
+vi.mock('@/components/history/RunGroupsContext', () => ({ useRunGroups: vi.fn() }))
+
+import { useAuth } from '@/auth/AuthContext'
+import { useRunGroups } from '@/components/history/RunGroupsContext'
+import { SidebarProvider } from '@/components/ui/sidebar'
+import { AppSidebar, NAV_PLATFORM } from './app-sidebar'
+import { gateAllowed, type Gate, type GateFlags } from '@/auth/pageGates'
 
 const learningItem = NAV_PLATFORM.find(i => i.url === '/learning')!
 
@@ -31,5 +48,152 @@ describe('gateAllowed for the Learning nav item', () => {
 
   it('is still shown for a platform admin (no regression)', () => {
     expect(gateAllowed(learningItem, { isAdmin: true, isOrgAdmin: false, canViewLearning: true })).toBe(true)
+  })
+})
+
+const mockUseAuth = vi.mocked(useAuth)
+const mockUseRunGroups = vi.mocked(useRunGroups)
+
+function renderSidebar(
+  flags: GateFlags,
+  runGroups: Partial<ReturnType<typeof useRunGroups>> = {},
+) {
+  mockUseAuth.mockReturnValue({
+    isAdmin: flags.isAdmin, isOrgAdmin: flags.isOrgAdmin, canViewLearning: flags.canViewLearning,
+    user: null, loading: false, isAuthenticated: true, status: 'active',
+    login: vi.fn(), signup: vi.fn(), loginWithToken: vi.fn(), logout: vi.fn(), logoutAll: vi.fn(),
+  } as unknown as ReturnType<typeof useAuth>)
+  mockUseRunGroups.mockReturnValue({
+    groups: [], ungroupedCount: 0, error: '', loaded: true,
+    refresh: vi.fn(), createGroup: vi.fn(), renameGroup: vi.fn(), deleteGroup: vi.fn(), assignRuns: vi.fn(),
+    groupFilter: null, setGroupFilter: vi.fn(),
+    ...runGroups,
+  } as unknown as ReturnType<typeof useRunGroups>)
+  return render(
+    <MemoryRouter>
+      <SidebarProvider>
+        <AppSidebar />
+      </SidebarProvider>
+    </MemoryRouter>,
+  )
+}
+
+const PLAIN: GateFlags = { isAdmin: false, isOrgAdmin: false, canViewLearning: false }
+const ADMIN: GateFlags = { isAdmin: true, isOrgAdmin: false, canViewLearning: false }
+const ORG_ADMIN: GateFlags = { isAdmin: false, isOrgAdmin: true, canViewLearning: false }
+const LEARNING_VIEWER: GateFlags = { isAdmin: false, isOrgAdmin: false, canViewLearning: true }
+
+const ROLES: Array<{ name: string; flags: GateFlags }> = [
+  { name: 'plain user', flags: PLAIN },
+  { name: 'platform admin', flags: ADMIN },
+  { name: 'org admin', flags: ORG_ADMIN },
+  { name: 'learning viewer', flags: LEARNING_VIEWER },
+]
+
+// Hand-pinned, not read off NAV_PLATFORM/NAV_WORKSPACE (the table under
+// test) — reading expectations back from that same table would make a
+// weakened gate invisible: drop `admin: true` from an entry and a test that
+// re-derives its expectation from that same entry "passes" the weakened
+// version too. Same reasoning as App.test.tsx's PAGE_CASES.
+const NAV_CASES: Array<{ title: string; gate: Gate }> = [
+  { title: 'Generate', gate: {} },
+  { title: 'Test Runs', gate: {} },
+  { title: 'Metrics', gate: { admin: true } },
+  { title: 'Learning', gate: { viewLearning: true } },
+  { title: 'Access', gate: { admin: true } },
+  { title: 'Team', gate: { orgAdmin: true } },
+  { title: 'Settings', gate: { admin: true } },
+]
+
+describe('AppSidebar — every nav item x every role, rendered for real', () => {
+  beforeEach(() => {
+    // SidebarProvider's useIsMobile() reads window.matchMedia in a useEffect,
+    // and the footer's real <BuildBadge/> fetches /api/health in another —
+    // both run on every render below, so both need a working stub or the
+    // mount throws/hits the network. Re-installed every test: this block's
+    // own afterEach(vi.resetAllMocks) strips whatever vi.fn() implementation
+    // was installed here (see app-header.test.tsx's identical note on
+    // matchMedia; build-badge.test.tsx is the equivalent note for fetch).
+    window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+      matches: false, media: query, onchange: null,
+      addEventListener: vi.fn(), removeEventListener: vi.fn(),
+      addListener: vi.fn(), removeListener: vi.fn(), dispatchEvent: vi.fn(),
+    }))
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false }))
+  })
+  afterEach(() => { vi.unstubAllGlobals(); vi.resetAllMocks() })
+
+  for (const { title, gate } of NAV_CASES) {
+    describe(title, () => {
+      for (const { name, flags } of ROLES) {
+        const expected = gateAllowed(gate, flags)
+        it(`is ${expected ? 'shown' : 'hidden'} for a ${name}`, () => {
+          renderSidebar(flags)
+
+          if (expected) {
+            expect(screen.getByText(title)).toBeInTheDocument()
+          } else {
+            expect(screen.queryByText(title)).not.toBeInTheDocument()
+          }
+        })
+      }
+    })
+  }
+})
+
+describe('AppSidebar — the Test Runs quick-access group list', () => {
+  beforeEach(() => {
+    window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+      matches: false, media: query, onchange: null,
+      addEventListener: vi.fn(), removeEventListener: vi.fn(),
+      addListener: vi.fn(), removeListener: vi.fn(), dispatchEvent: vi.fn(),
+    }))
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false }))
+  })
+  afterEach(() => { vi.unstubAllGlobals(); vi.resetAllMocks() })
+
+  const openList = () => fireEvent.click(screen.getByTitle('Show groups'))
+
+  it('stays collapsed until the chevron is clicked', () => {
+    renderSidebar(PLAIN, { loaded: false })
+
+    expect(screen.queryByText(/Loading groups/)).not.toBeInTheDocument()
+
+    openList()
+
+    expect(screen.getByText(/Loading groups/)).toBeInTheDocument()
+  })
+
+  it('lists each group by name, and clicking one sets the filter to ITS id', () => {
+    const setGroupFilter = vi.fn()
+    renderSidebar(PLAIN, {
+      loaded: true, error: '',
+      groups: [
+        { group_id: 'g-1', name: 'Checkout', created_by: 'u1', run_count: 2 },
+        { group_id: 'g-2', name: 'Regression', created_by: 'u1', run_count: 5 },
+      ],
+      setGroupFilter,
+    })
+    openList()
+
+    fireEvent.click(screen.getByText('Checkout'))
+
+    expect(setGroupFilter).toHaveBeenCalledWith('g-1')
+    expect(setGroupFilter).not.toHaveBeenCalledWith('g-2')
+  })
+
+  it('shows the load error instead of a false "no groups" empty state', () => {
+    renderSidebar(PLAIN, { loaded: true, error: 'network down', groups: [] })
+    openList()
+
+    expect(screen.getByText(/Couldn.t load groups — network down/)).toBeInTheDocument()
+    expect(screen.queryByText(/No groups yet/)).not.toBeInTheDocument()
+  })
+
+  it('says "No groups yet" only once loading finished AND the list is truly empty', () => {
+    renderSidebar(PLAIN, { loaded: true, error: '', groups: [] })
+    openList()
+
+    expect(screen.getByText(/No groups yet — create one on Test Runs/)).toBeInTheDocument()
   })
 })

--- a/src/frontend-react/src/components/build-badge.test.tsx
+++ b/src/frontend-react/src/components/build-badge.test.tsx
@@ -1,0 +1,139 @@
+/**
+ * BuildBadge — the commit stamp in the sidebar footer.
+ *
+ * Its whole reason to exist is that `-develop` and `-latest` are moving tags,
+ * so the image tag a container was pulled under says nothing about the code
+ * inside it. That makes two of its properties load-bearing rather than
+ * cosmetic: it must show the FULL commit on copy (the 7-char label is only a
+ * label), and it must fail silently — a diagnostic string that can throw, or
+ * sign a user out, is worse than no diagnostic string.
+ */
+import { render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { BuildBadge } from './build-badge'
+
+const FULL = '9b9836a1c2d3e4f5a6b7c8d9e0f1a2b3c4d5e6f7'
+
+function stubFetch(impl: () => Promise<unknown>) {
+  vi.stubGlobal('fetch', vi.fn().mockImplementation(impl))
+}
+
+function stubClipboard() {
+  const writeText = vi.fn().mockResolvedValue(undefined)
+  Object.defineProperty(navigator, 'clipboard', {
+    value: { writeText }, configurable: true, writable: true,
+  })
+  return writeText
+}
+
+beforeEach(() => vi.useRealTimers())
+afterEach(() => { vi.unstubAllGlobals(); vi.restoreAllMocks() })
+
+describe('BuildBadge', () => {
+  it('shows git’s own 7-character short form of the commit', async () => {
+    stubFetch(async () => ({ ok: true, json: async () => ({ build: { commit: FULL } }) }))
+
+    render(<BuildBadge />)
+
+    expect(await screen.findByText('build 9b9836a')).toBeInTheDocument()
+  })
+
+  it('copies the FULL commit, not the abbreviation it displays', async () => {
+    // The abbreviation is a label. Pasting 7 characters into a bug report
+    // loses the thing the badge exists to communicate.
+    const writeText = stubClipboard()
+    stubFetch(async () => ({ ok: true, json: async () => ({ build: { commit: FULL } }) }))
+    render(<BuildBadge />)
+    const btn = await screen.findByText('build 9b9836a')
+
+    btn.click()
+
+    await waitFor(() => expect(writeText).toHaveBeenCalledWith(FULL))
+    expect(writeText).not.toHaveBeenCalledWith('9b9836a')
+  })
+
+  it('confirms the copy, then goes back to showing the build', async () => {
+    stubClipboard()
+    stubFetch(async () => ({ ok: true, json: async () => ({ build: { commit: FULL } }) }))
+    render(<BuildBadge />)
+    const btn = await screen.findByText('build 9b9836a')
+
+    btn.click()
+
+    expect(await screen.findByText('copied')).toBeInTheDocument()
+    await waitFor(() => expect(screen.getByText('build 9b9836a')).toBeInTheDocument(), { timeout: 3000 })
+  })
+
+  it('renders an unstamped local build as "unknown" rather than slicing it', async () => {
+    stubFetch(async () => ({ ok: true, json: async () => ({ build: { commit: 'unknown' } }) }))
+
+    render(<BuildBadge />)
+
+    const el = await screen.findByText('build unknown')
+    expect(el).toBeInTheDocument()
+    expect(el.getAttribute('title')).toMatch(/not stamped with a commit/i)
+  })
+
+  it('titles a real commit with the full value and the copy hint', async () => {
+    stubFetch(async () => ({ ok: true, json: async () => ({ build: { commit: FULL } }) }))
+
+    render(<BuildBadge />)
+
+    const el = await screen.findByText('build 9b9836a')
+    expect(el.getAttribute('title')).toBe(`Build ${FULL} — click to copy`)
+  })
+
+  it('renders nothing when /api/health does not answer ok', async () => {
+    stubFetch(async () => ({ ok: false, json: async () => ({}) }))
+
+    const { container } = render(<BuildBadge />)
+
+    await waitFor(() => expect(container.querySelector('button')).toBeNull())
+  })
+
+  it('renders nothing, and does not throw, when the fetch itself rejects', async () => {
+    // Silent by design: a version string must never put an error on a page
+    // that is otherwise working.
+    stubFetch(async () => { throw new Error('network down') })
+
+    const { container } = render(<BuildBadge />)
+
+    await waitFor(() => expect(container.querySelector('button')).toBeNull())
+  })
+
+  it('renders nothing when the payload carries no commit', async () => {
+    stubFetch(async () => ({ ok: true, json: async () => ({ build: {} }) }))
+
+    const { container } = render(<BuildBadge />)
+
+    await waitFor(() => expect(container.querySelector('button')).toBeNull())
+  })
+
+  it('survives a clipboard that refuses (non-https origin) without crashing', async () => {
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText: vi.fn().mockRejectedValue(new Error('blocked')) },
+      configurable: true, writable: true,
+    })
+    stubFetch(async () => ({ ok: true, json: async () => ({ build: { commit: FULL } }) }))
+    render(<BuildBadge />)
+    const btn = await screen.findByText('build 9b9836a')
+
+    btn.click()
+
+    // Still the build label, never "copied", and no unhandled rejection.
+    await waitFor(() => expect(screen.getByText('build 9b9836a')).toBeInTheDocument())
+  })
+
+  it('does not set state after unmount when the response lands late', async () => {
+    let resolve: (v: unknown) => void = () => {}
+    stubFetch(() => new Promise(r => { resolve = r }))
+    const { unmount } = render(<BuildBadge />)
+
+    unmount()
+    resolve({ ok: true, json: async () => ({ build: { commit: FULL } }) })
+
+    // The `alive` flag guards this; reaching here without a warning is the point.
+    await waitFor(() => expect(screen.queryByText('build 9b9836a')).toBeNull())
+  })
+})

--- a/src/frontend-react/src/components/history/GroupChipsRow.test.tsx
+++ b/src/frontend-react/src/components/history/GroupChipsRow.test.tsx
@@ -8,7 +8,7 @@
  * offered a button that can only answer 404 — and never denied one that
  * would have worked.
  */
-import { fireEvent, render, screen } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { describe, expect, it, vi } from 'vitest'
 
 import { GroupChipsRow } from './GroupChipsRow'
@@ -98,5 +98,204 @@ describe('GroupChipsRow', () => {
     renderRow({ groups: [], active: 'ungrouped' })
 
     expect(screen.getByText('Ungrouped')).toBeInTheDocument()
+  })
+})
+
+/** Unique to the browse dialog's own copy — never collides with the "All
+ *  Groups"/active-group CHIP, which stays mounted behind the dialog. */
+const browseDialogOpen = () => screen.queryByText(/Pick a group to filter the runs/) !== null
+
+describe('GroupChipsRow — the Ungrouped chip toggles the filter', () => {
+  it('selects "ungrouped" when clicked while nothing is filtered', () => {
+    const onSelect = vi.fn()
+    renderRow({ active: null, onSelect })
+
+    fireEvent.click(screen.getByText('Ungrouped'))
+
+    expect(onSelect).toHaveBeenCalledWith('ungrouped')
+  })
+
+  it('clears the filter when clicked while Ungrouped IS already active', () => {
+    const onSelect = vi.fn()
+    renderRow({ active: 'ungrouped', onSelect })
+
+    fireEvent.click(screen.getByText('Ungrouped'))
+
+    expect(onSelect).toHaveBeenCalledWith(null)
+  })
+})
+
+describe('GroupChipsRow — the groups control opens the browse dialog', () => {
+  it('reads "All Groups" and opens the dialog when nothing is filtered', () => {
+    renderRow({ active: null })
+    expect(screen.getByText('All Groups')).toBeInTheDocument()
+
+    openBrowse()
+
+    expect(browseDialogOpen()).toBe(true)
+  })
+
+  it('reads as the active group’s own chip, and its LEFT side also opens the dialog', () => {
+    renderRow({ active: 'g-1' })
+    // "All Groups" must NOT be showing — the chip has switched identity.
+    expect(screen.queryByText('All Groups')).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByTitle('Switch or manage groups'))
+
+    expect(browseDialogOpen()).toBe(true)
+  })
+
+  it('the chip’s own ✕ clears the filter directly, WITHOUT opening the dialog', () => {
+    const onSelect = vi.fn()
+    renderRow({ active: 'g-1', onSelect })
+
+    fireEvent.click(screen.getByLabelText('Clear the group filter'))
+
+    expect(onSelect).toHaveBeenCalledWith(null)
+    expect(browseDialogOpen()).toBe(false)
+  })
+
+  it('picking a group row in the dialog selects it and closes the dialog', () => {
+    const onSelect = vi.fn()
+    renderRow({ onSelect })
+    openBrowse()
+
+    fireEvent.click(screen.getByText('Checkout'))
+
+    expect(onSelect).toHaveBeenCalledWith('g-1')
+    expect(browseDialogOpen()).toBe(false)
+  })
+})
+
+describe('GroupChipsRow — "Clear filter" inside the browse dialog', () => {
+  it('is offered only while a group is actually active', () => {
+    renderRow({ active: 'g-1' })
+    fireEvent.click(screen.getByTitle('Switch or manage groups'))
+    expect(screen.getByText('Clear filter')).toBeInTheDocument()
+  })
+
+  it('is absent with no active filter — nothing to clear', () => {
+    renderRow({ active: null })
+    openBrowse()
+    expect(screen.queryByText('Clear filter')).not.toBeInTheDocument()
+  })
+
+  it('clears the selection and closes the dialog when clicked', () => {
+    const onSelect = vi.fn()
+    renderRow({ active: 'g-1', onSelect })
+    fireEvent.click(screen.getByTitle('Switch or manage groups'))
+
+    fireEvent.click(screen.getByText('Clear filter'))
+
+    expect(onSelect).toHaveBeenCalledWith(null)
+    expect(browseDialogOpen()).toBe(false)
+  })
+})
+
+describe('GroupChipsRow — creating a group', () => {
+  it('disables Create until a name is entered, then submits the TRIMMED value', async () => {
+    const onCreate = vi.fn().mockResolvedValue(undefined)
+    renderRow({ onCreate })
+    fireEvent.click(screen.getByText('New'))
+    expect(screen.getByText('Create')).toBeDisabled()
+
+    fireEvent.change(screen.getByPlaceholderText('e.g. Checkout flows'), { target: { value: '  Regression  ' } })
+    expect(screen.getByText('Create')).not.toBeDisabled()
+
+    fireEvent.click(screen.getByText('Create'))
+
+    await waitFor(() => expect(onCreate).toHaveBeenCalledWith('Regression'))
+  })
+
+  it('shows the server’s rejection and keeps the dialog open', async () => {
+    const onCreate = vi.fn().mockRejectedValue(new Error('A group named "Dup" already exists'))
+    renderRow({ onCreate })
+    fireEvent.click(screen.getByText('New'))
+    fireEvent.change(screen.getByPlaceholderText('e.g. Checkout flows'), { target: { value: 'Dup' } })
+
+    fireEvent.click(screen.getByText('Create'))
+
+    expect(await screen.findByText('A group named "Dup" already exists')).toBeInTheDocument()
+    expect(screen.getByPlaceholderText('e.g. Checkout flows')).toBeInTheDocument()
+  })
+})
+
+describe('GroupChipsRow — renaming a group', () => {
+  it('calls onRename with the group id and the TRIMMED new name', async () => {
+    const onRename = vi.fn().mockResolvedValue(undefined)
+    renderRow({ canRename: () => true, onRename })
+    openBrowse()
+    fireEvent.click(screen.getByLabelText('Rename Checkout'))
+
+    fireEvent.change(screen.getByDisplayValue('Checkout'), { target: { value: '  Checkout Flow  ' } })
+    fireEvent.click(screen.getByText('Rename'))
+
+    await waitFor(() => expect(onRename).toHaveBeenCalledWith('g-1', 'Checkout Flow'))
+  })
+
+  it('starts with Rename disabled — the freshly-opened field equals the current name', () => {
+    // submitDisabled treats an UNCHANGED name as nothing to submit, so the
+    // button must not invite a no-op rename before the user edits anything.
+    renderRow({ canRename: () => true, onRename: vi.fn() })
+    openBrowse()
+    fireEvent.click(screen.getByLabelText('Rename Checkout'))
+
+    expect(screen.getByText('Rename')).toBeDisabled()
+  })
+
+  it('skips the onRename call when the form is submitted with the name unchanged', async () => {
+    // The button's disabled attribute already defends this (previous test);
+    // this pins the SEPARATE guard inside submit() itself
+    // (`if (name.trim() !== overlay.group.name)`) by submitting the form
+    // directly, bypassing the disabled button — a realistic path if the two
+    // guards ever drift apart.
+    const onRename = vi.fn()
+    renderRow({ canRename: () => true, onRename })
+    openBrowse()
+    fireEvent.click(screen.getByLabelText('Rename Checkout'))
+
+    // The dialog is portalled to document.body (a sibling of render()'s own
+    // container, not a descendant), so find the form via the input rather
+    // than container.querySelector.
+    fireEvent.submit(screen.getByDisplayValue('Checkout').closest('form')!)
+
+    await waitFor(() => expect(browseDialogOpen()).toBe(true))
+    expect(onRename).not.toHaveBeenCalled()
+  })
+
+  it('shows the server’s rejection and keeps the dialog open', async () => {
+    const onRename = vi.fn().mockRejectedValue(new Error('Only the creator or an org admin may rename this group'))
+    renderRow({ canRename: () => true, onRename })
+    openBrowse()
+    fireEvent.click(screen.getByLabelText('Rename Checkout'))
+    fireEvent.change(screen.getByDisplayValue('Checkout'), { target: { value: 'Renamed' } })
+
+    fireEvent.click(screen.getByText('Rename'))
+
+    expect(await screen.findByText('Only the creator or an org admin may rename this group')).toBeInTheDocument()
+  })
+})
+
+describe('GroupChipsRow — deleting a group', () => {
+  it('confirms, then calls onDelete with the group id', async () => {
+    const onDelete = vi.fn().mockResolvedValue(undefined)
+    renderRow({ canDelete: () => true, onDelete })
+    openBrowse()
+    fireEvent.click(screen.getByLabelText('Delete Checkout'))
+
+    fireEvent.click(screen.getByText('Delete group'))
+
+    await waitFor(() => expect(onDelete).toHaveBeenCalledWith('g-1'))
+  })
+
+  it('shows the server’s refusal and leaves the confirmation open', async () => {
+    const onDelete = vi.fn().mockRejectedValue(new Error('Only an org admin may delete a group'))
+    renderRow({ canDelete: () => true, onDelete })
+    openBrowse()
+    fireEvent.click(screen.getByLabelText('Delete Checkout'))
+
+    fireEvent.click(screen.getByText('Delete group'))
+
+    expect(await screen.findByText('Only an org admin may delete a group')).toBeInTheDocument()
   })
 })

--- a/src/frontend-react/src/components/history/MoveToGroupMenu.test.tsx
+++ b/src/frontend-react/src/components/history/MoveToGroupMenu.test.tsx
@@ -1,0 +1,196 @@
+/**
+ * MoveToGroupMenu — the one filing control shared by the history row, the
+ * detail drawer, and the bulk-select toolbar.
+ *
+ * Two things are load-bearing per the component's own docstring: the
+ * `onClick={e => e.stopPropagation()}` guard on DropdownMenuContent (without
+ * it, clicking an item bubbles through the REACT tree — which portals do NOT
+ * escape — to whatever the caller wrapped this menu in, e.g. a history row's
+ * onClick, opening that row's drawer behind the menu the user was actually
+ * using), and "Remove from group" being offered under EITHER currentGroupId
+ * OR showRemove (the bulk-select toolbar has no single currentGroupId but
+ * still needs the control, per the `showRemove` prop comment). This file
+ * pins both, plus the create-and-move flow and its error path.
+ */
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { MoveToGroupMenu } from './MoveToGroupMenu'
+import type { RunGroup } from './useGroups'
+
+afterEach(() => vi.resetAllMocks())
+
+const CHECKOUT: RunGroup = { group_id: 'g-1', name: 'Checkout', created_by: 'u1', run_count: 3 }
+const REGRESSION: RunGroup = { group_id: 'g-2', name: 'Regression', created_by: 'u1', run_count: 1 }
+
+function renderMenu(overrides: Partial<React.ComponentProps<typeof MoveToGroupMenu>> = {}) {
+  const props: React.ComponentProps<typeof MoveToGroupMenu> = {
+    groups: [CHECKOUT, REGRESSION],
+    currentGroupId: null,
+    onMove: vi.fn(),
+    onCreateGroup: vi.fn().mockResolvedValue({ group_id: 'g-3', name: 'New', created_by: 'u1', run_count: 0 }),
+    trigger: <button type="button">Open menu</button>,
+    ...overrides,
+  }
+  const utils = render(<MoveToGroupMenu {...props} />)
+  return { ...utils, props }
+}
+
+// DropdownMenuTrigger (@radix-ui/react-dropdown-menu) opens on POINTERDOWN,
+// not click (see its source: onPointerDown calls context.onOpenToggle(); the
+// button carries no onClick open-handler at all) — a plain fireEvent.click
+// never opens it. fireEvent.pointerDown ALSO doesn't work here: jsdom has no
+// PointerEvent class, so testing-library falls back to a bare Event whose
+// `.button` reads back undefined, and Radix's handler requires `=== 0`. A
+// MouseEvent typed 'pointerdown' carries a real, settable `.button` and
+// React routes it to onPointerDown the same way (it dispatches on the DOM
+// event's type string, not its class) — verified against this exact
+// component before writing the rest of the suite.
+function pointerDown(el: Element) {
+  fireEvent(el, new MouseEvent('pointerdown', { bubbles: true, cancelable: true, button: 0 }))
+}
+const openMenu = () => pointerDown(screen.getByText('Open menu'))
+
+describe('MoveToGroupMenu — listing groups', () => {
+  it('lists every group in the org', () => {
+    renderMenu()
+    openMenu()
+
+    expect(screen.getByText('Checkout')).toBeInTheDocument()
+    expect(screen.getByText('Regression')).toBeInTheDocument()
+  })
+
+  it('says "No groups yet." when the org has none', () => {
+    renderMenu({ groups: [] })
+    openMenu()
+
+    expect(screen.getByText('No groups yet.')).toBeInTheDocument()
+  })
+
+  it('checks off the run’s CURRENT group and no other', () => {
+    renderMenu({ currentGroupId: 'g-2' })
+    openMenu()
+
+    const regressionRow = screen.getByText('Regression').closest('[role="menuitem"]')!
+    const checkoutRow = screen.getByText('Checkout').closest('[role="menuitem"]')!
+    expect(regressionRow.querySelector('svg.lucide-check')).not.toBeNull()
+    expect(checkoutRow.querySelector('svg.lucide-check')).toBeNull()
+  })
+})
+
+describe('MoveToGroupMenu — moving', () => {
+  it('calls onMove with the clicked group’s id', () => {
+    const onMove = vi.fn()
+    renderMenu({ onMove })
+    openMenu()
+
+    fireEvent.click(screen.getByText('Checkout'))
+
+    expect(onMove).toHaveBeenCalledWith('g-1')
+  })
+
+  it('does not let a menu-item click escape to an ancestor click handler', () => {
+    // The exact bug the component's docstring calls out: the menu is
+    // portalled to <body>, but React's synthetic events bubble the REACT
+    // tree, so an unguarded item click would also fire the history ROW's
+    // onClick underneath it and open that run's drawer behind the menu.
+    const onMove = vi.fn()
+    const ancestorClick = vi.fn()
+    render(
+      <div onClick={ancestorClick}>
+        <MoveToGroupMenu
+          groups={[CHECKOUT]}
+          currentGroupId={null}
+          onMove={onMove}
+          onCreateGroup={vi.fn()}
+          trigger={<button type="button">Open menu</button>}
+        />
+      </div>,
+    )
+    pointerDown(screen.getByText('Open menu'))
+
+    fireEvent.click(screen.getByText('Checkout'))
+
+    expect(onMove).toHaveBeenCalledWith('g-1')
+    expect(ancestorClick).not.toHaveBeenCalled()
+  })
+})
+
+describe('MoveToGroupMenu — "Remove from group"', () => {
+  it('is offered when the run already has a group, and calls onMove(null)', () => {
+    const onMove = vi.fn()
+    renderMenu({ currentGroupId: 'g-1', onMove })
+    openMenu()
+
+    fireEvent.click(screen.getByText('Remove from group'))
+
+    expect(onMove).toHaveBeenCalledWith(null)
+  })
+
+  it('is offered for the bulk toolbar (showRemove) even with no single currentGroupId', () => {
+    renderMenu({ currentGroupId: undefined, showRemove: true })
+    openMenu()
+
+    expect(screen.getByText('Remove from group')).toBeInTheDocument()
+  })
+
+  it('is hidden for an ungrouped run outside the bulk toolbar', () => {
+    renderMenu({ currentGroupId: null, showRemove: false })
+    openMenu()
+
+    expect(screen.queryByText('Remove from group')).not.toBeInTheDocument()
+  })
+})
+
+describe('MoveToGroupMenu — create-and-move', () => {
+  it('disables Create & move until a name is entered', () => {
+    renderMenu()
+    openMenu()
+    fireEvent.click(screen.getByText('New group…'))
+
+    expect(screen.getByText('Create & move')).toBeDisabled()
+  })
+
+  it('creates the group, then moves into it using the SERVER-assigned id', async () => {
+    const onMove = vi.fn()
+    const onCreateGroup = vi.fn().mockResolvedValue({ group_id: 'g-server', name: 'Smoke', created_by: 'u1', run_count: 0 })
+    renderMenu({ onMove, onCreateGroup })
+    openMenu()
+    fireEvent.click(screen.getByText('New group…'))
+    fireEvent.change(screen.getByPlaceholderText('e.g. Checkout flows'), { target: { value: '  Smoke  ' } })
+
+    fireEvent.click(screen.getByText('Create & move'))
+
+    await waitFor(() => expect(onCreateGroup).toHaveBeenCalledWith('Smoke'))
+    expect(onMove).toHaveBeenCalledWith('g-server')
+  })
+
+  it('shows the server’s rejection and leaves the dialog open for another try', async () => {
+    const onMove = vi.fn()
+    const onCreateGroup = vi.fn().mockRejectedValue(new Error('A group with that name exists'))
+    renderMenu({ onMove, onCreateGroup })
+    openMenu()
+    fireEvent.click(screen.getByText('New group…'))
+    fireEvent.change(screen.getByPlaceholderText('e.g. Checkout flows'), { target: { value: 'Dup' } })
+
+    fireEvent.click(screen.getByText('Create & move'))
+
+    expect(await screen.findByText('A group with that name exists')).toBeInTheDocument()
+    expect(onMove).not.toHaveBeenCalled()
+    expect(screen.getByPlaceholderText('e.g. Checkout flows')).toBeInTheDocument()
+  })
+
+  it('closes on Cancel without creating or moving anything', () => {
+    const onMove = vi.fn()
+    const onCreateGroup = vi.fn()
+    renderMenu({ onMove, onCreateGroup })
+    openMenu()
+    fireEvent.click(screen.getByText('New group…'))
+
+    fireEvent.click(screen.getByText('Cancel'))
+
+    expect(screen.queryByPlaceholderText('e.g. Checkout flows')).not.toBeInTheDocument()
+    expect(onCreateGroup).not.toHaveBeenCalled()
+    expect(onMove).not.toHaveBeenCalled()
+  })
+})

--- a/src/frontend-react/src/components/theme-provider.test.tsx
+++ b/src/frontend-react/src/components/theme-provider.test.tsx
@@ -1,0 +1,151 @@
+/**
+ * ThemeProvider — colour mode and visual theme, both persisted to
+ * localStorage and both applied as classes on <html>.
+ *
+ * The interesting part is that `mode: 'system'` is not a stored preference but
+ * a live subscription: it has to follow the OS, and it has to stop following
+ * it the moment the user picks light or dark explicitly. A provider that
+ * leaves the listener attached keeps overriding the user's own choice the next
+ * time the OS flips.
+ */
+import { act, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { ThemeProvider, useTheme } from './theme-provider'
+
+/** matchMedia whose match state we control, recording listeners so we can fire them. */
+function stubMatchMedia(matches: boolean) {
+  const listeners: ((e: { matches: boolean }) => void)[] = []
+  window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+    matches, media: query, onchange: null,
+    addEventListener: (_: string, cb: (e: { matches: boolean }) => void) => listeners.push(cb),
+    removeEventListener: (_: string, cb: (e: { matches: boolean }) => void) => {
+      const i = listeners.indexOf(cb); if (i >= 0) listeners.splice(i, 1)
+    },
+    addListener: vi.fn(), removeListener: vi.fn(), dispatchEvent: vi.fn(),
+  }))
+  return listeners
+}
+
+function Probe() {
+  const { mode, theme, setMode, setTheme } = useTheme()
+  return (
+    <div>
+      <span data-testid="mode">{mode}</span>
+      <span data-testid="theme">{theme}</span>
+      <button onClick={() => setMode('dark')}>go dark</button>
+      <button onClick={() => setMode('light')}>go light</button>
+      <button onClick={() => setTheme('neo')}>go neo</button>
+      <button onClick={() => setTheme('professional')}>go professional</button>
+    </div>
+  )
+}
+
+const html = () => document.documentElement
+
+beforeEach(() => {
+  localStorage.clear()
+  html().className = ''
+})
+afterEach(() => {
+  vi.restoreAllMocks()
+  html().className = ''
+})
+
+describe('ThemeProvider', () => {
+  it('defaults to system mode and the professional theme with nothing stored', () => {
+    stubMatchMedia(false)
+
+    render(<ThemeProvider><Probe /></ThemeProvider>)
+
+    expect(screen.getByTestId('mode')).toHaveTextContent('system')
+    expect(screen.getByTestId('theme')).toHaveTextContent('professional')
+  })
+
+  it('seeds both values from localStorage on mount', () => {
+    localStorage.setItem('m1-mode', 'dark')
+    localStorage.setItem('m1-theme', 'neo')
+    stubMatchMedia(false)
+
+    render(<ThemeProvider><Probe /></ThemeProvider>)
+
+    expect(screen.getByTestId('mode')).toHaveTextContent('dark')
+    expect(screen.getByTestId('theme')).toHaveTextContent('neo')
+    expect(html()).toHaveClass('dark')
+    expect(html()).toHaveClass('neo')
+  })
+
+  it('follows the OS when mode is system', () => {
+    stubMatchMedia(true)   // OS says dark
+
+    render(<ThemeProvider><Probe /></ThemeProvider>)
+
+    expect(html()).toHaveClass('dark')
+  })
+
+  it('keeps following the OS while it stays on system', () => {
+    const listeners = stubMatchMedia(false)
+    render(<ThemeProvider><Probe /></ThemeProvider>)
+    expect(html()).not.toHaveClass('dark')
+
+    act(() => { listeners.forEach(cb => cb({ matches: true })) })
+
+    expect(html()).toHaveClass('dark')
+  })
+
+  it('stops following the OS once the user picks a mode explicitly', () => {
+    // The defect this guards: an explicit "light" that the next OS flip
+    // silently overrides.
+    const listeners = stubMatchMedia(false)
+    render(<ThemeProvider><Probe /></ThemeProvider>)
+
+    act(() => { screen.getByText('go light').click() })
+    expect(html()).not.toHaveClass('dark')
+
+    // The system listener is torn down when mode leaves 'system', so any
+    // surviving callback must no longer be able to reach the DOM class.
+    act(() => { listeners.forEach(cb => cb({ matches: true })) })
+
+    expect(html()).not.toHaveClass('dark')
+    expect(screen.getByTestId('mode')).toHaveTextContent('light')
+  })
+
+  it('persists an explicit mode so a reload keeps it', () => {
+    stubMatchMedia(false)
+    render(<ThemeProvider><Probe /></ThemeProvider>)
+
+    act(() => { screen.getByText('go dark').click() })
+
+    expect(localStorage.getItem('m1-mode')).toBe('dark')
+    expect(html()).toHaveClass('dark')
+  })
+
+  it('toggles the neo class on and off, and persists the choice', () => {
+    stubMatchMedia(false)
+    render(<ThemeProvider><Probe /></ThemeProvider>)
+    expect(html()).not.toHaveClass('neo')
+
+    act(() => { screen.getByText('go neo').click() })
+    expect(html()).toHaveClass('neo')
+    expect(localStorage.getItem('m1-theme')).toBe('neo')
+
+    act(() => { screen.getByText('go professional').click() })
+    expect(html()).not.toHaveClass('neo')
+    expect(localStorage.getItem('m1-theme')).toBe('professional')
+  })
+
+  it('keeps colour mode and visual theme independent', () => {
+    // Two separate classes and two separate keys: picking neo must not
+    // disturb dark, and vice versa.
+    stubMatchMedia(false)
+    render(<ThemeProvider><Probe /></ThemeProvider>)
+
+    act(() => { screen.getByText('go dark').click() })
+    act(() => { screen.getByText('go neo').click() })
+
+    expect(html()).toHaveClass('dark')
+    expect(html()).toHaveClass('neo')
+    expect(localStorage.getItem('m1-mode')).toBe('dark')
+    expect(localStorage.getItem('m1-theme')).toBe('neo')
+  })
+})

--- a/src/frontend-react/src/hooks/use-mobile.test.ts
+++ b/src/frontend-react/src/hooks/use-mobile.test.ts
@@ -1,0 +1,100 @@
+/**
+ * useIsMobile — the breakpoint the sidebar collapses on.
+ *
+ * Worth testing for one reason: the hook seeds its state `undefined` and only
+ * resolves it in an effect, then returns `!!isMobile`. So the FIRST render of
+ * every consumer says "not mobile" regardless of the real viewport, and a
+ * consumer that renders a different tree on that first pass will flash the
+ * desktop layout on a phone. These pin that behaviour rather than assume it.
+ */
+import { renderHook, act } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { useIsMobile } from './use-mobile'
+
+const BREAKPOINT = 768
+
+/** Replace matchMedia with one that records its listener so we can fire it. */
+function stubMatchMedia() {
+  const listeners: (() => void)[] = []
+  window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+    matches: window.innerWidth < BREAKPOINT,
+    media: query,
+    onchange: null,
+    addEventListener: (_: string, cb: () => void) => listeners.push(cb),
+    removeEventListener: (_: string, cb: () => void) => {
+      const i = listeners.indexOf(cb)
+      if (i >= 0) listeners.splice(i, 1)
+    },
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  }))
+  return listeners
+}
+
+function setWidth(px: number) {
+  Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: px })
+}
+
+const originalWidth = window.innerWidth
+afterEach(() => {
+  setWidth(originalWidth)
+  vi.restoreAllMocks()
+})
+
+describe('useIsMobile', () => {
+  it('reports mobile for a viewport below the 768px breakpoint', () => {
+    stubMatchMedia()
+    setWidth(500)
+
+    const { result } = renderHook(() => useIsMobile())
+
+    expect(result.current).toBe(true)
+  })
+
+  it('reports not-mobile at exactly the breakpoint, not one below it', () => {
+    // 768 is the first DESKTOP width: the query is max-width 767px and the
+    // comparison is `< 768`. An off-by-one here flips the layout for every
+    // tablet held at exactly 768.
+    stubMatchMedia()
+    setWidth(BREAKPOINT)
+
+    const { result } = renderHook(() => useIsMobile())
+
+    expect(result.current).toBe(false)
+  })
+
+  it('reports mobile one pixel below the breakpoint', () => {
+    stubMatchMedia()
+    setWidth(BREAKPOINT - 1)
+
+    const { result } = renderHook(() => useIsMobile())
+
+    expect(result.current).toBe(true)
+  })
+
+  it('re-reads the width when the media query changes, not just on mount', () => {
+    const listeners = stubMatchMedia()
+    setWidth(1200)
+    const { result } = renderHook(() => useIsMobile())
+    expect(result.current).toBe(false)
+
+    setWidth(400)
+    act(() => { listeners.forEach(cb => cb()) })
+
+    expect(result.current).toBe(true)
+  })
+
+  it('removes its listener on unmount', () => {
+    const listeners = stubMatchMedia()
+    const { unmount } = renderHook(() => useIsMobile())
+    expect(listeners).toHaveLength(1)
+
+    unmount()
+
+    // A leaked listener would call setState on an unmounted hook on every
+    // resize for the lifetime of the tab.
+    expect(listeners).toHaveLength(0)
+  })
+})

--- a/src/frontend-react/src/lib/api.test.ts
+++ b/src/frontend-react/src/lib/api.test.ts
@@ -1,13 +1,55 @@
 /**
- * isAccessLoss — which failures mean "this is no longer yours to read".
+ * lib/api — the fetch wrapper every authenticated call in the SPA goes
+ * through, plus isAccessLoss, which decides whether a failed request means a
+ * row is gone for good.
  *
- * The Test Runs page drops a row from its loaded list on the strength of
- * this answer, so a false positive DELETES something the user can still
- * open. Every status below is one the re-run endpoint can actually return.
+ * isAccessLoss: the Test Runs page drops a row from its loaded list on the
+ * strength of this answer, so a false positive DELETES something the user
+ * can still open. Every status below is one the re-run endpoint can actually
+ * return.
+ *
+ * api(): a 401 must clear the stored token and redirect to /login BEFORE the
+ * caller ever sees a rejected promise - a caller racing that redirect would
+ * otherwise flash its own error UI for a heartbeat before the browser
+ * navigates away. That clear-and-redirect is gated on the same `auth` flag
+ * that decides whether the bearer header is attached at all, so a request
+ * made with `auth: false` (login, register) gets neither - its own 401 is a
+ * refused login, not a session that needs clearing.
+ *
+ * extractDetail(): FastAPI answers errors in three different shapes across
+ * its own routes (a plain string `detail`, a 422 validation `detail` array,
+ * or a bare `message`), and every one of them must turn into one human
+ * sentence instead of "Request failed (422)".
  */
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
-import { ApiError, isAccessLoss } from './api'
+import { ApiError, api, clearToken, extractDetail, getToken, isAccessLoss, setToken } from './api'
+
+function stubFetch(impl: () => Promise<unknown>) {
+  const fn = vi.fn().mockImplementation(impl)
+  vi.stubGlobal('fetch', fn)
+  return fn
+}
+
+function stubLocation(pathname: string, href: string) {
+  const original = window.location
+  Object.defineProperty(window, 'location', { writable: true, value: { pathname, href } })
+  return () => Object.defineProperty(window, 'location', { writable: true, value: original })
+}
+
+/** Resolves to the rejection reason, or fails the test if the promise resolved. */
+async function reasonOf(p: Promise<unknown>): Promise<unknown> {
+  return p.then(
+    () => { throw new Error('expected api(...) to reject, but it resolved') },
+    (err: unknown) => err,
+  )
+}
+
+afterEach(() => {
+  clearToken()
+  vi.unstubAllGlobals()
+  vi.resetAllMocks()
+})
 
 describe('isAccessLoss', () => {
   it('is true when the resource is gone or was never ours', () => {
@@ -45,5 +87,184 @@ describe('isAccessLoss', () => {
     expect(isAccessLoss({ status: 404 })).toBe(false)
     expect(isAccessLoss(undefined)).toBe(false)
     expect(isAccessLoss(null)).toBe(false)
+  })
+})
+
+describe('api — the happy path', () => {
+  it('returns the parsed JSON body on success', async () => {
+    stubFetch(async () => ({ status: 200, ok: true, json: async () => ({ total: 3, rows: ['a', 'b', 'c'] }) }))
+
+    const result = await api<{ total: number; rows: string[] }>('/runs')
+
+    expect(result).toEqual({ total: 3, rows: ['a', 'b', 'c'] })
+  })
+
+  it('returns undefined on 204 without ever trying to parse a body', async () => {
+    // If the 204 short-circuit were ever dropped, this would call .json() on
+    // a body FastAPI never sent for a 204 - the spy below is what proves the
+    // early return actually fires, not just that the result happens to be
+    // undefined.
+    const jsonSpy = vi.fn().mockResolvedValue({ should: 'never be read' })
+    stubFetch(async () => ({ status: 204, ok: true, json: jsonSpy }))
+
+    const result = await api('/runs/1')
+
+    expect(result).toBeUndefined()
+    expect(jsonSpy).not.toHaveBeenCalled()
+  })
+
+  it('passes method and body straight through to fetch', async () => {
+    const fetchMock = stubFetch(async () => ({ status: 200, ok: true, json: async () => ({}) }))
+
+    await api('/runs/1/rerun', { method: 'POST', body: JSON.stringify({ force: true }) })
+
+    const [path, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect(path).toBe('/runs/1/rerun')
+    expect(init.method).toBe('POST')
+    expect(init.body).toBe(JSON.stringify({ force: true }))
+  })
+})
+
+describe('api — the bearer token', () => {
+  it('attaches it when auth defaults true and a token exists', async () => {
+    setToken('secret-token')
+    const fetchMock = stubFetch(async () => ({ status: 200, ok: true, json: async () => ({}) }))
+
+    await api('/runs')
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect((init.headers as Record<string, string>).Authorization).toBe('Bearer secret-token')
+  })
+
+  it('omits it when there is no token, even though auth is true', async () => {
+    const fetchMock = stubFetch(async () => ({ status: 200, ok: true, json: async () => ({}) }))
+
+    await api('/runs')
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect('Authorization' in (init.headers as Record<string, string>)).toBe(false)
+  })
+
+  it('omits it when auth is false, even though a token exists', async () => {
+    // The login/register contract: those calls must not present whatever
+    // token is left over from a previous session.
+    setToken('secret-token')
+    const fetchMock = stubFetch(async () => ({ status: 200, ok: true, json: async () => ({}) }))
+
+    await api('/auth/login', { auth: false })
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect('Authorization' in (init.headers as Record<string, string>)).toBe(false)
+  })
+
+  it('still sends the JSON content type when auth is false', async () => {
+    const fetchMock = stubFetch(async () => ({ status: 200, ok: true, json: async () => ({}) }))
+
+    await api('/auth/login', { auth: false })
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect((init.headers as Record<string, string>)['Content-Type']).toBe('application/json')
+  })
+})
+
+describe('api — the 401 contract', () => {
+  it('clears the token and redirects to /login before the promise rejects', async () => {
+    setToken('secret-token')
+    stubFetch(async () => ({ status: 401, ok: false, json: async () => ({}) }))
+    const restore = stubLocation('/generate', '')
+
+    const err = await reasonOf(api('/runs'))
+
+    expect(err).toBeInstanceOf(ApiError)
+    expect((err as ApiError).status).toBe(401)
+    expect((err as Error).message).toBe('Session expired. Please sign in again.')
+    expect(getToken()).toBeNull()
+    expect((window.location as unknown as { href: string }).href).toBe('/login')
+    restore()
+  })
+
+  it('does not redirect again when already on the login page', async () => {
+    setToken('secret-token')
+    stubFetch(async () => ({ status: 401, ok: false, json: async () => ({}) }))
+    const restore = stubLocation('/login', 'unchanged')
+
+    await reasonOf(api('/runs'))
+
+    expect((window.location as unknown as { href: string }).href).toBe('unchanged')
+    restore()
+  })
+
+  it('does NOT clear the token or redirect on a 401 when auth is false', async () => {
+    // Surprising at first read: `resp.status === 401 && auth` gates the
+    // special-case entirely on the same flag that gates the header. A failed
+    // login legitimately answers 401 (bad credentials) - that is not a
+    // session expiring, and must not evict whatever token another tab is
+    // using. It falls through to the plain error branch below instead.
+    setToken('someone-elses-still-valid-token')
+    stubFetch(async () => ({ status: 401, ok: false, json: async () => ({ detail: 'Incorrect email or password' }) }))
+    const restore = stubLocation('/login', 'unchanged')
+
+    const err = await reasonOf(api('/auth/login', { auth: false }))
+
+    expect(err).toBeInstanceOf(ApiError)
+    expect((err as ApiError).status).toBe(401)
+    expect((err as Error).message).toBe('Incorrect email or password')
+    expect(getToken()).toBe('someone-elses-still-valid-token')
+    expect((window.location as unknown as { href: string }).href).toBe('unchanged')
+    restore()
+  })
+})
+
+describe('api — error responses', () => {
+  it('throws an ApiError built from the response’s own detail message', async () => {
+    stubFetch(async () => ({ status: 404, ok: false, json: async () => ({ detail: 'Run not found' }) }))
+
+    const err = await reasonOf(api('/runs/missing'))
+
+    expect(err).toBeInstanceOf(ApiError)
+    expect((err as ApiError).status).toBe(404)
+    expect((err as Error).message).toBe('Run not found')
+  })
+
+  it('falls back to a generic message when the error body is not JSON', async () => {
+    stubFetch(async () => ({ status: 500, ok: false, json: async () => { throw new Error('not json') } }))
+
+    const err = await reasonOf(api('/runs'))
+
+    expect((err as ApiError).status).toBe(500)
+    expect((err as Error).message).toBe('Request failed (500)')
+  })
+})
+
+describe('extractDetail — normalizing FastAPI’s error body shapes', () => {
+  it('returns a plain string detail as-is', () => {
+    expect(extractDetail({ detail: 'Run not found' }, 'fallback')).toBe('Run not found')
+  })
+
+  it('pulls msg out of a 422 validation array', () => {
+    const body = { detail: [{ loc: ['body', 'query'], msg: 'field required', type: 'missing' }] }
+    expect(extractDetail(body, 'fallback')).toBe('field required')
+  })
+
+  it('falls back to {message} when there is no detail at all', () => {
+    expect(extractDetail({ message: 'Incorrect email or password' }, 'fallback')).toBe('Incorrect email or password')
+  })
+
+  it('prefers a string detail over message when both are present', () => {
+    expect(extractDetail({ detail: 'from detail', message: 'from message' }, 'fallback')).toBe('from detail')
+  })
+
+  it('falls through to message when the detail array has no usable msg', () => {
+    const body = { detail: [{ loc: ['body'] }], message: 'from message' }
+    expect(extractDetail(body, 'fallback')).toBe('from message')
+  })
+
+  it('returns the fallback for shapes with nothing usable', () => {
+    expect(extractDetail({}, 'fallback')).toBe('fallback')
+    expect(extractDetail({ detail: [] }, 'fallback')).toBe('fallback')
+    expect(extractDetail({ detail: 42 }, 'fallback')).toBe('fallback')
+    expect(extractDetail('a bare string body', 'fallback')).toBe('fallback')
+    expect(extractDetail(null, 'fallback')).toBe('fallback')
+    expect(extractDetail(undefined, 'fallback')).toBe('fallback')
   })
 })

--- a/src/frontend-react/src/lib/api.test.ts
+++ b/src/frontend-react/src/lib/api.test.ts
@@ -31,10 +31,28 @@ function stubFetch(impl: () => Promise<unknown>) {
   return fn
 }
 
+/* Restoring window.location is afterEach's job, not the caller's.
+ * vi.unstubAllGlobals() reverts what vi.stubGlobal installed and nothing else,
+ * so it has no record of this defineProperty - and a restore() written at the
+ * end of a test body is precisely the line that does not run when an assertion
+ * above it throws. Registering the undo here means one red test stays one red
+ * test instead of handing a fake location to every test after it. */
+let restoreLocation: (() => void) | null = null
+
+/** jsdom's real location, read before anything has had a chance to stub it. */
+const REAL_PATHNAME = window.location.pathname
+
 function stubLocation(pathname: string, href: string) {
-  const original = window.location
-  Object.defineProperty(window, 'location', { writable: true, value: { pathname, href } })
-  return () => Object.defineProperty(window, 'location', { writable: true, value: original })
+  // jsdom defines `location` as an own property of window, so there is always a
+  // descriptor to put back. If that ever stops being true, defineProperty
+  // throws here in afterEach - which is the loud failure this whole helper is
+  // for, and better than a silent fallback branch no test can reach.
+  const original = Object.getOwnPropertyDescriptor(window, 'location')!
+  Object.defineProperty(window, 'location', { configurable: true, writable: true, value: { pathname, href } })
+  restoreLocation = () => {
+    restoreLocation = null
+    Object.defineProperty(window, 'location', original)
+  }
 }
 
 /** Resolves to the rejection reason, or fails the test if the promise resolved. */
@@ -46,6 +64,7 @@ async function reasonOf(p: Promise<unknown>): Promise<unknown> {
 }
 
 afterEach(() => {
+  restoreLocation?.()
   clearToken()
   vi.unstubAllGlobals()
   vi.resetAllMocks()
@@ -171,7 +190,7 @@ describe('api — the 401 contract', () => {
   it('clears the token and redirects to /login before the promise rejects', async () => {
     setToken('secret-token')
     stubFetch(async () => ({ status: 401, ok: false, json: async () => ({}) }))
-    const restore = stubLocation('/generate', '')
+    stubLocation('/generate', '')
 
     const err = await reasonOf(api('/runs'))
 
@@ -180,18 +199,16 @@ describe('api — the 401 contract', () => {
     expect((err as Error).message).toBe('Session expired. Please sign in again.')
     expect(getToken()).toBeNull()
     expect((window.location as unknown as { href: string }).href).toBe('/login')
-    restore()
   })
 
   it('does not redirect again when already on the login page', async () => {
     setToken('secret-token')
     stubFetch(async () => ({ status: 401, ok: false, json: async () => ({}) }))
-    const restore = stubLocation('/login', 'unchanged')
+    stubLocation('/login', 'unchanged')
 
     await reasonOf(api('/runs'))
 
     expect((window.location as unknown as { href: string }).href).toBe('unchanged')
-    restore()
   })
 
   it('does NOT clear the token or redirect on a 401 when auth is false', async () => {
@@ -202,7 +219,7 @@ describe('api — the 401 contract', () => {
     // using. It falls through to the plain error branch below instead.
     setToken('someone-elses-still-valid-token')
     stubFetch(async () => ({ status: 401, ok: false, json: async () => ({ detail: 'Incorrect email or password' }) }))
-    const restore = stubLocation('/login', 'unchanged')
+    stubLocation('/login', 'unchanged')
 
     const err = await reasonOf(api('/auth/login', { auth: false }))
 
@@ -211,7 +228,6 @@ describe('api — the 401 contract', () => {
     expect((err as Error).message).toBe('Incorrect email or password')
     expect(getToken()).toBe('someone-elses-still-valid-token')
     expect((window.location as unknown as { href: string }).href).toBe('unchanged')
-    restore()
   })
 })
 
@@ -266,5 +282,34 @@ describe('extractDetail — normalizing FastAPI’s error body shapes', () => {
     expect(extractDetail('a bare string body', 'fallback')).toBe('fallback')
     expect(extractDetail(null, 'fallback')).toBe('fallback')
     expect(extractDetail(undefined, 'fallback')).toBe('fallback')
+  })
+})
+
+/* The guard on stubLocation's afterEach cleanup. Undoing the stub used to be
+ * the caller's job, at the end of each test body - the one line that does NOT
+ * run when an assertion above it throws - and vi.unstubAllGlobals() cannot
+ * cover for it, because it reverts only what vi.stubGlobal installed. One
+ * failing 401 test would have handed every later test in this file a fake
+ * window.location, turning one red test into a cascade pointing nowhere near
+ * the cause.
+ *
+ * These two run as a pair: the first leaks on purpose, exactly the way a
+ * mid-test failure does, and the second is the one that would have paid for
+ * it. Deleting either leaves the other passing for the wrong reason. */
+describe('stubLocation cleans up even when a test fails partway', () => {
+  it('installs a stub and never restores it, as a failing test would not', () => {
+    stubLocation('/leaked-from-the-previous-test', 'leaked')
+
+    expect(window.location.pathname).toBe('/leaked-from-the-previous-test')
+    // deliberately no restore() here
+  })
+
+  it('still sees the real window.location afterwards', () => {
+    // The real one, not merely "not the fake one": putting back some other
+    // object would also clear the leaked pathname while leaving window.location
+    // a stub.
+    expect(window.location.pathname).toBe(REAL_PATHNAME)
+    expect(window.location).toBeInstanceOf(Object)
+    expect(typeof window.location.assign).toBe('function')
   })
 })

--- a/src/frontend-react/src/lib/sse.test.ts
+++ b/src/frontend-react/src/lib/sse.test.ts
@@ -1,0 +1,325 @@
+/**
+ * streamSSE — the POST+SSE reader behind GeneratePage's generate/execute flow.
+ *
+ * Everything here is invisible to a type check and silent when it breaks: a
+ * dropped Authorization header still compiles, a 401 that forgets to clear
+ * the token still compiles, and a chunk-boundary bug in the buffer only shows
+ * up as an event that quietly never arrives — no throw, just a step the UI
+ * never draws. This file pins:
+ *   - the request shape (method, headers, the bearer token gated on its own
+ *     existence, the abort signal forwarded),
+ *   - the same 401-clears-and-redirects-before-throwing contract lib/api.ts
+ *     implements (this module's own docstring says "same contract as
+ *     lib/api"), including the already-on-/login case that must NOT redirect
+ *     again,
+ *   - non-401 failures turned into an ApiError carrying the server's own
+ *     detail message, with a plain-status fallback when the error body isn't
+ *     JSON,
+ *   - the ok-but-bodyless response, which would otherwise hang forever on
+ *     `resp.body.getReader()`,
+ *   - and the actual SSE parsing: buffering a JSON event split across two
+ *     network reads, flushing a final event with no trailing blank line,
+ *     ignoring non-"data:" blocks and empty "data:" lines, and swallowing one
+ *     malformed event without failing every event after it.
+ *
+ * ./api is mocked wholesale: getToken/clearToken/extractDetail are the only
+ * things streamSSE asks of it, and ApiError is a real minimal stand-in (not
+ * the actual export) so the `instanceof` checks below see the exact class
+ * streamSSE itself throws.
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('./api', () => {
+  class ApiError extends Error {
+    status: number
+    constructor(status: number, message: string) {
+      super(message)
+      this.status = status
+      this.name = 'ApiError'
+    }
+  }
+  return {
+    ApiError,
+    getToken: vi.fn(),
+    clearToken: vi.fn(),
+    extractDetail: vi.fn(),
+  }
+})
+
+import { ApiError, clearToken, extractDetail, getToken } from './api'
+import { streamSSE } from './sse'
+
+const mockGetToken = vi.mocked(getToken)
+const mockClearToken = vi.mocked(clearToken)
+const mockExtractDetail = vi.mocked(extractDetail)
+
+function stubFetch(impl: () => Promise<unknown>) {
+  const fn = vi.fn().mockImplementation(impl)
+  vi.stubGlobal('fetch', fn)
+  return fn
+}
+
+/** Feeds `chunks` out of resp.body.getReader().read(), one per call, then signals done. */
+function bodyOf(chunks: string[]) {
+  const encoder = new TextEncoder()
+  let i = 0
+  return {
+    getReader: () => ({
+      read: vi.fn().mockImplementation(async () => {
+        if (i < chunks.length) {
+          const value = encoder.encode(chunks[i])
+          i += 1
+          return { done: false, value }
+        }
+        return { done: true, value: undefined }
+      }),
+    }),
+  }
+}
+
+function bodyThatRejects(err: unknown) {
+  return { getReader: () => ({ read: vi.fn().mockRejectedValue(err) }) }
+}
+
+function okResponse(chunks: string[], status = 200) {
+  return { status, ok: true, body: bodyOf(chunks) }
+}
+
+function stubLocation(pathname: string, href: string) {
+  const original = window.location
+  Object.defineProperty(window, 'location', { writable: true, value: { pathname, href } })
+  return () => Object.defineProperty(window, 'location', { writable: true, value: original })
+}
+
+/** Resolves to the rejection reason, or fails the test if the promise resolved. */
+async function reasonOf(p: Promise<unknown>): Promise<unknown> {
+  return p.then(
+    () => { throw new Error('expected streamSSE(...) to reject, but it resolved') },
+    (err: unknown) => err,
+  )
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  vi.resetAllMocks()
+})
+
+describe('streamSSE — the request it sends', () => {
+  it('posts JSON with an SSE accept header', async () => {
+    const fetchMock = stubFetch(async () => okResponse([]))
+    mockGetToken.mockReturnValue(null)
+
+    await streamSSE('/generate-and-run', { query: 'open flipkart' }, vi.fn())
+
+    const [path, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect(path).toBe('/generate-and-run')
+    expect(init.method).toBe('POST')
+    expect(init.body).toBe(JSON.stringify({ query: 'open flipkart' }))
+    expect((init.headers as Record<string, string>)['Content-Type']).toBe('application/json')
+    expect((init.headers as Record<string, string>).Accept).toBe('text/event-stream')
+  })
+
+  it('attaches the bearer token when one exists', async () => {
+    const fetchMock = stubFetch(async () => okResponse([]))
+    mockGetToken.mockReturnValue('tok-123')
+
+    await streamSSE('/x', {}, vi.fn())
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect((init.headers as Record<string, string>).Authorization).toBe('Bearer tok-123')
+  })
+
+  it('sends no Authorization header at all when there is no token', async () => {
+    // Not "empty string" - genuinely absent, so a caller can't tell a missing
+    // token from an empty one by inspecting the header.
+    const fetchMock = stubFetch(async () => okResponse([]))
+    mockGetToken.mockReturnValue(null)
+
+    await streamSSE('/x', {}, vi.fn())
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect('Authorization' in (init.headers as Record<string, string>)).toBe(false)
+  })
+
+  it('forwards the caller’s AbortSignal to fetch', async () => {
+    const fetchMock = stubFetch(async () => okResponse([]))
+    mockGetToken.mockReturnValue(null)
+    const controller = new AbortController()
+
+    await streamSSE('/x', {}, vi.fn(), controller.signal)
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect(init.signal).toBe(controller.signal)
+  })
+})
+
+describe('streamSSE — the 401 contract (same as lib/api)', () => {
+  it('clears the token and redirects to /login before rejecting', async () => {
+    stubFetch(async () => ({ status: 401, ok: false, json: async () => ({}) }))
+    mockGetToken.mockReturnValue('tok')
+    const restore = stubLocation('/generate', '')
+
+    const err = await reasonOf(streamSSE('/x', {}, vi.fn()))
+
+    expect((err as Error).message).toBe('Session expired. Please sign in again.')
+    expect(mockClearToken).toHaveBeenCalledTimes(1)
+    expect((window.location as unknown as { href: string }).href).toBe('/login')
+    restore()
+  })
+
+  it('still clears the token but does not redirect again when already on /login', async () => {
+    stubFetch(async () => ({ status: 401, ok: false, json: async () => ({}) }))
+    mockGetToken.mockReturnValue('tok')
+    const restore = stubLocation('/login', 'unchanged')
+
+    await reasonOf(streamSSE('/x', {}, vi.fn()))
+
+    expect(mockClearToken).toHaveBeenCalledTimes(1)
+    expect((window.location as unknown as { href: string }).href).toBe('unchanged')
+    restore()
+  })
+
+  it('never calls onEvent on a 401', async () => {
+    stubFetch(async () => ({ status: 401, ok: false, json: async () => ({}) }))
+    mockGetToken.mockReturnValue(null)
+    const onEvent = vi.fn()
+    const restore = stubLocation('/x', '')
+
+    await reasonOf(streamSSE('/x', {}, onEvent))
+
+    expect(onEvent).not.toHaveBeenCalled()
+    restore()
+  })
+})
+
+describe('streamSSE — non-401 error responses', () => {
+  it('throws an ApiError built from the server’s own detail message', async () => {
+    const body = { detail: 'Run not found' }
+    stubFetch(async () => ({ status: 404, ok: false, json: async () => body }))
+    mockGetToken.mockReturnValue(null)
+    mockExtractDetail.mockReturnValue('Run not found')
+
+    const err = await reasonOf(streamSSE('/x', {}, vi.fn()))
+
+    expect(err).toBeInstanceOf(ApiError)
+    expect((err as InstanceType<typeof ApiError>).status).toBe(404)
+    expect((err as Error).message).toBe('Run not found')
+    expect(mockExtractDetail).toHaveBeenCalledWith(body, 'Request failed (404)')
+  })
+
+  it('falls back to a generic message when the error body is not JSON', async () => {
+    stubFetch(async () => ({
+      status: 500, ok: false, json: async () => { throw new Error('not json') },
+    }))
+    mockGetToken.mockReturnValue(null)
+
+    const err = await reasonOf(streamSSE('/x', {}, vi.fn()))
+
+    expect((err as InstanceType<typeof ApiError>).status).toBe(500)
+    expect((err as Error).message).toBe('Request failed (500)')
+    // The catch is around `await resp.json()` itself - a body that fails to
+    // parse must never reach extractDetail at all.
+    expect(mockExtractDetail).not.toHaveBeenCalled()
+  })
+})
+
+describe('streamSSE — a response with no readable body', () => {
+  it('throws instead of hanging when resp.body is missing on an ok response', async () => {
+    stubFetch(async () => ({ status: 200, ok: true, body: null }))
+    mockGetToken.mockReturnValue(null)
+
+    const err = await reasonOf(streamSSE('/x', {}, vi.fn()))
+
+    expect((err as InstanceType<typeof ApiError>).status).toBe(200)
+    expect((err as Error).message).toBe('The server sent no event stream')
+  })
+})
+
+describe('streamSSE — parsing the event stream', () => {
+  it('parses a single data: event and hands the parsed JSON to onEvent', async () => {
+    stubFetch(async () => okResponse(['data: {"step":"start"}\n\n']))
+    mockGetToken.mockReturnValue(null)
+    const onEvent = vi.fn()
+
+    await streamSSE('/x', {}, onEvent)
+
+    expect(onEvent).toHaveBeenCalledTimes(1)
+    expect(onEvent).toHaveBeenCalledWith({ step: 'start' })
+  })
+
+  it('parses multiple events delivered in the same chunk, in order', async () => {
+    stubFetch(async () => okResponse(['data: {"i":1}\n\ndata: {"i":2}\n\n']))
+    mockGetToken.mockReturnValue(null)
+    const onEvent = vi.fn()
+
+    await streamSSE('/x', {}, onEvent)
+
+    expect(onEvent.mock.calls).toEqual([[{ i: 1 }], [{ i: 2 }]])
+  })
+
+  it('reassembles one event whose JSON is split across two network reads', async () => {
+    // The exact case the module docstring calls out. Without the buffer
+    // carrying `{"a"` forward, that fragment has no blank-line terminator on
+    // its own read and would be dropped rather than joined with `:1}`.
+    stubFetch(async () => okResponse(['data: {"a"', ':1}\n\n']))
+    mockGetToken.mockReturnValue(null)
+    const onEvent = vi.fn()
+
+    await streamSSE('/x', {}, onEvent)
+
+    expect(onEvent).toHaveBeenCalledTimes(1)
+    expect(onEvent).toHaveBeenCalledWith({ a: 1 })
+  })
+
+  it('still emits the last event when the stream ends with no trailing blank line', async () => {
+    stubFetch(async () => okResponse(['data: {"done":true}']))
+    mockGetToken.mockReturnValue(null)
+    const onEvent = vi.fn()
+
+    await streamSSE('/x', {}, onEvent)
+
+    expect(onEvent).toHaveBeenCalledTimes(1)
+    expect(onEvent).toHaveBeenCalledWith({ done: true })
+  })
+
+  it('ignores a non-data block (a comment/keep-alive line) without losing the event after it', async () => {
+    stubFetch(async () => okResponse([': keep-alive\n\ndata: {"x":1}\n\n']))
+    mockGetToken.mockReturnValue(null)
+    const onEvent = vi.fn()
+
+    await streamSSE('/x', {}, onEvent)
+
+    expect(onEvent).toHaveBeenCalledTimes(1)
+    expect(onEvent).toHaveBeenCalledWith({ x: 1 })
+  })
+
+  it('ignores an empty "data:" line', async () => {
+    stubFetch(async () => okResponse(['data:\n\ndata: {"x":1}\n\n']))
+    mockGetToken.mockReturnValue(null)
+    const onEvent = vi.fn()
+
+    await streamSSE('/x', {}, onEvent)
+
+    expect(onEvent).toHaveBeenCalledTimes(1)
+    expect(onEvent).toHaveBeenCalledWith({ x: 1 })
+  })
+
+  it('swallows one malformed JSON event without failing the whole stream', async () => {
+    stubFetch(async () => okResponse(['data: {not valid json\n\ndata: {"ok":true}\n\n']))
+    mockGetToken.mockReturnValue(null)
+    const onEvent = vi.fn()
+
+    await expect(streamSSE('/x', {}, onEvent)).resolves.toBeUndefined()
+    expect(onEvent).toHaveBeenCalledTimes(1)
+    expect(onEvent).toHaveBeenCalledWith({ ok: true })
+  })
+
+  it('propagates a read() rejection instead of hanging forever', async () => {
+    stubFetch(async () => ({ status: 200, ok: true, body: bodyThatRejects(new Error('connection reset')) }))
+    mockGetToken.mockReturnValue(null)
+
+    const err = await reasonOf(streamSSE('/x', {}, vi.fn()))
+
+    expect((err as Error).message).toBe('connection reset')
+  })
+})

--- a/src/frontend-react/src/lib/useFetch.test.ts
+++ b/src/frontend-react/src/lib/useFetch.test.ts
@@ -1,0 +1,192 @@
+/**
+ * useFetch — the hook's own tests. It had none before this file, while being
+ * called from 16 places, which is why the staleness defect below survived.
+ *
+ * What this pins, in the order it matters:
+ *
+ *  - The defect: a fetch that FAILS for a path the data on screen does not
+ *    belong to must not leave that data on screen. Three call sites build
+ *    their path from a filter that changes while mounted and render the error
+ *    banner and the rows as SIBLINGS rather than as an early return
+ *    (LearningPage.tsx's hints and runs tables, TriggersTab.tsx's list), so
+ *    before this the banner appeared above the PREVIOUS filter's rows and its
+ *    previous total.
+ *
+ *  - The behaviour that must survive the fix: on the SUCCESS path a path
+ *    change must not blank the data first. Two of those three sites write
+ *    `{loading && !data && <Loading…/>}` precisely so the old rows stay put
+ *    while the new ones load, and clearing data on every path change defeats
+ *    that guard — measured, it commits BLANK then LOADING then the rows,
+ *    three states where there was one, on every filter click and every
+ *    debounced keystroke.
+ *
+ *  - The other behaviour that must survive it: a SAME-path reload() that
+ *    fails keeps its data, under the banner. That is not staleness, it is the
+ *    last good view of the same screen, and six call sites render it
+ *    deliberately. LearningPage.tsx's act() awaits reload() after every
+ *    unflag/retract/reactivate, so this is the live path, not a hypothetical.
+ *
+ * Together those three are why the fix is scoped to "the data belongs to a
+ * different path", and is neither "clear on every path change" nor "clear on
+ * every error" — each of which fixes the defect but breaks one of the other
+ * two.
+ */
+import { renderHook, waitFor, act } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('./api', () => ({ api: vi.fn() }))
+
+import { api } from './api'
+import { useFetch } from './useFetch'
+
+const mockApi = vi.mocked(api)
+
+beforeEach(() => mockApi.mockReset())
+afterEach(() => vi.resetAllMocks())
+
+const ROWS_A = { total: 122, rows: ['a'] }
+const ROWS_B = { total: 48, rows: ['b'] }
+
+describe('useFetch — the basics it never had a test for', () => {
+  it('fetches on mount and returns the payload', async () => {
+    mockApi.mockResolvedValue(ROWS_A)
+
+    const { result } = renderHook(() => useFetch<typeof ROWS_A>('/runs'))
+
+    await waitFor(() => expect(result.current.data).toEqual(ROWS_A))
+    expect(mockApi).toHaveBeenCalledWith('/runs')
+    expect(result.current.loading).toBe(false)
+    expect(result.current.error).toBe('')
+  })
+
+  it('does not fetch at all when the path is null, and settles loading to false', async () => {
+    const { result } = renderHook(() => useFetch<typeof ROWS_A>(null))
+
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    expect(mockApi).not.toHaveBeenCalled()
+    expect(result.current.data).toBeNull()
+  })
+
+  it('surfaces the error message and leaves data null when the FIRST fetch fails', async () => {
+    mockApi.mockRejectedValue(new Error('nope'))
+
+    const { result } = renderHook(() => useFetch<typeof ROWS_A>('/runs'))
+
+    await waitFor(() => expect(result.current.error).toBe('nope'))
+    expect(result.current.data).toBeNull()
+  })
+
+  it('ignores a response that lands after the path has already moved on', async () => {
+    // The monotonic seq guard. A resolves LAST but is no longer the newest
+    // request, so its payload must not overwrite B's.
+    let resolveA: (v: unknown) => void = () => {}
+    mockApi.mockImplementationOnce(() => new Promise(r => { resolveA = r }))
+    mockApi.mockResolvedValueOnce(ROWS_B)
+
+    const { result, rerender } = renderHook(({ p }) => useFetch<typeof ROWS_A>(p), {
+      initialProps: { p: '/runs' },
+    })
+    rerender({ p: '/runs?status=failed' })
+    await waitFor(() => expect(result.current.data).toEqual(ROWS_B))
+
+    await act(async () => { resolveA(ROWS_A) })
+
+    expect(result.current.data).toEqual(ROWS_B)
+  })
+})
+
+describe('useFetch — data must not outlive the path it answered', () => {
+  it('clears data when a fetch FAILS for a path the data does not belong to', async () => {
+    // The defect. Filter A loaded 122 rows; the user clicks a filter whose
+    // read the server refuses. Before the fix, `data` stayed — so the caller
+    // rendered its error banner above filter A's rows and its "122 runs".
+    mockApi.mockResolvedValueOnce(ROWS_A)
+    mockApi.mockRejectedValueOnce(new Error('403 refused'))
+
+    const { result, rerender } = renderHook(({ p }) => useFetch<typeof ROWS_A>(p), {
+      initialProps: { p: '/runs' },
+    })
+    await waitFor(() => expect(result.current.data).toEqual(ROWS_A))
+
+    rerender({ p: '/runs?status=failed' })
+
+    await waitFor(() => expect(result.current.error).toBe('403 refused'))
+    expect(result.current.data).toBeNull()
+  })
+
+  it('keeps data through a SUCCESSFUL path change, never nulling it in between', async () => {
+    // Keep-previous-data. If this regresses, `{loading && !data && …}` at
+    // LearningPage.tsx and TriggersTab.tsx starts flashing a blank table and
+    // then "Loading…" on every filter click.
+    mockApi.mockResolvedValueOnce(ROWS_A)
+    mockApi.mockResolvedValueOnce(ROWS_B)
+
+    const seen: (typeof ROWS_A | null)[] = []
+    const { result, rerender } = renderHook(({ p }) => {
+      const r = useFetch<typeof ROWS_A>(p)
+      seen.push(r.data)
+      return r
+    }, { initialProps: { p: '/runs' } })
+    await waitFor(() => expect(result.current.data).toEqual(ROWS_A))
+    const from = seen.length
+
+    rerender({ p: '/runs?status=failed' })
+    await waitFor(() => expect(result.current.data).toEqual(ROWS_B))
+
+    // Every render between the two payloads held one of them — never null.
+    expect(seen.slice(from)).not.toContain(null)
+  })
+
+  it('keeps data when a SAME-path reload() fails', async () => {
+    // Not staleness: the last good view of the same screen, under a banner.
+    // LearningPage.tsx's act() awaits reload() after every hint mutation.
+    mockApi.mockResolvedValueOnce(ROWS_A)
+    mockApi.mockRejectedValueOnce(new Error('500 on refresh'))
+
+    const { result } = renderHook(() => useFetch<typeof ROWS_A>('/runs'))
+    await waitFor(() => expect(result.current.data).toEqual(ROWS_A))
+
+    await act(async () => { await result.current.reload() })
+
+    expect(result.current.error).toBe('500 on refresh')
+    expect(result.current.data).toEqual(ROWS_A)
+  })
+
+  it('clears data when returning to a path whose refetch fails after another path succeeded', async () => {
+    // A succeeds, B succeeds (so the data on screen is B's), then back to A
+    // and A fails. B's rows must not sit under an A-shaped banner.
+    mockApi.mockResolvedValueOnce(ROWS_A)
+    mockApi.mockResolvedValueOnce(ROWS_B)
+    mockApi.mockRejectedValueOnce(new Error('A refused'))
+
+    const { result, rerender } = renderHook(({ p }) => useFetch<typeof ROWS_A>(p), {
+      initialProps: { p: '/runs' },
+    })
+    await waitFor(() => expect(result.current.data).toEqual(ROWS_A))
+    rerender({ p: '/runs?status=failed' })
+    await waitFor(() => expect(result.current.data).toEqual(ROWS_B))
+
+    rerender({ p: '/runs' })
+
+    await waitFor(() => expect(result.current.error).toBe('A refused'))
+    expect(result.current.data).toBeNull()
+  })
+
+  it('a failed path change followed by a successful one recovers, with no residue', async () => {
+    mockApi.mockResolvedValueOnce(ROWS_A)
+    mockApi.mockRejectedValueOnce(new Error('transient'))
+    mockApi.mockResolvedValueOnce(ROWS_B)
+
+    const { result, rerender } = renderHook(({ p }) => useFetch<typeof ROWS_A>(p), {
+      initialProps: { p: '/runs' },
+    })
+    await waitFor(() => expect(result.current.data).toEqual(ROWS_A))
+    rerender({ p: '/runs?status=passed' })
+    await waitFor(() => expect(result.current.data).toBeNull())
+
+    rerender({ p: '/runs?status=failed' })
+
+    await waitFor(() => expect(result.current.data).toEqual(ROWS_B))
+    expect(result.current.error).toBe('')
+  })
+})

--- a/src/frontend-react/src/lib/useFetch.test.ts
+++ b/src/frontend-react/src/lib/useFetch.test.ts
@@ -32,6 +32,7 @@
  * two.
  */
 import { renderHook, waitFor, act } from '@testing-library/react'
+import { StrictMode, createElement, type ReactNode } from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 vi.mock('./api', () => ({ api: vi.fn() }))
@@ -187,6 +188,131 @@ describe('useFetch — data must not outlive the path it answered', () => {
     rerender({ p: '/runs?status=failed' })
 
     await waitFor(() => expect(result.current.data).toEqual(ROWS_B))
+    expect(result.current.error).toBe('')
+  })
+})
+
+// StrictMode is ON in this app (main.tsx wraps <App/> in it), so in dev every
+// effect mounts, unmounts and mounts again — reload() fires twice per mount and
+// the FIRST request is superseded before it resolves. These re-run the two
+// behaviours that matter under that double-invocation, because the rest of this
+// file renders without it and would not catch a regression that only appears
+// there.
+const strict = {
+  wrapper: ({ children }: { children: ReactNode }) => createElement(StrictMode, null, children),
+}
+
+describe('useFetch — under StrictMode double-invocation', () => {
+  it('still clears data on a cross-path failure', async () => {
+    mockApi.mockResolvedValue(ROWS_A)
+    const { result, rerender } = renderHook(({ p }) => useFetch<typeof ROWS_A>(p), {
+      initialProps: { p: '/runs' }, ...strict,
+    })
+    await waitFor(() => expect(result.current.data).toEqual(ROWS_A))
+
+    mockApi.mockRejectedValue(new Error('403 refused'))
+    rerender({ p: '/runs?status=failed' })
+
+    await waitFor(() => expect(result.current.error).toBe('403 refused'))
+    expect(result.current.data).toBeNull()
+  })
+
+  it('still keeps data when a same-path reload() fails', async () => {
+    mockApi.mockResolvedValue(ROWS_A)
+    const { result } = renderHook(() => useFetch<typeof ROWS_A>('/runs'), strict)
+    await waitFor(() => expect(result.current.data).toEqual(ROWS_A))
+
+    mockApi.mockRejectedValue(new Error('500 on refresh'))
+    await act(async () => { await result.current.reload() })
+
+    expect(result.current.data).toEqual(ROWS_A)
+  })
+})
+
+describe('useFetch — paths that pass through null', () => {
+  // Two call sites do this: HistoryPage's detail and corrections fetches are
+  // `selected ? \`/api/.../${selected}\` : null`, so closing the drawer sends
+  // the path to null and reload() early-returns without touching anything.
+  it('clears data when the path goes A -> null -> B and B fails', async () => {
+    mockApi.mockResolvedValueOnce(ROWS_A)
+    const { result, rerender } = renderHook(({ p }) => useFetch<typeof ROWS_A>(p), {
+      initialProps: { p: '/runs' as string | null },
+    })
+    await waitFor(() => expect(result.current.data).toEqual(ROWS_A))
+
+    rerender({ p: null })
+    expect(result.current.data).toEqual(ROWS_A)   // nothing runs on a null path
+
+    mockApi.mockRejectedValueOnce(new Error('B refused'))
+    rerender({ p: '/runs?status=failed' })
+
+    await waitFor(() => expect(result.current.error).toBe('B refused'))
+    expect(result.current.data).toBeNull()
+  })
+
+  it('KEEPS data when the path goes A -> null -> A and A fails', async () => {
+    // Reopening the SAME row. What is on screen is still that path's own
+    // answer, so this is the keep case, not the drop case.
+    mockApi.mockResolvedValueOnce(ROWS_A)
+    const { result, rerender } = renderHook(({ p }) => useFetch<typeof ROWS_A>(p), {
+      initialProps: { p: '/runs' as string | null },
+    })
+    await waitFor(() => expect(result.current.data).toEqual(ROWS_A))
+
+    rerender({ p: null })
+    mockApi.mockRejectedValueOnce(new Error('A refused'))
+    rerender({ p: '/runs' })
+
+    await waitFor(() => expect(result.current.error).toBe('A refused'))
+    expect(result.current.data).toEqual(ROWS_A)
+  })
+})
+
+describe('useFetch — teardown and pile-ups', () => {
+  it('does not throw when the component unmounts with a request still in flight', async () => {
+    let settle: (v: unknown) => void = () => {}
+    mockApi.mockImplementationOnce(() => new Promise(r => { settle = r }))
+    const { unmount } = renderHook(() => useFetch<typeof ROWS_A>('/runs'))
+
+    unmount()
+
+    await act(async () => { settle(ROWS_A) })
+    // Reaching here without an unhandled rejection or a React warning IS the
+    // assertion; the explicit one keeps the test from being vacuous.
+    expect(mockApi).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not throw when the component unmounts with a request about to FAIL', async () => {
+    let boom: (e: unknown) => void = () => {}
+    mockApi.mockImplementationOnce(() => new Promise((_, rej) => { boom = rej }))
+    const { unmount } = renderHook(() => useFetch<typeof ROWS_A>('/runs'))
+
+    unmount()
+
+    await act(async () => { boom(new Error('late failure')) })
+    expect(mockApi).toHaveBeenCalledTimes(1)
+  })
+
+  it('a superseded request that FAILS late never clears the current path’s data', async () => {
+    // A -> B -> C where B rejects after C has already landed. B is not the
+    // newest request, so its catch must not run at all - if it did, its clear
+    // would wipe C's perfectly good data.
+    let failB: (e: unknown) => void = () => {}
+    mockApi.mockResolvedValueOnce(ROWS_A)
+    mockApi.mockImplementationOnce(() => new Promise((_, rej) => { failB = rej }))
+    mockApi.mockResolvedValueOnce(ROWS_B)
+
+    const { result, rerender } = renderHook(({ p }) => useFetch<typeof ROWS_A>(p), {
+      initialProps: { p: '/runs' },
+    })
+    await waitFor(() => expect(result.current.data).toEqual(ROWS_A))
+    rerender({ p: '/runs?status=passed' })
+    rerender({ p: '/runs?status=failed' })
+    await waitFor(() => expect(result.current.data).toEqual(ROWS_B))
+
+    await act(async () => { failB(new Error('late B failure')) })
+
+    expect(result.current.data).toEqual(ROWS_B)
     expect(result.current.error).toBe('')
   })
 })

--- a/src/frontend-react/src/lib/useFetch.ts
+++ b/src/frontend-react/src/lib/useFetch.ts
@@ -13,6 +13,10 @@ export function useFetch<T = unknown>(path: string | null) {
   // Monotonic request id — a response only lands if no newer request started
   // since (path can change mid-flight, e.g. switching drawer rows).
   const seq = useRef(0)
+  // The path `data` is currently an answer TO. Not state: nothing renders it,
+  // it is only read on the failure path below, and it is written in the same
+  // place `data` is.
+  const dataPath = useRef<string | null>(null)
 
   const reload = useCallback(async () => {
     if (!path) {
@@ -24,9 +28,34 @@ export function useFetch<T = unknown>(path: string | null) {
     setError('')
     try {
       const result = await api<T>(path)
-      if (id === seq.current) setData(result)
+      if (id === seq.current) {
+        setData(result)
+        dataPath.current = path
+      }
     } catch (e) {
-      if (id === seq.current) setError(e instanceof Error ? e.message : 'Failed to load')
+      if (id === seq.current) {
+        setError(e instanceof Error ? e.message : 'Failed to load')
+        // `data` is deliberately KEPT when this path's own refetch fails —
+        // that is the last good view of the same screen, and most callers
+        // render it under an error banner on purpose.
+        //
+        // It must NOT be kept when it belongs to a different path. Then it is
+        // not a stale view of this request, it is another request's answer,
+        // and callers that render `{error && …}` and `{data && …}` as
+        // siblings (LearningPage's hints and runs tables, TriggersTab's list —
+        // each with a path built from a filter that changes while mounted)
+        // would put the banner above the PREVIOUS filter's rows and its
+        // previous total.
+        //
+        // Scoped to the failure path on purpose: clearing on every path change
+        // would also fire on the SUCCESS path, defeating the
+        // `{loading && !data && …}` keep-previous-data guard those same
+        // callers rely on.
+        if (dataPath.current !== path) {
+          setData(null)
+          dataPath.current = null
+        }
+      }
     } finally {
       if (id === seq.current) setLoading(false)
     }

--- a/src/frontend-react/src/pages/FeedbackPanel.test.tsx
+++ b/src/frontend-react/src/pages/FeedbackPanel.test.tsx
@@ -774,6 +774,33 @@ describe('T7: retracting a hint from the feedback panel', () => {
       expect(screen.getByText('— retracted')).toBeInTheDocument()
       expect(screen.queryByText('— switched off')).toBeNull()
     })
+
+    it('lets the in-session retract win in the NOTICE too, not just the marker', async () => {
+      // The same precedence as the marker above, one layer down - and it was
+      // NOT covered: swapping the two branches of the duplicate notice left
+      // all 48 tests green. Both sentences state the same "it will not come
+      // back on this run" fact; only the retracted one claims WHO, and
+      // active === false alone cannot know the retract was this user's own.
+      //
+      // The fixture is unreachable by construction, exactly like the marker
+      // test above: can_retract ANDs in is_active server-side, so a row cannot
+      // arrive both retractable and inactive. Pinned because the ORDERING is
+      // deliberate - if the state ever becomes reachable, the more specific
+      // sentence has to win.
+      answersConfirm(true)
+      onFile([{ ...RETRACTABLE[0], active: false }])
+      const { box } = renderFailPanel()
+      const retractBtn = await screen.findByRole('button', { name: /Retract/ })
+      mockApi.mockResolvedValueOnce({ hint: {}, changed: true })
+      fireEvent.click(retractBtn)
+      await waitFor(() => expect(screen.queryByRole('button', { name: /Retract/ })).toBeNull())
+
+      // The notice only appears once the typed text matches a correction on file.
+      fireEvent.change(box, { target: { value: RETRACTABLE[0].feedback_text } })
+
+      expect(await screen.findByText(/You retracted this correction/)).toBeInTheDocument()
+      expect(screen.queryByText(/This correction is switched off/)).toBeNull()
+    })
   })
 
   describe('the duplicate notice, once active is known', () => {

--- a/src/frontend-react/src/pages/FeedbackPanel.test.tsx
+++ b/src/frontend-react/src/pages/FeedbackPanel.test.tsx
@@ -804,6 +804,29 @@ describe('T7: retracting a hint from the feedback panel', () => {
   })
 
   describe('the duplicate notice, once active is known', () => {
+    it('does not say "you retracted" when the retract found it already off', async () => {
+      /* changed: false is the route's own answer for a hint that was ALREADY
+       * inactive - an org admin retracted it between this panel's GET and this
+       * click. The click happened, but it is not what switched the correction
+       * off, and the panel has no business telling the user it was. The
+       * "won't come back" half is still true and still has to be said, so the
+       * neutral switched-off sentence is the right one - not the third branch,
+       * which drops that fact entirely. */
+      answersConfirm(true)
+      onFile(RETRACTABLE)
+      const { box } = renderFailPanel()
+      const retractBtn = await screen.findByRole('button', { name: /Retract/ })
+      mockApi.mockResolvedValueOnce({ hint: {}, changed: false })
+      fireEvent.click(retractBtn)
+      await waitFor(() => expect(screen.queryByRole('button', { name: /Retract/ })).toBeNull())
+
+      fireEvent.change(box, { target: { value: RETRACTABLE[0].feedback_text } })
+
+      expect(await screen.findByText(/This correction is switched off/)).toBeInTheDocument()
+      expect(screen.queryByText(/You retracted this correction/)).toBeNull()
+      expect(screen.queryByText(/already sent this/)).toBeNull()
+    })
+
     it('shows the switched-off sentence — not "already sent" — when active is false', async () => {
       onFile([{ ...RETRACTABLE[0], can_retract: false, active: false }])
       const { box } = renderFailPanel()

--- a/src/frontend-react/src/pages/FeedbackPanel.test.tsx
+++ b/src/frontend-react/src/pages/FeedbackPanel.test.tsx
@@ -599,7 +599,9 @@ describe('T7: retracting a hint from the feedback panel', () => {
 
     it('does not re-fetch the list to find that out', async () => {
       // The server would hand back this same row: the GET is unfiltered on
-      // is_active, and only can_retract flips. A round trip buys nothing.
+      // is_active, so can_retract and active would both flip. A round trip
+      // still buys nothing — the local retracted marker already outranks
+      // active === false, so the render is identical either way.
       await retractIt()
 
       expect(mockApi.mock.calls.filter(([path]) => path === '/api/feedback/wf-1')).toHaveLength(1)
@@ -608,11 +610,11 @@ describe('T7: retracting a hint from the feedback panel', () => {
     it('tells the user a re-send will not undo it — scoped to this run', async () => {
       // The warning this arms: retract by mistake, retype the identical
       // text, and the panel warns before the resend instead of staying
-      // silent about it, while the writer thread dedupes to the retracted
-      // hint and returns before the reinforcement that sets is_active back
-      // to 1. The resend still goes through and still gets thanked; closing
-      // that is a separate, owner-deferred change (the engine's claim gate
-      // is not reported upward).
+      // silent about it. The resend itself is answered honestly too — the
+      // writer thread dedupes to the retracted hint and the engine reports
+      // outcome "hint_inactive" rather than thanking the user for a no-op —
+      // but that response only exists after the click, so this warning is
+      // still the only thing that reaches the user BEFORE it.
       const { box } = await retractIt()
 
       fireEvent.change(box, { target: { value: 'wait for the spinner' } })
@@ -712,6 +714,77 @@ describe('T7: retracting a hint from the feedback panel', () => {
       await waitFor(() => expect(b).toBeDisabled())
 
       expect(screen.getByText('Failed to retract hint')).toBeInTheDocument()
+    })
+  })
+
+  /* `active` is the server's own signal (is_active, forwarded by
+     get_run_corrections) — orthogonal to `retracted`, which is client-only
+     and knows only about THIS session's own click. Global Constraint 1 is
+     why the marker for it says "switched off", never "retracted": is_active
+     going to 0 has four possible causes and the client cannot tell them
+     apart. */
+  describe('active: false — switched off by something other than this session', () => {
+    it('renders "— switched off" and no Retract control', async () => {
+      onFile([{ ...RETRACTABLE[0], can_retract: false, active: false }])
+      renderFailPanel()
+
+      await screen.findByText('— switched off')
+      expect(screen.queryByRole('button', { name: /Retract/ })).toBeNull()
+    })
+
+    it('renders no marker at all when active is true', async () => {
+      onFile([{ ...RETRACTABLE[0], active: true }])
+      renderFailPanel()
+      await screen.findByText(/wait for the spinner/)
+
+      expect(screen.queryByText('— switched off')).toBeNull()
+      expect(screen.queryByText(/^— (already )?retracted$/)).toBeNull()
+    })
+
+    it('renders no marker when the field is absent (older backend)', async () => {
+      onFile(RETRACTABLE)
+      renderFailPanel()
+      await screen.findByText(/wait for the spinner/)
+
+      expect(screen.queryByText('— switched off')).toBeNull()
+      expect(screen.queryByText(/^— (already )?retracted$/)).toBeNull()
+    })
+
+    it('lets the in-session retracted marker win over active: false', async () => {
+      answersConfirm(true)
+      onFile([{ ...RETRACTABLE[0], active: false }])
+      renderFailPanel()
+      const retractBtn = await screen.findByRole('button', { name: /Retract/ })
+      mockApi.mockResolvedValueOnce({ hint: {}, changed: true })
+
+      fireEvent.click(retractBtn)
+
+      await waitFor(() => expect(screen.queryByRole('button', { name: /Retract/ })).toBeNull())
+      expect(screen.getByText('— retracted')).toBeInTheDocument()
+      expect(screen.queryByText('— switched off')).toBeNull()
+    })
+  })
+
+  describe('the duplicate notice, once active is known', () => {
+    it('shows the switched-off sentence — not "already sent" — when active is false', async () => {
+      onFile([{ ...RETRACTABLE[0], can_retract: false, active: false }])
+      const { box } = renderFailPanel()
+      await screen.findByText(/Already recorded for this run/)
+
+      fireEvent.change(box, { target: { value: 'wait for the spinner' } })
+
+      await screen.findByText(/turn it back on/)
+      expect(screen.queryByText(/already sent this/)).toBeNull()
+    })
+
+    it('still shows "already sent" when active is true', async () => {
+      onFile([{ ...RETRACTABLE[0], can_retract: false, active: true }])
+      const { box } = renderFailPanel()
+      await screen.findByText(/Already recorded for this run/)
+
+      fireEvent.change(box, { target: { value: 'wait for the spinner' } })
+
+      await screen.findByText(/won’t be counted again/)
     })
   })
 })

--- a/src/frontend-react/src/pages/FeedbackPanel.test.tsx
+++ b/src/frontend-react/src/pages/FeedbackPanel.test.tsx
@@ -750,6 +750,17 @@ describe('T7: retracting a hint from the feedback panel', () => {
       expect(screen.queryByText(/^— (already )?retracted$/)).toBeNull()
     })
 
+    // RETRACTABLE[0] carries can_retract: true, which the real server only
+    // ever sends alongside is_active (get_run_corrections ANDs the two,
+    // endpoints.py) — so a live GET can never pair it with active: false.
+    // Clicking Retract here can't produce that combination either: the
+    // panel's retract() (GeneratePage.tsx) spreads the existing row and
+    // only overrides can_retract/retracted, so active stays whatever it
+    // was at mount — true, since that is what made can_retract: true
+    // realistic to begin with. This fixture is server-impossible by
+    // construction, on purpose: the test pins the render's DEFENSIVE
+    // branch order (retracted beats active === false) for a combination
+    // that cannot currently arise, not a live path.
     it('lets the in-session retracted marker win over active: false', async () => {
       answersConfirm(true)
       onFile([{ ...RETRACTABLE[0], active: false }])

--- a/src/frontend-react/src/pages/GeneratePage.test.tsx
+++ b/src/frontend-react/src/pages/GeneratePage.test.tsx
@@ -467,7 +467,8 @@ describe('GeneratePage — prefilled from History’s Regenerate', () => {
     renderPage({ prefillQuery: 'search flipkart for shoes' })
 
     expect(screen.getByPlaceholderText(/Open Google, search for/)).toHaveValue('search flipkart for shoes')
-    expect(replaceStateSpy).toHaveBeenCalled()
+    // Verify the state is actually cleared: replaceState called with empty state and empty title.
+    expect(replaceStateSpy).toHaveBeenCalledWith({}, '')
     replaceStateSpy.mockRestore()
   })
 })

--- a/src/frontend-react/src/pages/GeneratePage.test.tsx
+++ b/src/frontend-react/src/pages/GeneratePage.test.tsx
@@ -332,6 +332,45 @@ describe('GeneratePage — running pasted code (no generation)', () => {
     // correction to — the panel must not mount (and so must never fetch).
     expect(mockApi).not.toHaveBeenCalled()
   })
+
+  it('Ctrl+Enter inside the code editor runs the pasted code too, from the keyboard alone', async () => {
+    mockStreamSSE.mockImplementation(async (_path, _body, onEvent) => {
+      onEvent({
+        status: 'complete',
+        result: { report_html: '/reports/RUN-PASTE-KBD/log.html', logs: 'Results: 1 passed, 0 failed' },
+        test_status: 'passed',
+      })
+    })
+    renderPage()
+    pasteCode()
+
+    // The Run button's own click is covered by the test above; this fires
+    // the same handleRun through the code editor's Ctrl+Enter shortcut
+    // instead — the keydown starts on the editor's own textarea and must
+    // bubble up to the wrapping div's handler, exactly as it does for real.
+    fireEvent.keyDown(screen.getByPlaceholderText(/Generated code appears here/), { key: 'Enter', ctrlKey: true })
+
+    await waitFor(() => expect(mockStreamSSE).toHaveBeenCalledWith(
+      '/execute-test',
+      { robot_code: CODE, user_query: null, workflow_id: null },
+      expect.any(Function),
+    ))
+    await screen.findByText('Test passed! 🎉')
+  })
+
+  it('marks the code-editor keydown wrapper as presentational, not a fake control', () => {
+    renderPage()
+    pasteCode()
+
+    // The wrapper div only relays the bubbled Ctrl+Enter above; it is not
+    // itself a button, so it must say "ignore me" (role="presentation") to
+    // assistive tech rather than nothing at all (S6848) or a role it doesn't
+    // behave like. Requiring the role to sit on the element that actually
+    // contains the editor rules out a role planted on some unrelated div.
+    expect(screen.getByRole('presentation')).toContainElement(
+      screen.getByPlaceholderText(/Generated code appears here/),
+    )
+  })
 })
 
 describe('GeneratePage — a completed execution', () => {

--- a/src/frontend-react/src/pages/GeneratePage.test.tsx
+++ b/src/frontend-react/src/pages/GeneratePage.test.tsx
@@ -1,0 +1,522 @@
+/**
+ * GeneratePage — the page shell around the generate/execute SSE flow.
+ *
+ * FeedbackPanel.test.tsx already renders FeedbackPanel in isolation and pins
+ * its behaviour (outcome handling, retract, duplicate warnings, ...) — none
+ * of that is repeated here. This file covers everything else: the query and
+ * code inputs, the generate and execute SSE calls (lib/sse.ts is mocked —
+ * it has its own test file), the pipeline progress rail, the post-run result
+ * card, New Test's confirm guard (both the confirmed and cancelled path),
+ * copy/export, and — the failure class a type checker cannot catch because
+ * both sides of a mix-up are plain strings — which run id a correction or a
+ * download actually gets attributed to.
+ */
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/lib/sse', () => ({ streamSSE: vi.fn() }))
+vi.mock('@/lib/api', async importOriginal => ({
+  ...(await importOriginal<typeof import('@/lib/api')>()),
+  api: vi.fn(),
+}))
+
+import { streamSSE } from '@/lib/sse'
+import { api } from '@/lib/api'
+import GeneratePage from './GeneratePage'
+
+const mockStreamSSE = vi.mocked(streamSSE)
+const mockApi = vi.mocked(api)
+
+// jsdom implements neither scrollIntoView nor real navigation. GeneratePage
+// calls scrollIntoView from two effects (entering "executing", and once an
+// outcome lands); without a stub those effects throw inside a setTimeout and
+// the failure surfaces on a completely unrelated later test.
+HTMLElement.prototype.scrollIntoView = vi.fn()
+
+afterEach(() => { vi.resetAllMocks(); vi.unstubAllGlobals() })
+
+const QUERY = 'open flipkart and search for shoes'
+// No trailing newline: split('\n').length below is then exactly the number
+// of lines a human would count, so the "(N lines)" assertion isn't derived
+// from the same formula the source uses to compute it.
+const CODE = '*** Settings ***\nLibrary    Browser\n\n*** Test Cases ***\nSearch\n    New Page    https://flipkart.com'
+
+function stubClipboard() {
+  const writeText = vi.fn().mockResolvedValue(undefined)
+  Object.defineProperty(navigator, 'clipboard', { value: { writeText }, configurable: true, writable: true })
+  return writeText
+}
+
+/** URL.createObjectURL/revokeObjectURL don't exist in jsdom, jsdom's own
+ *  Blob has no .text()/.arrayBuffer() to read a captured one back with, and
+ *  a real anchor .click() logs a "Not implemented: navigation" jsdom error.
+ *  Replace Blob with a constructor that just records what it was built
+ *  from — nothing downstream needs a real blob, since createObjectURL is
+ *  stubbed too. */
+function stubDownload() {
+  let parts: unknown[] | null = null
+  let anchor: HTMLAnchorElement | null = null
+  vi.stubGlobal('Blob', vi.fn().mockImplementation((p: unknown[]) => { parts = p; return {} }))
+  URL.createObjectURL = vi.fn(() => 'blob:mock-url') as typeof URL.createObjectURL
+  URL.revokeObjectURL = vi.fn()
+  vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(function (this: HTMLAnchorElement) { anchor = this })
+  return { getParts: () => parts, getAnchor: () => anchor }
+}
+
+/** Answers FeedbackPanel's mount GET so a test whose flow reaches "outcome"
+ *  doesn't leave that fetch unanswered. */
+function allowFeedbackMount() {
+  mockApi.mockImplementation(async (path: string) => {
+    if (path.startsWith('/api/feedback/')) return { corrections: [] }
+    throw new Error(`allowFeedbackMount: unexpected api(${path})`)
+  })
+}
+
+function renderPage(initialState: { prefillQuery?: string } = {}) {
+  return render(
+    <MemoryRouter initialEntries={[{ pathname: '/generate', state: initialState }]}>
+      <GeneratePage />
+    </MemoryRouter>,
+  )
+}
+
+function typeQuery(text = QUERY) {
+  fireEvent.change(screen.getByPlaceholderText(/Open Google, search for/), { target: { value: text } })
+}
+
+function pasteCode(text = CODE) {
+  fireEvent.change(screen.getByPlaceholderText(/Generated code appears here/), { target: { value: text } })
+}
+
+describe('GeneratePage — idle state', () => {
+  it('starts empty: no code, a disabled action button, no New Test control', () => {
+    renderPage()
+
+    expect(screen.getByPlaceholderText(/Open Google, search for/)).toHaveValue('')
+    expect(screen.getByRole('button', { name: /Enter a query or paste code/ })).toBeDisabled()
+    expect(screen.queryByRole('button', { name: /New Test/ })).toBeNull()
+  })
+})
+
+describe('GeneratePage — starting a generation', () => {
+  it('enables "Generate Test" once a query is typed, and sends it verbatim', async () => {
+    mockStreamSSE.mockImplementation(() => new Promise(() => {}))
+    renderPage()
+    typeQuery()
+
+    fireEvent.click(screen.getByRole('button', { name: /Generate Test/ }))
+
+    await waitFor(() => expect(mockStreamSSE).toHaveBeenCalledWith(
+      '/generate-test', { query: QUERY }, expect.any(Function),
+    ))
+  })
+
+  it('Ctrl+Enter in the query box also starts generation while no code exists yet', async () => {
+    mockStreamSSE.mockImplementation(() => new Promise(() => {}))
+    renderPage()
+    typeQuery()
+
+    fireEvent.keyDown(screen.getByPlaceholderText(/Open Google, search for/), { key: 'Enter', ctrlKey: true })
+
+    await waitFor(() => expect(mockStreamSSE).toHaveBeenCalledWith(
+      '/generate-test', { query: QUERY }, expect.any(Function),
+    ))
+  })
+})
+
+describe('GeneratePage — the generation pipeline rail', () => {
+  it.each([
+    [10, 'Breaking your description into test steps'],
+    [30, 'Visiting the page and pinning down each element'],
+    [70, 'Writing test.robot from the plan and locators'],
+    [90, 'Compiling the test in a clean Docker container — auto-fixing anything that fails'],
+  ])('shows the right stage as active at %i%% progress', async (progress, expectedTitle) => {
+    mockStreamSSE.mockImplementation(async (_path, _body, onEvent) => {
+      onEvent({ status: 'running', progress, message: 'working…' })
+      return new Promise(() => {}) // stays "generating" so the pipeline stays on screen
+    })
+    renderPage()
+    typeQuery()
+
+    fireEvent.click(screen.getByRole('button', { name: /Generate Test/ }))
+
+    expect(await screen.findByText(expectedTitle)).toBeInTheDocument()
+  })
+
+  it('surfaces the element count once the locate stage reports one', async () => {
+    mockStreamSSE.mockImplementation(async (_path, _body, onEvent) => {
+      onEvent({ status: 'running', progress: 30, message: 'Found 12 elements on the page' })
+      return new Promise(() => {})
+    })
+    renderPage()
+    typeQuery()
+
+    fireEvent.click(screen.getByRole('button', { name: /Generate Test/ }))
+
+    expect(await screen.findByText('12 elements found on the page')).toBeInTheDocument()
+  })
+
+  it('marks earlier stages done, with their own summaries, once progress passes them', async () => {
+    mockStreamSSE.mockImplementation(async (_path, _body, onEvent) => {
+      onEvent({ status: 'running', progress: 90, message: 'Dry-run verification' })
+      return new Promise(() => {})
+    })
+    renderPage()
+    typeQuery()
+
+    fireEvent.click(screen.getByRole('button', { name: /Generate Test/ }))
+
+    expect(await screen.findByText('Test plan ready')).toBeInTheDocument()
+    expect(screen.getByText('Element locators captured')).toBeInTheDocument()
+    expect(screen.getByText('test.robot assembled')).toBeInTheDocument()
+    expect(screen.getByText('90%')).toBeInTheDocument()
+  })
+})
+
+describe('GeneratePage — a completed generation', () => {
+  it('shows the generated code and a success log line once delivery is clean', async () => {
+    mockStreamSSE.mockImplementation(async (_path, _body, onEvent) => {
+      onEvent({ status: 'complete', robot_code: CODE, workflow_id: 'wf-1' })
+    })
+    renderPage()
+    typeQuery()
+
+    fireEvent.click(screen.getByRole('button', { name: /Generate Test/ }))
+
+    await screen.findByRole('button', { name: /^Run Test/ })
+    expect(screen.getByText('Generated test.robot (6 lines)')).toBeInTheDocument()
+  })
+
+  it('flags a delivered-but-unverified dryrun without inventing a cause', async () => {
+    mockStreamSSE.mockImplementation(async (_path, _body, onEvent) => {
+      onEvent({
+        status: 'complete', robot_code: CODE, workflow_id: 'wf-1',
+        dryrun_status: 'unverified', dryrun_message: 'Docker health check timed out',
+      })
+    })
+    renderPage()
+    typeQuery()
+
+    fireEvent.click(screen.getByRole('button', { name: /Generate Test/ }))
+
+    expect(await screen.findByText('Delivered — this test was NOT verified, because the dryrun could not run')).toBeInTheDocument()
+    expect(screen.getByText('Docker health check timed out')).toBeInTheDocument()
+  })
+
+  it('flags a failed dryrun with the backend’s own message', async () => {
+    mockStreamSSE.mockImplementation(async (_path, _body, onEvent) => {
+      onEvent({
+        status: 'complete', robot_code: CODE, workflow_id: 'wf-1',
+        dryrun_status: 'failed', dryrun_message: 'Keyword not found: Click Buttonn',
+      })
+    })
+    renderPage()
+    typeQuery()
+
+    fireEvent.click(screen.getByRole('button', { name: /Generate Test/ }))
+
+    expect(await screen.findByText('Delivered — dryrun found issues you may want to review')).toBeInTheDocument()
+    expect(screen.getByText('Keyword not found: Click Buttonn')).toBeInTheDocument()
+  })
+
+  it('shows the SSE error message and re-enables the form on status: error', async () => {
+    mockStreamSSE.mockImplementation(async (_path, _body, onEvent) => {
+      onEvent({ status: 'error', message: 'The planner produced no usable steps' })
+    })
+    renderPage()
+    typeQuery()
+
+    fireEvent.click(screen.getByRole('button', { name: /Generate Test/ }))
+
+    // Written to BOTH the error banner and the (now-visible) generation
+    // log — asserting the count pins that double-write rather than just
+    // picking whichever element happens to match first.
+    await waitFor(() => expect(screen.getAllByText('The planner produced no usable steps')).toHaveLength(2))
+    expect(screen.getByRole('button', { name: /Generate Test/ })).not.toBeDisabled()
+  })
+
+  it('shows a fallback error and recovers when streamSSE itself rejects (network failure)', async () => {
+    mockStreamSSE.mockRejectedValue(new Error('Failed to fetch'))
+    renderPage()
+    typeQuery()
+
+    fireEvent.click(screen.getByRole('button', { name: /Generate Test/ }))
+
+    await waitFor(() => expect(screen.getAllByText('Failed to fetch')).toHaveLength(2))
+    expect(screen.getByRole('button', { name: /Generate Test/ })).not.toBeDisabled()
+  })
+})
+
+describe('GeneratePage — running pasted code (no generation)', () => {
+  it('sends user_query: null and mounts no FeedbackPanel, even with unrelated text in the query box', async () => {
+    mockStreamSSE.mockImplementation(async (_path, _body, onEvent) => {
+      onEvent({
+        status: 'complete',
+        result: { report_html: '/reports/RUN-PASTE/log.html', logs: 'Results: 1 passed, 0 failed' },
+        test_status: 'passed',
+      })
+    })
+    renderPage()
+    typeQuery('this text was never used to generate anything')
+    pasteCode()
+
+    fireEvent.click(screen.getByRole('button', { name: /^Run Test/ }))
+
+    await waitFor(() => expect(mockStreamSSE).toHaveBeenCalledWith(
+      '/execute-test',
+      { robot_code: CODE, user_query: null, workflow_id: null },
+      expect.any(Function),
+    ))
+    await screen.findByText('Test passed! 🎉')
+    // Paste-and-execute has no query, so there is nothing to attribute a
+    // correction to — the panel must not mount (and so must never fetch).
+    expect(mockApi).not.toHaveBeenCalled()
+  })
+})
+
+describe('GeneratePage — a completed execution', () => {
+  it('shows a per-test breakdown and the failing step’s message', async () => {
+    allowFeedbackMount()
+    const logs = [
+      'Test: Login flow - PASS',
+      'Test: Checkout flow - FAIL',
+      'Error: Element not found: #submit',
+      'Results: 1 passed, 1 failed',
+    ].join('\n')
+    mockStreamSSE.mockImplementation(async (path, _body, onEvent) => {
+      if (path === '/generate-test') onEvent({ status: 'complete', robot_code: CODE, workflow_id: 'wf-1' })
+      else if (path === '/execute-test') {
+        onEvent({ status: 'complete', result: { report_html: '/reports/RUN-1/log.html', logs }, test_status: 'failed' })
+      }
+    })
+    renderPage()
+    typeQuery()
+    fireEvent.click(screen.getByRole('button', { name: /Generate Test/ }))
+    await screen.findByRole('button', { name: /^Run Test/ })
+
+    fireEvent.click(screen.getByRole('button', { name: /^Run Test/ }))
+
+    expect(await screen.findByText('1 of 2 tests failed')).toBeInTheDocument()
+    expect(screen.getByText('Login flow')).toBeInTheDocument()
+    expect(screen.getByText('Checkout flow')).toBeInTheDocument()
+    expect(screen.getByText(/Element not found: #submit/)).toBeInTheDocument()
+  })
+
+  it('shows the SSE error message and no result card on status: error', async () => {
+    mockStreamSSE.mockImplementation(async (path, _body, onEvent) => {
+      if (path === '/generate-test') onEvent({ status: 'complete', robot_code: CODE, workflow_id: 'wf-1' })
+      else if (path === '/execute-test') onEvent({ status: 'error', message: 'Docker daemon unreachable' })
+    })
+    renderPage()
+    typeQuery()
+    fireEvent.click(screen.getByRole('button', { name: /Generate Test/ }))
+    await screen.findByRole('button', { name: /^Run Test/ })
+
+    fireEvent.click(screen.getByRole('button', { name: /^Run Test/ }))
+
+    await waitFor(() => expect(screen.getAllByText('Docker daemon unreachable')).toHaveLength(2))
+    expect(screen.queryByText(/Test passed|tests failed|Test failed/)).toBeNull()
+  })
+})
+
+describe('GeneratePage — which run a correction or download is attributed to', () => {
+  it('attributes feedback to the EXECUTED run’s id from the report URL, not the generation’s internal workflow id', async () => {
+    // The two ids are different on purpose: workflow_id is CrewAI's
+    // internal handle from the generation call; the report URL carries the
+    // DB run_id the execute call actually produced. /api/feedback/{id}
+    // must be the second one.
+    allowFeedbackMount()
+    mockStreamSSE.mockImplementation(async (path, _body, onEvent) => {
+      if (path === '/generate-test') onEvent({ status: 'complete', robot_code: CODE, workflow_id: 'WF-INTERNAL-999' })
+      else if (path === '/execute-test') {
+        onEvent({
+          status: 'complete',
+          result: { report_html: '/reports/RUN-REAL-123/log.html', logs: 'Results: 1 passed, 0 failed' },
+          test_status: 'passed',
+        })
+      }
+    })
+    renderPage()
+    typeQuery()
+    fireEvent.click(screen.getByRole('button', { name: /Generate Test/ }))
+    await screen.findByRole('button', { name: /^Run Test/ })
+
+    fireEvent.click(screen.getByRole('button', { name: /^Run Test/ }))
+
+    await waitFor(() => expect(mockApi).toHaveBeenCalledWith('/api/feedback/RUN-REAL-123', { cache: 'no-store' }))
+    expect(mockApi).not.toHaveBeenCalledWith('/api/feedback/WF-INTERNAL-999', expect.anything())
+  })
+
+  it('severs attribution once the editor is cleared — a run pasted afterwards is sent with no workflow id or query', async () => {
+    // "Clearing the editor severs the link to the last generation" per the
+    // RobotCodeEditor onChange handler's own comment. Generate once, wipe
+    // the box, paste different code, and the execute call for THAT code
+    // must not carry the old generation's workflow_id — otherwise a
+    // correction typed against the NEW code would land on the OLD run.
+    mockStreamSSE.mockImplementation(async (path, _body, onEvent) => {
+      if (path === '/generate-test') onEvent({ status: 'complete', robot_code: CODE, workflow_id: 'WF-OLD' })
+      else if (path === '/execute-test') return new Promise(() => {})
+    })
+    renderPage()
+    typeQuery()
+    fireEvent.click(screen.getByRole('button', { name: /Generate Test/ }))
+    await screen.findByRole('button', { name: /^Run Test/ })
+
+    pasteCode('')
+    pasteCode('*** Settings ***\nLibrary    Browser\n')
+
+    fireEvent.click(screen.getByRole('button', { name: /^Run Test/ }))
+
+    await waitFor(() => expect(mockStreamSSE).toHaveBeenCalledWith(
+      '/execute-test',
+      expect.objectContaining({ workflow_id: null, user_query: null }),
+      expect.any(Function),
+    ))
+  })
+})
+
+describe('GeneratePage — New Test', () => {
+  it('clears immediately, with no confirm prompt, when only a query is typed (no code yet)', () => {
+    const confirmSpy = vi.spyOn(window, 'confirm')
+    renderPage()
+    typeQuery()
+
+    fireEvent.click(screen.getByRole('button', { name: /New Test/ }))
+
+    expect(confirmSpy).not.toHaveBeenCalled()
+    expect(screen.getByPlaceholderText(/Open Google, search for/)).toHaveValue('')
+    confirmSpy.mockRestore()
+  })
+
+  it('asks for confirmation once code exists, and clears nothing when the user cancels', async () => {
+    mockStreamSSE.mockImplementation(async (_path, _body, onEvent) => {
+      onEvent({ status: 'complete', robot_code: CODE, workflow_id: 'wf-1' })
+    })
+    renderPage()
+    typeQuery()
+    fireEvent.click(screen.getByRole('button', { name: /Generate Test/ }))
+    await screen.findByRole('button', { name: /^Run Test/ })
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(false)
+
+    fireEvent.click(screen.getByRole('button', { name: /New Test/ }))
+
+    expect(confirmSpy).toHaveBeenCalledWith('This will clear your current test. Start a new test?')
+    expect(screen.getByPlaceholderText(/Generated code appears here/)).toHaveValue(CODE)
+    expect(screen.getByPlaceholderText(/Open Google, search for/)).toHaveValue(QUERY)
+    confirmSpy.mockRestore()
+  })
+
+  it('clears query, code and logs once the user confirms', async () => {
+    mockStreamSSE.mockImplementation(async (_path, _body, onEvent) => {
+      onEvent({ status: 'complete', robot_code: CODE, workflow_id: 'wf-1' })
+    })
+    renderPage()
+    typeQuery()
+    fireEvent.click(screen.getByRole('button', { name: /Generate Test/ }))
+    await screen.findByRole('button', { name: /^Run Test/ })
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true)
+
+    fireEvent.click(screen.getByRole('button', { name: /New Test/ }))
+
+    expect(screen.getByPlaceholderText(/Open Google, search for/)).toHaveValue('')
+    expect(screen.getByPlaceholderText(/Generated code appears here/)).toHaveValue('')
+    expect(screen.queryByRole('button', { name: /New Test/ })).toBeNull()
+    confirmSpy.mockRestore()
+  })
+})
+
+describe('GeneratePage — copy and export', () => {
+  it('copies the exact generated code, not the query text', async () => {
+    const writeText = stubClipboard()
+    mockStreamSSE.mockImplementation(async (_path, _body, onEvent) => {
+      onEvent({ status: 'complete', robot_code: CODE, workflow_id: 'wf-1' })
+    })
+    renderPage()
+    typeQuery()
+    fireEvent.click(screen.getByRole('button', { name: /Generate Test/ }))
+    await screen.findByRole('button', { name: /^Run Test/ })
+
+    fireEvent.click(screen.getByRole('button', { name: /^Copy/ }))
+
+    expect(writeText).toHaveBeenCalledWith(CODE)
+    expect(writeText).not.toHaveBeenCalledWith(QUERY)
+  })
+
+  it('downloads a .robot file whose content is the exact code on screen', async () => {
+    const { getParts, getAnchor } = stubDownload()
+    mockStreamSSE.mockImplementation(async (_path, _body, onEvent) => {
+      onEvent({ status: 'complete', robot_code: CODE, workflow_id: 'wf-1' })
+    })
+    renderPage()
+    typeQuery()
+    fireEvent.click(screen.getByRole('button', { name: /Generate Test/ }))
+    await screen.findByRole('button', { name: /^Run Test/ })
+
+    fireEvent.click(screen.getByRole('button', { name: /^Export/ }))
+
+    expect(getAnchor()?.download).toBe('test.robot')
+    expect(getParts()).toEqual([CODE])
+  })
+})
+
+describe('GeneratePage — prefilled from History’s Regenerate', () => {
+  it('fills the query from router state, then clears that state so a refresh starts clean', () => {
+    const replaceStateSpy = vi.spyOn(window.history, 'replaceState')
+
+    renderPage({ prefillQuery: 'search flipkart for shoes' })
+
+    expect(screen.getByPlaceholderText(/Open Google, search for/)).toHaveValue('search flipkart for shoes')
+    expect(replaceStateSpy).toHaveBeenCalled()
+    replaceStateSpy.mockRestore()
+  })
+})
+
+describe('GeneratePage — while executing', () => {
+  it('shows a live "running" strip and disables the editor', async () => {
+    mockStreamSSE.mockImplementation(async (path, _body, onEvent) => {
+      if (path === '/generate-test') { onEvent({ status: 'complete', robot_code: CODE, workflow_id: 'wf-1' }); return }
+      return new Promise(() => {}) // execute-test hangs — stay "executing"
+    })
+    renderPage()
+    typeQuery()
+    fireEvent.click(screen.getByRole('button', { name: /Generate Test/ }))
+    await screen.findByRole('button', { name: /^Run Test/ })
+
+    fireEvent.click(screen.getByRole('button', { name: /^Run Test/ }))
+
+    expect(await screen.findByText('Running your scenario')).toBeInTheDocument()
+    expect(screen.getByPlaceholderText(/Generated code appears here/)).toBeDisabled()
+    expect(screen.getByRole('button', { name: /Executing…/ })).toBeDisabled()
+  })
+})
+
+describe('GeneratePage — logs after a run', () => {
+  it('auto-collapses both log sections once the run completes, and Expand reveals one again', async () => {
+    allowFeedbackMount()
+    mockStreamSSE.mockImplementation(async (path, _body, onEvent) => {
+      if (path === '/generate-test') onEvent({ status: 'complete', robot_code: CODE, workflow_id: 'wf-1' })
+      else if (path === '/execute-test') {
+        onEvent({
+          status: 'complete',
+          result: { report_html: '/reports/RUN-1/log.html', logs: 'Results: 1 passed, 0 failed' },
+          test_status: 'passed',
+        })
+      }
+    })
+    renderPage()
+    typeQuery()
+    fireEvent.click(screen.getByRole('button', { name: /Generate Test/ }))
+    await screen.findByRole('button', { name: /^Run Test/ })
+    fireEvent.click(screen.getByRole('button', { name: /^Run Test/ }))
+    await screen.findByText('Test passed! 🎉')
+
+    const expandButtons = screen.getAllByRole('button', { name: 'Expand' })
+    expect(expandButtons).toHaveLength(2) // Generation Logs + Execution Logs
+
+    fireEvent.click(expandButtons[0])
+
+    expect(screen.getAllByRole('button', { name: 'Expand' })).toHaveLength(1)
+    expect(screen.getByRole('button', { name: 'Collapse' })).toBeInTheDocument()
+  })
+})

--- a/src/frontend-react/src/pages/GeneratePage.test.tsx
+++ b/src/frontend-react/src/pages/GeneratePage.test.tsx
@@ -99,6 +99,32 @@ describe('GeneratePage — idle state', () => {
   })
 })
 
+describe('GeneratePage — the run button’s icon and label', () => {
+  it('shows the Zap icon for "Generate Test", and swaps to Play once code exists', () => {
+    renderPage()
+    typeQuery()
+    expect(screen.getByRole('button', { name: /Generate Test/ }).querySelector('svg')).toHaveClass('lucide-zap')
+
+    pasteCode()
+    expect(screen.getByRole('button', { name: /^Run Test/ }).querySelector('svg')).toHaveClass('lucide-play')
+  })
+
+  it('shows a spinner (no icon glyph) and "Generating… N%" while a generation is in flight', async () => {
+    mockStreamSSE.mockImplementation(async (_path, _body, onEvent) => {
+      onEvent({ status: 'running', progress: 42, message: 'working…' })
+      return new Promise(() => {})
+    })
+    renderPage()
+    typeQuery()
+
+    fireEvent.click(screen.getByRole('button', { name: /Generate Test/ }))
+
+    const busyBtn = await screen.findByRole('button', { name: /Generating… 42%/ })
+    expect(busyBtn).toBeDisabled()
+    expect(busyBtn.querySelector('svg')).toBeNull()
+  })
+})
+
 describe('GeneratePage — starting a generation', () => {
   it('enables "Generate Test" once a query is typed, and sends it verbatim', async () => {
     mockStreamSSE.mockImplementation(() => new Promise(() => {}))
@@ -171,12 +197,39 @@ describe('GeneratePage — the generation pipeline rail', () => {
     expect(screen.getByText('Element locators captured')).toBeInTheDocument()
     expect(screen.getByText('test.robot assembled')).toBeInTheDocument()
     expect(screen.getByText('90%')).toBeInTheDocument()
+    // A finished stage (Plan) and the current one (Verify, the last stage —
+    // there is no later `at` to pass, so it can only ever be active or done)
+    // must read as visually distinct, not just as different text.
+    const planIcon = screen.getByText('Plan').parentElement!.querySelector('span')!
+    const verifyIcon = screen.getByText('Verify').parentElement!.querySelector('span')!
+    expect(planIcon).toHaveClass('border-emerald-500/40')
+    expect(verifyIcon).toHaveClass('stage-active')
+  })
+
+  it('leaves a not-yet-reached stage in its pending style while an earlier one is active', async () => {
+    mockStreamSSE.mockImplementation(async (_path, _body, onEvent) => {
+      onEvent({ status: 'running', progress: 10, message: 'working…' })
+      return new Promise(() => {})
+    })
+    renderPage()
+    typeQuery()
+
+    fireEvent.click(screen.getByRole('button', { name: /Generate Test/ }))
+
+    await screen.findByText('Plan')
+    const planIcon = screen.getByText('Plan').parentElement!.querySelector('span')!
+    const locateIcon = screen.getByText('Locate').parentElement!.querySelector('span')!
+    const locateLabel = screen.getByText('Locate')
+    expect(planIcon).toHaveClass('stage-active')
+    expect(locateIcon).toHaveClass('border-[#30363d]')
+    expect(locateLabel).toHaveClass('text-[#484f58]')
   })
 })
 
 describe('GeneratePage — a completed generation', () => {
   it('shows the generated code and a success log line once delivery is clean', async () => {
     mockStreamSSE.mockImplementation(async (_path, _body, onEvent) => {
+      onEvent({ status: 'running', message: 'Doing work…' })
       onEvent({ status: 'complete', robot_code: CODE, workflow_id: 'wf-1' })
     })
     renderPage()
@@ -186,6 +239,10 @@ describe('GeneratePage — a completed generation', () => {
 
     await screen.findByRole('button', { name: /^Run Test/ })
     expect(screen.getByText('Generated test.robot (6 lines)')).toBeInTheDocument()
+    // Info and success log lines get their own left-border color, not just
+    // their own text.
+    expect(screen.getByText('Doing work…').parentElement).toHaveClass('border-l-blue-400')
+    expect(screen.getByText('Generated test.robot (6 lines)').parentElement).toHaveClass('border-l-green-500')
   })
 
   it('flags a delivered-but-unverified dryrun without inventing a cause', async () => {
@@ -218,6 +275,8 @@ describe('GeneratePage — a completed generation', () => {
 
     expect(await screen.findByText('Delivered — dryrun found issues you may want to review')).toBeInTheDocument()
     expect(screen.getByText('Keyword not found: Click Buttonn')).toBeInTheDocument()
+    // Error-kind log lines get their own left-border color too.
+    expect(screen.getByText('Keyword not found: Click Buttonn').parentElement).toHaveClass('border-l-destructive')
   })
 
   it('shows the SSE error message and re-enables the form on status: error', async () => {
@@ -301,6 +360,99 @@ describe('GeneratePage — a completed execution', () => {
     expect(screen.getByText('Login flow')).toBeInTheDocument()
     expect(screen.getByText('Checkout flow')).toBeInTheDocument()
     expect(screen.getByText(/Element not found: #submit/)).toBeInTheDocument()
+  })
+
+  it('derives pass/fail counts by counting per-test lines when the summary has no Results: line', async () => {
+    // Every other fixture in this file includes a "Results: N passed, M
+    // failed" line, so the count always comes from that regex match. This
+    // one omits it on purpose, forcing the fallback that counts parsed
+    // per-test lines instead — 2 passes and 1 fail, deliberately unequal so
+    // a mixed-up PASS/FAIL count would show up as a wrong total.
+    allowFeedbackMount()
+    const logs = [
+      'Test: Login flow - PASS',
+      'Test: Search flow - PASS',
+      'Test: Checkout flow - FAIL',
+      'Error: Element not found: #submit',
+    ].join('\n')
+    mockStreamSSE.mockImplementation(async (path, _body, onEvent) => {
+      if (path === '/generate-test') onEvent({ status: 'complete', robot_code: CODE, workflow_id: 'wf-1' })
+      else if (path === '/execute-test') {
+        onEvent({ status: 'complete', result: { report_html: '/reports/RUN-2/log.html', logs }, test_status: 'failed' })
+      }
+    })
+    renderPage()
+    typeQuery()
+    fireEvent.click(screen.getByRole('button', { name: /Generate Test/ }))
+    await screen.findByRole('button', { name: /^Run Test/ })
+
+    fireEvent.click(screen.getByRole('button', { name: /^Run Test/ }))
+
+    expect(await screen.findByText('1 of 3 tests failed')).toBeInTheDocument()
+  })
+
+  it('says "Test failed" (not "N of M") for a single failing test', async () => {
+    allowFeedbackMount()
+    const logs = [
+      'Test: Checkout flow - FAIL',
+      'Error: Element not found: #submit',
+      'Results: 0 passed, 1 failed',
+    ].join('\n')
+    mockStreamSSE.mockImplementation(async (path, _body, onEvent) => {
+      if (path === '/generate-test') onEvent({ status: 'complete', robot_code: CODE, workflow_id: 'wf-1' })
+      else if (path === '/execute-test') {
+        onEvent({ status: 'complete', result: { report_html: '/reports/RUN-5/log.html', logs }, test_status: 'failed' })
+      }
+    })
+    renderPage()
+    typeQuery()
+    fireEvent.click(screen.getByRole('button', { name: /Generate Test/ }))
+    await screen.findByRole('button', { name: /^Run Test/ })
+
+    fireEvent.click(screen.getByRole('button', { name: /^Run Test/ }))
+
+    expect(await screen.findByText('Test failed')).toBeInTheDocument()
+  })
+
+  it('says "All tests passed!" (not the single-test wording) for a multi-test run with no failures', async () => {
+    allowFeedbackMount()
+    const logs = [
+      'Test: Login flow - PASS',
+      'Test: Search flow - PASS',
+      'Results: 2 passed, 0 failed',
+    ].join('\n')
+    mockStreamSSE.mockImplementation(async (path, _body, onEvent) => {
+      if (path === '/generate-test') onEvent({ status: 'complete', robot_code: CODE, workflow_id: 'wf-1' })
+      else if (path === '/execute-test') {
+        onEvent({ status: 'complete', result: { report_html: '/reports/RUN-3/log.html', logs }, test_status: 'passed' })
+      }
+    })
+    renderPage()
+    typeQuery()
+    fireEvent.click(screen.getByRole('button', { name: /Generate Test/ }))
+    await screen.findByRole('button', { name: /^Run Test/ })
+
+    fireEvent.click(screen.getByRole('button', { name: /^Run Test/ }))
+
+    expect(await screen.findByText('All tests passed! 🎉')).toBeInTheDocument()
+  })
+
+  it('falls back to "Test execution failed" when a failing run reports no parseable summary', async () => {
+    allowFeedbackMount()
+    mockStreamSSE.mockImplementation(async (path, _body, onEvent) => {
+      if (path === '/generate-test') onEvent({ status: 'complete', robot_code: CODE, workflow_id: 'wf-1' })
+      else if (path === '/execute-test') {
+        onEvent({ status: 'complete', result: { report_html: '/reports/RUN-4/log.html' }, test_status: 'failed' })
+      }
+    })
+    renderPage()
+    typeQuery()
+    fireEvent.click(screen.getByRole('button', { name: /Generate Test/ }))
+    await screen.findByRole('button', { name: /^Run Test/ })
+
+    fireEvent.click(screen.getByRole('button', { name: /^Run Test/ }))
+
+    expect(await screen.findByText('Test execution failed')).toBeInTheDocument()
   })
 
   it('shows the SSE error message and no result card on status: error', async () => {

--- a/src/frontend-react/src/pages/GeneratePage.test.tsx
+++ b/src/frontend-react/src/pages/GeneratePage.test.tsx
@@ -333,7 +333,10 @@ describe('GeneratePage — running pasted code (no generation)', () => {
     expect(mockApi).not.toHaveBeenCalled()
   })
 
-  it('Ctrl+Enter inside the code editor runs the pasted code too, from the keyboard alone', async () => {
+  it.each([
+    ['Ctrl', { ctrlKey: true }],
+    ['Cmd', { metaKey: true }],
+  ])('%s+Enter inside the code editor runs the pasted code too, from the keyboard alone', async (_label, modifier) => {
     mockStreamSSE.mockImplementation(async (_path, _body, onEvent) => {
       onEvent({
         status: 'complete',
@@ -345,10 +348,11 @@ describe('GeneratePage — running pasted code (no generation)', () => {
     pasteCode()
 
     // The Run button's own click is covered by the test above; this fires
-    // the same handleRun through the code editor's Ctrl+Enter shortcut
-    // instead — the keydown starts on the editor's own textarea and must
-    // bubble up to the wrapping div's handler, exactly as it does for real.
-    fireEvent.keyDown(screen.getByPlaceholderText(/Generated code appears here/), { key: 'Enter', ctrlKey: true })
+    // the same handleRun through the code editor's own Ctrl/Cmd+Enter
+    // shortcut instead — the handler now lives directly on the editor's
+    // textarea (RobotCodeEditor forwards onKeyDown to it), not a wrapping
+    // div, so this exercises the real, current wiring rather than bubbling.
+    fireEvent.keyDown(screen.getByPlaceholderText(/Generated code appears here/), { key: 'Enter', ...modifier })
 
     await waitFor(() => expect(mockStreamSSE).toHaveBeenCalledWith(
       '/execute-test',
@@ -356,20 +360,6 @@ describe('GeneratePage — running pasted code (no generation)', () => {
       expect.any(Function),
     ))
     await screen.findByText('Test passed! 🎉')
-  })
-
-  it('marks the code-editor keydown wrapper as presentational, not a fake control', () => {
-    renderPage()
-    pasteCode()
-
-    // The wrapper div only relays the bubbled Ctrl+Enter above; it is not
-    // itself a button, so it must say "ignore me" (role="presentation") to
-    // assistive tech rather than nothing at all (S6848) or a role it doesn't
-    // behave like. Requiring the role to sit on the element that actually
-    // contains the editor rules out a role planted on some unrelated div.
-    expect(screen.getByRole('presentation')).toContainElement(
-      screen.getByPlaceholderText(/Generated code appears here/),
-    )
   })
 })
 

--- a/src/frontend-react/src/pages/GeneratePage.test.tsx
+++ b/src/frontend-react/src/pages/GeneratePage.test.tsx
@@ -466,6 +466,55 @@ describe('GeneratePage — a completed execution', () => {
     expect(await screen.findByText('All tests passed! 🎉')).toBeInTheDocument()
   })
 
+  // The result card's SECOND line, which nothing else in this file asserts.
+  // It is assembled from two optional facts — a test count that only earns
+  // its place above one test, and a duration only when the run was timed —
+  // so a multi-test pass and a single-test pass exercise different halves.
+  it('lists the test count and the duration in the pass subtitle for a multi-test run', async () => {
+    allowFeedbackMount()
+    const logs = [
+      'Test: Login flow - PASS',
+      'Test: Search flow - PASS',
+      'Results: 2 passed, 0 failed',
+    ].join('\n')
+    mockStreamSSE.mockImplementation(async (path, _body, onEvent) => {
+      if (path === '/generate-test') onEvent({ status: 'complete', robot_code: CODE, workflow_id: 'wf-1' })
+      else if (path === '/execute-test') {
+        onEvent({ status: 'complete', result: { report_html: '/reports/RUN-5/log.html', logs }, test_status: 'passed' })
+      }
+    })
+    renderPage()
+    typeQuery()
+    fireEvent.click(screen.getByRole('button', { name: /Generate Test/ }))
+    await screen.findByRole('button', { name: /^Run Test/ })
+
+    fireEvent.click(screen.getByRole('button', { name: /^Run Test/ }))
+
+    expect(await screen.findByText(/^2 tests · finished in \d+\.\ds$/)).toBeInTheDocument()
+  })
+
+  it('drops the count from the pass subtitle for a single-test run, keeping the duration', async () => {
+    allowFeedbackMount()
+    const logs = [
+      'Test: Login flow - PASS',
+      'Results: 1 passed, 0 failed',
+    ].join('\n')
+    mockStreamSSE.mockImplementation(async (path, _body, onEvent) => {
+      if (path === '/generate-test') onEvent({ status: 'complete', robot_code: CODE, workflow_id: 'wf-1' })
+      else if (path === '/execute-test') {
+        onEvent({ status: 'complete', result: { report_html: '/reports/RUN-6/log.html', logs }, test_status: 'passed' })
+      }
+    })
+    renderPage()
+    typeQuery()
+    fireEvent.click(screen.getByRole('button', { name: /Generate Test/ }))
+    await screen.findByRole('button', { name: /^Run Test/ })
+
+    fireEvent.click(screen.getByRole('button', { name: /^Run Test/ }))
+
+    expect(await screen.findByText(/^finished in \d+\.\ds$/)).toBeInTheDocument()
+  })
+
   it('falls back to "Test execution failed" when a failing run reports no parseable summary', async () => {
     allowFeedbackMount()
     mockStreamSSE.mockImplementation(async (path, _body, onEvent) => {

--- a/src/frontend-react/src/pages/GeneratePage.tsx
+++ b/src/frontend-react/src/pages/GeneratePage.tsx
@@ -43,6 +43,19 @@ interface RobotSummary {
   failed: number | null
 }
 
+/** One pass/fail count: the `Results:` line's own number when there is one,
+    else a count of the per-test lines this blob actually parsed. */
+function testCount(
+  counts: RegExpExecArray | null,
+  index: 1 | 2,
+  tests: RobotSummary['tests'],
+  status: 'PASS' | 'FAIL',
+): number | null {
+  if (counts) return Number(counts[index])
+  if (tests.length) return tests.filter(t => t.status === status).length
+  return null
+}
+
 function parseRobotSummary(blob: string): RobotSummary {
   const tests: RobotSummary['tests'] = []
   const failures: RobotSummary['failures'] = []
@@ -64,9 +77,15 @@ function parseRobotSummary(blob: string): RobotSummary {
   return {
     tests,
     failures,
-    passed: counts ? Number(counts[1]) : tests.length ? tests.filter(t => t.status === 'PASS').length : null,
-    failed: counts ? Number(counts[2]) : tests.length ? tests.filter(t => t.status === 'FAIL').length : null,
+    passed: testCount(counts, 1, tests, 'PASS'),
+    failed: testCount(counts, 2, tests, 'FAIL'),
   }
+}
+
+const LOG_BORDER_CLASS: Record<LogEntry['kind'], string> = {
+  success: 'border-l-green-500',
+  error: 'border-l-destructive',
+  info: 'border-l-blue-400',
 }
 
 /* ── Collapsible logs card with an indeterminate bar while running ── */
@@ -110,9 +129,7 @@ function LogsSection({ title, desc, logs, running, collapseOnDone }: Readonly<{
                 key={i}
                 className={cn(
                   'flex gap-3 border-b px-4 py-1.5 last:border-0 border-l-2',
-                  log.kind === 'success' ? 'border-l-green-500'
-                    : log.kind === 'error' ? 'border-l-destructive'
-                      : 'border-l-blue-400',
+                  LOG_BORDER_CLASS[log.kind],
                 )}
               >
                 <span className="shrink-0 text-muted-foreground">{log.ts}</span>
@@ -215,6 +232,26 @@ function VerifyActivity() {
   )
 }
 
+type StageState = 'done' | 'active' | 'pending'
+
+function stageState(done: boolean, active: boolean): StageState {
+  if (done) return 'done'
+  if (active) return 'active'
+  return 'pending'
+}
+
+const STAGE_ICON_CLASSES: Record<StageState, string> = {
+  done: 'border-emerald-500/40 bg-emerald-500/15 text-emerald-400',
+  active: 'stage-active border-sky-400/50 bg-sky-400/10 text-sky-300',
+  pending: 'border-[#30363d] text-[#484f58]',
+}
+
+const STAGE_LABEL_CLASSES: Record<StageState, string> = {
+  done: 'text-[#8b949e]',
+  active: 'text-[#e6edf3]',
+  pending: 'text-[#484f58]',
+}
+
 function GenerationPipeline({ progress, stage, logs }: Readonly<{ progress: number; stage: string; logs: LogEntry[] }>) {
   // The element-scan SSE event carries the only real artifact count we get
   // ("📍 Found N elements on the page") — surface it in the Locate block.
@@ -229,21 +266,19 @@ function GenerationPipeline({ progress, stage, logs }: Readonly<{ progress: numb
             const nextAt = PIPELINE_STAGES[i + 1]?.at ?? 100
             const done = progress >= nextAt
             const active = !done && progress >= s.at
+            const state = stageState(done, active)
             const Icon = s.icon
             return (
               <div key={s.label} className="flex items-center gap-2">
                 <span
                   className={cn(
                     'flex h-6 w-6 items-center justify-center rounded-full border transition-colors',
-                    done ? 'border-emerald-500/40 bg-emerald-500/15 text-emerald-400'
-                      : active ? 'stage-active border-sky-400/50 bg-sky-400/10 text-sky-300'
-                        : 'border-[#30363d] text-[#484f58]',
+                    STAGE_ICON_CLASSES[state],
                   )}
                 >
                   {done ? <Check className="h-3.5 w-3.5" /> : <Icon className="h-3.5 w-3.5" />}
                 </span>
-                <span className={cn('text-xs font-medium',
-                  done ? 'text-[#8b949e]' : active ? 'text-[#e6edf3]' : 'text-[#484f58]')}>
+                <span className={cn('text-xs font-medium', STAGE_LABEL_CLASSES[state])}>
                   {s.label}
                 </span>
                 {i < PIPELINE_STAGES.length - 1 && (
@@ -343,6 +378,14 @@ function ConfettiBurst() {
   )
 }
 
+/** The result card's headline. Single-test runs are the norm — counts and the
+    per-test list only earn their place when there is more than one test. */
+function resultTitle(pass: boolean, total: number | null, failed: number | null | undefined): string {
+  if (pass) return total === 1 ? 'Test passed! 🎉' : 'All tests passed! 🎉'
+  if (failed && total) return total > 1 ? `${failed} of ${total} tests failed` : 'Test failed'
+  return 'Test execution failed'
+}
+
 /* ── Post-run result card: outcome banner, per-test breakdown, report links,
    and an optional feedback footer (children) ── */
 function ExecutionResult({ outcome, summary, secs, reportUrl, logUrl, children }: Readonly<{
@@ -355,13 +398,7 @@ function ExecutionResult({ outcome, summary, secs, reportUrl, logUrl, children }
   const total = summary?.passed != null && summary?.failed != null
     ? summary.passed + summary.failed
     : tests.length || null
-  // Single-test runs are the norm — counts and the per-test list only earn
-  // their place when there is more than one test.
-  const title = pass
-    ? total === 1 ? 'Test passed! 🎉' : 'All tests passed! 🎉'
-    : summary?.failed && total
-      ? total > 1 ? `${summary.failed} of ${total} tests failed` : 'Test failed'
-      : 'Test execution failed'
+  const title = resultTitle(pass, total, summary?.failed)
   const subtitle = pass
     ? [total && total > 1 ? `${total} tests` : null, secs != null ? `finished in ${secs.toFixed(1)}s` : null]
         .filter(Boolean).join(' · ') || 'Execution finished'
@@ -922,6 +959,22 @@ export function FeedbackPanel({ outcome, workflowId }: Readonly<{ outcome: Exclu
   )
 }
 
+/* ── The single adaptive action button: code present → Run Test; otherwise
+   a query → Generate Test (see the button's own comment at its call site
+   for why this stays one control rather than a combined generate-and-run) ── */
+function runButtonIcon(busy: boolean, hasCode: boolean): ReactNode {
+  if (busy) return <span className="h-4 w-4 animate-spin rounded-full border-2 border-current border-t-transparent" />
+  return hasCode ? <Play className="h-4 w-4" /> : <Zap className="h-4 w-4" />
+}
+
+function runButtonLabel(phase: Phase, genProgress: number, hasCode: boolean, hasQuery: boolean): string {
+  if (phase === 'generating') return `Generating… ${genProgress}%`
+  if (phase === 'executing') return 'Executing…'
+  if (hasCode) return 'Run Test'
+  if (hasQuery) return 'Generate Test'
+  return 'Enter a query or paste code'
+}
+
 /* ── Main page ── */
 export default function GeneratePage() {
   const [query, setQuery]   = useState('')
@@ -1151,14 +1204,8 @@ export default function GeneratePage() {
                 disabled={busy || (!code.trim() && !query.trim())}
                 className="h-10 flex-1 gap-2"
               >
-                {busy
-                  ? <span className="h-4 w-4 animate-spin rounded-full border-2 border-current border-t-transparent" />
-                  : code.trim() ? <Play className="h-4 w-4" /> : <Zap className="h-4 w-4" />}
-                {phase === 'generating' ? `Generating… ${genProgress}%`
-                  : phase === 'executing' ? 'Executing…'
-                    : code.trim() ? 'Run Test'
-                      : query.trim() ? 'Generate Test'
-                        : 'Enter a query or paste code'}
+                {runButtonIcon(busy, !!code.trim())}
+                {runButtonLabel(phase, genProgress, !!code.trim(), !!query.trim())}
               </Button>
               {!busy && code.trim() && query.trim() && (
                 <Button variant="outline" onClick={handleGenerate} className="h-10 gap-1.5" title="Discard the current code and regenerate from the description">

--- a/src/frontend-react/src/pages/GeneratePage.tsx
+++ b/src/frontend-react/src/pages/GeneratePage.tsx
@@ -475,6 +475,47 @@ interface RecordedResponse { corrections?: RecordedCorrection[] }
     the changed:false answer below: retracted, but not by this click. */
 interface PanelCorrection extends RecordedCorrection { retracted?: 'now' | 'already' }
 
+/**
+ * The ONE marker a recorded correction shows, in precedence order.
+ *
+ * `retracted` is client-only, set by THIS session's own retract click, and it
+ * wins because it is the more specific fact — it knows WHO did it.
+ * `active === false` covers every other way the hint went inactive (another
+ * caller's retract, auto-disable, an LLM review); the server cannot tell those
+ * apart, so this marker does not pretend to either.
+ *
+ * The test is `active === false`, never `!active`, so a missing field — an
+ * older backend, or the learning-disabled response — renders exactly as it
+ * does today, with no marker at all.
+ */
+function correctionMarker(c: PanelCorrection): string | null {
+  if (c.retracted === 'already') return '— already retracted'
+  if (c.retracted) return '— retracted'
+  if (c.active === false) return SWITCHED_OFF_MARKER
+  return null
+}
+
+/**
+ * What to say about a correction this run has already contributed.
+ *
+ * All three sentences are scoped to THIS run on purpose. Sending the same text
+ * again here dedups to the existing hint and the claim row for this run already
+ * exists, so nothing reactivates it — but the same text from a LATER run does
+ * reinforce, and an unqualified "it can't come back" would be a new false
+ * claim. These fire BEFORE the click: they are the only thing that warns while
+ * the user can still change their mind, which is why they are kept even though
+ * the backend now answers such a resubmission honestly ("hint_inactive").
+ *
+ * The first two say the same "won't come back" fact; only the first claims WHO.
+ * `active === false` alone does not know the retract was this user's own, so
+ * the second must not say "you".
+ */
+function alreadySentNotice(c: PanelCorrection): string {
+  if (c.retracted) return 'You retracted this correction. Sending it again on this run won’t restore it.'
+  if (c.active === false) return 'This correction is switched off. Sending it again on this run won’t turn it back on.'
+  return 'You already sent this for this run — it won’t be counted again.'
+}
+
 /** POST /api/learning/hints/{id}/retract → { hint, changed, note }
     (learning_endpoints.py). `changed: false` is the route's own answer for a
     hint that was ALREADY inactive — an org admin who retracted it between
@@ -784,13 +825,9 @@ export function FeedbackPanel({ outcome, workflowId }: { outcome: Exclude<Outcom
                         retract, auto-disable, an LLM review) — the server
                         can't tell those apart, so this marker doesn't
                         pretend to either. */}
-                    {c.retracted ? (
-                      <span className="ml-1.5 italic">
-                        {c.retracted === 'already' ? '— already retracted' : '— retracted'}
-                      </span>
-                    ) : c.active === false ? (
-                      <span className="ml-1.5 italic">{SWITCHED_OFF_MARKER}</span>
-                    ) : null}
+                    {correctionMarker(c) && (
+                      <span className="ml-1.5 italic">{correctionMarker(c)}</span>
+                    )}
                   </span>
                   {/* can_retract is absent or false on an older backend and on
                       the learning-disabled shape — both render exactly like
@@ -839,23 +876,7 @@ export function FeedbackPanel({ outcome, workflowId }: { outcome: Exclude<Outcom
           this width the sentence wraps and collides with the 0/500 counter. */}
       {alreadySent && (
         <p className="text-xs text-muted-foreground">
-          {alreadySent.retracted
-            /* Scoped to THIS run on purpose. Sending it again here dedups to
-               the hint that was just retracted and the claim row for this run
-               already exists, so nothing reactivates it — but the same text
-               from a LATER run does reinforce, and an unqualified "it can't
-               come back" would be a new false claim. Kept now that the
-               backend answers such a resubmission honestly ("hint_inactive"),
-               because this fires BEFORE the click: it is the only thing that
-               warns while the user can still change their mind. */
-            ? 'You retracted this correction. Sending it again on this run won’t restore it.'
-            : alreadySent.active === false
-              /* Same "won't come back" fact as the branch above, minus the
-                 claim of WHO — active===false alone doesn't know it was this
-                 user's own retract, so unlike the branch above this must not
-                 say "you". */
-              ? 'This correction is switched off. Sending it again on this run won’t turn it back on.'
-              : 'You already sent this for this run — it won’t be counted again.'}
+          {alreadySentNotice(alreadySent)}
         </p>
       )}
       <div className="flex items-center justify-between">

--- a/src/frontend-react/src/pages/GeneratePage.tsx
+++ b/src/frontend-react/src/pages/GeneratePage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState, type CSSProperties, type ReactNode } from 'react'
+import { useEffect, useReducer, useRef, useState, type CSSProperties, type ReactNode } from 'react'
 import { useLocation } from 'react-router-dom'
 import { Button } from '@/components/ui/button'
 import { Textarea } from '@/components/ui/textarea'
@@ -305,17 +305,16 @@ function GenerationPipeline({ progress, stage, logs }: { progress: number; stage
 
 /* ── Live elapsed-seconds counter for the execution strip ── */
 function ExecElapsed({ start }: { start: number | null }) {
-  const [tick, setTick] = useState(0)
+  // useReducer, not useState: this value is never read, only ever bumped to
+  // force a re-render every second, so there is no "state" here to name.
+  const [, forceRerender] = useReducer(x => x + 1, 0)
   useEffect(() => {
-    const id = setInterval(() => setTick(t => t + 1), 1000)
+    const id = setInterval(forceRerender, 1000)
     return () => clearInterval(id)
   }, [])
   if (start == null) return null
   return (
-    // data-tick surfaces the actual re-render counter: setTick already forces
-    // the re-render on its own, so this doesn't change what renders — it just
-    // gives `tick` a real reader instead of leaving it write-only.
-    <span data-tick={tick} className="ml-auto shrink-0 tabular-nums text-[#8b949e]">
+    <span className="ml-auto shrink-0 tabular-nums text-[#8b949e]">
       {Math.max(0, Math.round((Date.now() - start) / 1000))}s
     </span>
   )

--- a/src/frontend-react/src/pages/GeneratePage.tsx
+++ b/src/frontend-react/src/pages/GeneratePage.tsx
@@ -1058,6 +1058,83 @@ function runButtonLabel(phase: Phase, genProgress: number, hasCode: boolean, has
   return 'Enter a query or paste code'
 }
 
+/* ── Left workspace card: the plain-English description, and the single
+   adaptive action beneath it (legacy-UI pattern) — code present → Run Test,
+   otherwise a query → Generate Test. Review-before-run is deliberate: there
+   is no combined generate-and-run ── */
+function TestDescriptionCard({ query, code, phase, genProgress, busy, onQueryChange, onGenerate, onRun }: Readonly<{
+  query: string; code: string; phase: Phase; genProgress: number; busy: boolean
+  onQueryChange: (value: string) => void; onGenerate: () => void; onRun: () => void
+}>) {
+  return (
+    <Card className="col-span-2 flex flex-col max-lg:col-span-1">
+      <CardHeader className="pb-3">
+        <CardTitle className="text-sm">Test Description</CardTitle>
+        <CardDescription className="text-xs">Write what you want to test in plain English</CardDescription>
+      </CardHeader>
+      <CardContent className="flex flex-1 flex-col gap-3 pt-0">
+        <Textarea
+          className="min-h-[260px] flex-1 resize-none font-mono text-[13px]"
+          placeholder={PLACEHOLDER}
+          value={query}
+          onChange={e => onQueryChange(e.target.value)}
+          onKeyDown={e => {
+            if (e.key === 'Enter' && (e.ctrlKey || e.metaKey) && !code.trim()) {
+              e.preventDefault(); onGenerate()
+            }
+          }}
+          disabled={busy}
+        />
+        <div className="flex items-center gap-2">
+          <Button
+            onClick={code.trim() ? onRun : onGenerate}
+            disabled={busy || (!code.trim() && !query.trim())}
+            className="h-10 flex-1 gap-2"
+          >
+            {runButtonIcon(busy, !!code.trim())}
+            {runButtonLabel(phase, genProgress, !!code.trim(), !!query.trim())}
+          </Button>
+          {!busy && code.trim() && query.trim() && (
+            <Button variant="outline" onClick={onGenerate} className="h-10 gap-1.5" title="Discard the current code and regenerate from the description">
+              <Zap className="h-3.5 w-3.5" /> Regenerate
+            </Button>
+          )}
+        </div>
+      </CardContent>
+    </Card>
+  )
+}
+
+/* ── The code card's header controls: the live run-status badges, then copy
+   and export. Both buttons stay mounted and merely disable with no code, so
+   the header's width never jumps mid-run ── */
+function CodePanelControls({ phase, outcome, execSecs, copied, hasCode, onCopy, onDownload }: Readonly<{
+  phase: Phase; outcome: Outcome; execSecs: number | null; copied: boolean; hasCode: boolean
+  onCopy: () => void; onDownload: () => void
+}>) {
+  return (
+    <div className="flex items-center gap-2 shrink-0">
+      {phase === 'executing' && (
+        <Badge variant="secondary" className="gap-1.5 text-xs">
+          <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-current" /> Executing
+        </Badge>
+      )}
+      {outcome === 'pass' && (
+        <Badge className="bg-green-100 text-green-700 hover:bg-green-100 text-xs border-green-200">
+          Passed{execSecs != null ? ` in ${execSecs.toFixed(1)}s` : ''}
+        </Badge>
+      )}
+      {outcome === 'fail' && <Badge className="bg-red-100 text-red-700 hover:bg-red-100 text-xs border-red-200">Failed</Badge>}
+      <Button variant="outline" size="sm" className="h-7 gap-1 text-xs" onClick={onCopy} disabled={!hasCode}>
+        {copied ? <Check className="h-3 w-3 text-green-600" /> : <Copy className="h-3 w-3" />} Copy
+      </Button>
+      <Button variant="outline" size="sm" className="h-7 gap-1 text-xs" onClick={onDownload} disabled={!hasCode}>
+        <Download className="h-3 w-3" /> Export
+      </Button>
+    </div>
+  )
+}
+
 /* ── Main page ── */
 export default function GeneratePage() {
   const [query, setQuery]   = useState('')
@@ -1246,45 +1323,16 @@ export default function GeneratePage() {
 
       {/* Two-column workspace — fills the viewport like the legacy runner */}
       <div className="mb-6 grid grid-cols-5 gap-4 max-lg:grid-cols-1 lg:h-[calc(100vh-235px)] lg:min-h-[480px]">
-        {/* Input card */}
-        <Card className="col-span-2 flex flex-col max-lg:col-span-1">
-          <CardHeader className="pb-3">
-            <CardTitle className="text-sm">Test Description</CardTitle>
-            <CardDescription className="text-xs">Write what you want to test in plain English</CardDescription>
-          </CardHeader>
-          <CardContent className="flex flex-1 flex-col gap-3 pt-0">
-            <Textarea
-              className="min-h-[260px] flex-1 resize-none font-mono text-[13px]"
-              placeholder={PLACEHOLDER}
-              value={query}
-              onChange={e => setQuery(e.target.value)}
-              onKeyDown={e => {
-                if (e.key === 'Enter' && (e.ctrlKey || e.metaKey) && !code.trim()) {
-                  e.preventDefault(); handleGenerate()
-                }
-              }}
-              disabled={busy}
-            />
-            {/* Single adaptive action (legacy-UI pattern): code present → Run Test;
-                otherwise a query → Generate Test. Review-before-run is deliberate —
-                there is no combined generate-and-run. */}
-            <div className="flex items-center gap-2">
-              <Button
-                onClick={code.trim() ? handleRun : handleGenerate}
-                disabled={busy || (!code.trim() && !query.trim())}
-                className="h-10 flex-1 gap-2"
-              >
-                {runButtonIcon(busy, !!code.trim())}
-                {runButtonLabel(phase, genProgress, !!code.trim(), !!query.trim())}
-              </Button>
-              {!busy && code.trim() && query.trim() && (
-                <Button variant="outline" onClick={handleGenerate} className="h-10 gap-1.5" title="Discard the current code and regenerate from the description">
-                  <Zap className="h-3.5 w-3.5" /> Regenerate
-                </Button>
-              )}
-            </div>
-          </CardContent>
-        </Card>
+        <TestDescriptionCard
+          query={query}
+          code={code}
+          phase={phase}
+          genProgress={genProgress}
+          busy={busy}
+          onQueryChange={setQuery}
+          onGenerate={handleGenerate}
+          onRun={handleRun}
+        />
 
         {/* Generated / editable code card. overflow-hidden is load-bearing: as a
             grid item its automatic minimum size would otherwise be the editor's
@@ -1297,25 +1345,15 @@ export default function GeneratePage() {
               <CardTitle className="text-sm">Generated Code</CardTitle>
               <CardDescription className="text-xs">Editable — tweak it or paste your own, then run</CardDescription>
             </div>
-            <div className="flex items-center gap-2 shrink-0">
-              {phase === 'executing' && (
-                <Badge variant="secondary" className="gap-1.5 text-xs">
-                  <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-current" /> Executing
-                </Badge>
-              )}
-              {outcome === 'pass' && (
-                <Badge className="bg-green-100 text-green-700 hover:bg-green-100 text-xs border-green-200">
-                  Passed{execSecs != null ? ` in ${execSecs.toFixed(1)}s` : ''}
-                </Badge>
-              )}
-              {outcome === 'fail' && <Badge className="bg-red-100 text-red-700 hover:bg-red-100 text-xs border-red-200">Failed</Badge>}
-              <Button variant="outline" size="sm" className="h-7 gap-1 text-xs" onClick={handleCopy} disabled={!code}>
-                {copied ? <Check className="h-3 w-3 text-green-600" /> : <Copy className="h-3 w-3" />} Copy
-              </Button>
-              <Button variant="outline" size="sm" className="h-7 gap-1 text-xs" onClick={handleDownload} disabled={!code}>
-                <Download className="h-3 w-3" /> Export
-              </Button>
-            </div>
+            <CodePanelControls
+              phase={phase}
+              outcome={outcome}
+              execSecs={execSecs}
+              copied={copied}
+              hasCode={!!code}
+              onCopy={handleCopy}
+              onDownload={handleDownload}
+            />
           </CardHeader>
           <CardContent className="flex min-h-0 flex-1 flex-col gap-3 px-4 pt-0">
             {phase === 'generating' ? (

--- a/src/frontend-react/src/pages/GeneratePage.tsx
+++ b/src/frontend-react/src/pages/GeneratePage.tsx
@@ -458,8 +458,13 @@ interface FeedbackResponse { status?: string; outcome?: string; message?: string
     auth/ownership.py — the same rule that gates the admin dashboard's hint
     mutations): true for the hint's own author or an org admin, false for
     anyone else. Optional because an older backend, or the learning-disabled
-    response shape, never sends it — absence must render exactly like false. */
-interface RecordedCorrection { hint_id: number; feedback_text: string; recorded_at: string; can_retract?: boolean }
+    response shape, never sends it — absence must render exactly like false.
+
+    active is the server's own word for is_active. Optional for the same
+    reason can_retract is: an older backend, or the learning-disabled
+    response shape, never sends it — absence must render exactly like today,
+    never like switched off. */
+interface RecordedCorrection { hint_id: number; feedback_text: string; recorded_at: string; active?: boolean; can_retract?: boolean }
 interface RecordedResponse { corrections?: RecordedCorrection[] }
 
 /** A recorded correction as the PANEL holds it: the server's row plus what
@@ -770,15 +775,21 @@ export function FeedbackPanel({ outcome, workflowId }: { outcome: Exclude<Outcom
                 <div className="flex items-center justify-between gap-2">
                   <span>
                     “{c.feedback_text}”
-                    {/* Set only by this session's own retract. The server
-                        never says "retracted" on this route — it answers
-                        can_retract, which is false for plenty of hints that
-                        are still perfectly active. */}
-                    {c.retracted && (
+                    {/* Exactly one marker, in precedence order. `retracted` is
+                        client-only, set by THIS session's own retract click,
+                        and wins because it is the more specific fact — it
+                        knows WHO did it. `active === false` covers every
+                        other way the hint went inactive (another caller's
+                        retract, auto-disable, an LLM review) — the server
+                        can't tell those apart, so this marker doesn't
+                        pretend to either. */}
+                    {c.retracted ? (
                       <span className="ml-1.5 italic">
                         {c.retracted === 'already' ? '— already retracted' : '— retracted'}
                       </span>
-                    )}
+                    ) : c.active === false ? (
+                      <span className="ml-1.5 italic">— switched off</span>
+                    ) : null}
                   </span>
                   {/* can_retract is absent or false on an older backend and on
                       the learning-disabled shape — both render exactly like
@@ -837,7 +848,13 @@ export function FeedbackPanel({ outcome, workflowId }: { outcome: Exclude<Outcom
                because this fires BEFORE the click: it is the only thing that
                warns while the user can still change their mind. */
             ? 'You retracted this correction. Sending it again on this run won’t restore it.'
-            : 'You already sent this for this run — it won’t be counted again.'}
+            : alreadySent.active === false
+              /* Same "won't come back" fact as the branch above, minus the
+                 claim of WHO — active===false alone doesn't know it was this
+                 user's own retract, so unlike the branch above this must not
+                 say "you". */
+              ? 'This correction is switched off. Sending it again on this run won’t turn it back on.'
+              : 'You already sent this for this run — it won’t be counted again.'}
         </p>
       )}
       <div className="flex items-center justify-between">

--- a/src/frontend-react/src/pages/GeneratePage.tsx
+++ b/src/frontend-react/src/pages/GeneratePage.tsx
@@ -1267,9 +1267,19 @@ export default function GeneratePage() {
               <GenerationPipeline progress={genProgress} stage={genStage} logs={genLogs} />
             ) : (
               /* Inset, bordered dark code block (GitHub-style) rather than an
-                  edge-to-edge black panel */
+                  edge-to-edge black panel.
+                  role="presentation": this div is not a control — it only
+                  relays the Ctrl/Cmd+Enter keydown that bubbles up from the
+                  editor's own textarea inside it. A bare div with a key
+                  handler and no role reads to Sonar's S6848 as a fake
+                  interactive element, but jsx-a11y's own docs name this exact
+                  shape ("an element catching bubbled events from elements it
+                  contains") and prescribe role="presentation" as the fix.
+                  It is purely an ARIA hint — the shortcut still fires
+                  identically for mouse and keyboard users either way. */
               <div
                 className="relative flex min-h-0 flex-1 flex-col"
+                role="presentation"
                 onKeyDown={e => {
                   if (e.key === 'Enter' && (e.ctrlKey || e.metaKey) && code.trim()) {
                     e.preventDefault(); handleRun()

--- a/src/frontend-react/src/pages/GeneratePage.tsx
+++ b/src/frontend-react/src/pages/GeneratePage.tsx
@@ -1267,25 +1267,8 @@ export default function GeneratePage() {
               <GenerationPipeline progress={genProgress} stage={genStage} logs={genLogs} />
             ) : (
               /* Inset, bordered dark code block (GitHub-style) rather than an
-                  edge-to-edge black panel.
-                  role="presentation": this div is not a control — it only
-                  relays the Ctrl/Cmd+Enter keydown that bubbles up from the
-                  editor's own textarea inside it. A bare div with a key
-                  handler and no role reads to Sonar's S6848 as a fake
-                  interactive element, but jsx-a11y's own docs name this exact
-                  shape ("an element catching bubbled events from elements it
-                  contains") and prescribe role="presentation" as the fix.
-                  It is purely an ARIA hint — the shortcut still fires
-                  identically for mouse and keyboard users either way. */
-              <div
-                className="relative flex min-h-0 flex-1 flex-col"
-                role="presentation"
-                onKeyDown={e => {
-                  if (e.key === 'Enter' && (e.ctrlKey || e.metaKey) && code.trim()) {
-                    e.preventDefault(); handleRun()
-                  }
-                }}
-              >
+                  edge-to-edge black panel */
+              <div className="relative flex min-h-0 flex-1 flex-col">
                 <RobotCodeEditor
                   value={code}
                   onChange={v => {
@@ -1303,6 +1286,16 @@ export default function GeneratePage() {
                   disabled={busy}
                   placeholder={'*** Settings ***\nLibrary    Browser\n\nGenerated code appears here, or paste your own…'}
                   className="min-h-[300px] flex-1 rounded-lg border border-border shadow-sm"
+                  // Ctrl/Cmd+Enter runs the current code. Wired onto the
+                  // editor's own textarea (forwarded through RobotCodeEditor)
+                  // rather than a wrapping div, so there is no non-native
+                  // element listening for input in the first place — S6848
+                  // never gets anything to fire on.
+                  onKeyDown={e => {
+                    if (e.key === 'Enter' && (e.ctrlKey || e.metaKey) && code.trim()) {
+                      e.preventDefault(); handleRun()
+                    }
+                  }}
                 />
                 {/* Live-run strip while the scenario executes: the code is not
                     being "scanned" — it is running against a real browser in an

--- a/src/frontend-react/src/pages/GeneratePage.tsx
+++ b/src/frontend-react/src/pages/GeneratePage.tsx
@@ -70,9 +70,9 @@ function parseRobotSummary(blob: string): RobotSummary {
 }
 
 /* ── Collapsible logs card with an indeterminate bar while running ── */
-function LogsSection({ title, desc, logs, running, collapseOnDone }: {
+function LogsSection({ title, desc, logs, running, collapseOnDone }: Readonly<{
   title: string; desc: string; logs: LogEntry[]; running: boolean; collapseOnDone?: boolean
-}) {
+}>) {
   const [open, setOpen] = useState(true)
   const listRef = useRef<HTMLDivElement>(null)
   // Keep the newest log line in view while streaming (legacy-UI behaviour)
@@ -142,7 +142,7 @@ const PIPELINE_STAGES = [
 ] as const
 
 /* Plan: numbered ghost steps, revealed as the planner's SSE events arrive */
-function PlanActivity({ progress }: { progress: number }) {
+function PlanActivity({ progress }: Readonly<{ progress: number }>) {
   const widths = ['w-64', 'w-52', 'w-72']
   return (
     <div>
@@ -157,7 +157,7 @@ function PlanActivity({ progress }: { progress: number }) {
 }
 
 /* Locate: element → locator pairs being captured from the live page */
-function LocateActivity({ progress, elementCount }: { progress: number; elementCount: number | null }) {
+function LocateActivity({ progress, elementCount }: Readonly<{ progress: number; elementCount: number | null }>) {
   const widths: [string, string][] = [['w-24', 'w-48'], ['w-28', 'w-40'], ['w-20', 'w-56']]
   return (
     <div>
@@ -215,7 +215,7 @@ function VerifyActivity() {
   )
 }
 
-function GenerationPipeline({ progress, stage, logs }: { progress: number; stage: string; logs: LogEntry[] }) {
+function GenerationPipeline({ progress, stage, logs }: Readonly<{ progress: number; stage: string; logs: LogEntry[] }>) {
   // The element-scan SSE event carries the only real artifact count we get
   // ("📍 Found N elements on the page") — surface it in the Locate block.
   const elMatch = logs.map(l => /Found (\d+) elements/.exec(l.msg)).find(Boolean)
@@ -304,7 +304,7 @@ function GenerationPipeline({ progress, stage, logs }: { progress: number; stage
 }
 
 /* ── Live elapsed-seconds counter for the execution strip ── */
-function ExecElapsed({ start }: { start: number | null }) {
+function ExecElapsed({ start }: Readonly<{ start: number | null }>) {
   // useReducer, not useState: this value is never read, only ever bumped to
   // force a re-render every second, so there is no "state" here to name.
   const [, forceRerender] = useReducer(x => x + 1, 0)
@@ -345,10 +345,10 @@ function ConfettiBurst() {
 
 /* ── Post-run result card: outcome banner, per-test breakdown, report links,
    and an optional feedback footer (children) ── */
-function ExecutionResult({ outcome, summary, secs, reportUrl, logUrl, children }: {
+function ExecutionResult({ outcome, summary, secs, reportUrl, logUrl, children }: Readonly<{
   outcome: Exclude<Outcome, null>; summary: RobotSummary | null; secs: number | null
   reportUrl: string | null; logUrl: string | null; children?: ReactNode
-}) {
+}>) {
   const pass = outcome === 'pass'
   const tests = summary?.tests ?? []
   const failures = summary?.failures ?? []
@@ -547,7 +547,7 @@ const RETRACT_ACTOR_PLACEHOLDER = 'feedback-panel'
    Fail: form open by default; Skip still records an empty completely_wrong
    label on the execution record, but nothing is learned from it (outcome
    "no_text") — the empty text carries nothing for any engine to route. ── */
-export function FeedbackPanel({ outcome, workflowId }: { outcome: Exclude<Outcome, null>; workflowId: string | null }) {
+export function FeedbackPanel({ outcome, workflowId }: Readonly<{ outcome: Exclude<Outcome, null>; workflowId: string | null }>) {
   const [open, setOpen] = useState(outcome === 'fail')
   const [ack, setAck] = useState(false)
   const [text, setText] = useState('')

--- a/src/frontend-react/src/pages/GeneratePage.tsx
+++ b/src/frontend-react/src/pages/GeneratePage.tsx
@@ -31,7 +31,7 @@ function nowTs() {
 /** /reports/{run_id}/log.html -> run_id (for feedback attribution) */
 function runIdFromReport(url: string | null): string | null {
   if (!url) return null
-  const m = url.match(/\/reports\/([^/]+)\//)
+  const m = /\/reports\/([^/]+)\//.exec(url)
   return m ? m[1] : null
 }
 
@@ -48,19 +48,19 @@ function parseRobotSummary(blob: string): RobotSummary {
   const failures: RobotSummary['failures'] = []
   let failing: string | null = null
   for (const line of blob.split('\n')) {
-    const t = line.match(/^\s*Test: (.+) - (PASS|FAIL)$/)
+    const t = /^\s*Test: (.+) - (PASS|FAIL)$/.exec(line)
     if (t) {
       tests.push({ name: t[1], status: t[2] as 'PASS' | 'FAIL' })
       failing = t[2] === 'FAIL' ? t[1] : null
       continue
     }
-    const e = line.match(/^\s*Error: (.+)$/)
+    const e = /^\s*Error: (.+)$/.exec(line)
     if (e && failing) {
       failures.push({ test: failing, message: e[1] })
       failing = null
     }
   }
-  const counts = blob.match(/^Results: (\d+) passed, (\d+) failed$/m)
+  const counts = /^Results: (\d+) passed, (\d+) failed$/m.exec(blob)
   return {
     tests,
     failures,
@@ -209,7 +209,7 @@ function AssembleActivity() {
 function VerifyActivity() {
   return (
     <div className="ghost-line flex items-center gap-2.5 text-xs text-[#8b949e]">
-      <span className="h-3.5 w-3.5 shrink-0 animate-spin rounded-full border-2 border-[#30363d] border-t-sky-400" />
+      <span className="h-3.5 w-3.5 shrink-0 animate-spin rounded-full border-2 border-[#30363d] border-t-sky-400" />{' '}
       Compiling the test in a clean Docker container — auto-fixing anything that fails
     </div>
   )
@@ -218,7 +218,7 @@ function VerifyActivity() {
 function GenerationPipeline({ progress, stage, logs }: { progress: number; stage: string; logs: LogEntry[] }) {
   // The element-scan SSE event carries the only real artifact count we get
   // ("📍 Found N elements on the page") — surface it in the Locate block.
-  const elMatch = logs.map(l => l.msg.match(/Found (\d+) elements/)).find(Boolean)
+  const elMatch = logs.map(l => /Found (\d+) elements/.exec(l.msg)).find(Boolean)
   const elementCount = elMatch ? Number(elMatch[1]) : null
   return (
     <div className="flex min-h-[300px] flex-1 flex-col overflow-hidden rounded-lg border border-border bg-[#0d1117] shadow-sm">
@@ -305,7 +305,7 @@ function GenerationPipeline({ progress, stage, logs }: { progress: number; stage
 
 /* ── Live elapsed-seconds counter for the execution strip ── */
 function ExecElapsed({ start }: { start: number | null }) {
-  const [, force] = useState(0)
+  const [_tick, force] = useState(0)
   useEffect(() => {
     const id = setInterval(() => force(t => t + 1), 1000)
     return () => clearInterval(id)
@@ -350,7 +350,7 @@ function ExecutionResult({ outcome, summary, secs, reportUrl, logUrl, children }
   const pass = outcome === 'pass'
   const tests = summary?.tests ?? []
   const failures = summary?.failures ?? []
-  const total = summary && summary.passed != null && summary.failed != null
+  const total = summary?.passed != null && summary?.failed != null
     ? summary.passed + summary.failed
     : tests.length || null
   // Single-test runs are the norm — counts and the per-test list only earn

--- a/src/frontend-react/src/pages/GeneratePage.tsx
+++ b/src/frontend-react/src/pages/GeneratePage.tsx
@@ -305,14 +305,17 @@ function GenerationPipeline({ progress, stage, logs }: { progress: number; stage
 
 /* ── Live elapsed-seconds counter for the execution strip ── */
 function ExecElapsed({ start }: { start: number | null }) {
-  const [_tick, force] = useState(0)
+  const [tick, setTick] = useState(0)
   useEffect(() => {
-    const id = setInterval(() => force(t => t + 1), 1000)
+    const id = setInterval(() => setTick(t => t + 1), 1000)
     return () => clearInterval(id)
   }, [])
   if (start == null) return null
   return (
-    <span className="ml-auto shrink-0 tabular-nums text-[#8b949e]">
+    // data-tick surfaces the actual re-render counter: setTick already forces
+    // the re-render on its own, so this doesn't change what renders — it just
+    // gives `tick` a real reader instead of leaving it write-only.
+    <span data-tick={tick} className="ml-auto shrink-0 tabular-nums text-[#8b949e]">
       {Math.max(0, Math.round((Date.now() - start) / 1000))}s
     </span>
   )

--- a/src/frontend-react/src/pages/GeneratePage.tsx
+++ b/src/frontend-react/src/pages/GeneratePage.tsx
@@ -393,6 +393,104 @@ function resultTitle(pass: boolean, total: number | null, failed: number | null 
   return 'Test execution failed'
 }
 
+/** The result card's second line. Pass runs get whichever facts we actually
+    have — a test count only when there is more than one, a duration only when
+    the run was timed — and a neutral sentence when we have neither. */
+function resultSubtitle(pass: boolean, total: number | null, secs: number | null): string {
+  if (!pass) return 'Open the detailed log to see exactly which step went wrong.'
+  const parts: string[] = []
+  if (total && total > 1) parts.push(`${total} tests`)
+  if (secs != null) parts.push(`finished in ${secs.toFixed(1)}s`)
+  return parts.join(' · ') || 'Execution finished'
+}
+
+/* ── Result card banner: outcome icon, headline, and the two report links ── */
+function ResultBanner({ pass, title, subtitle, reportUrl, logUrl }: Readonly<{
+  pass: boolean; title: string; subtitle: string
+  reportUrl: string | null; logUrl: string | null
+}>) {
+  return (
+    <div className="flex flex-wrap items-center justify-between gap-3">
+      <div className="flex items-center gap-3">
+        {pass
+          ? <CheckCircle2 className="check-pop h-10 w-10 shrink-0 text-green-500" />
+          : <XCircle className="h-10 w-10 shrink-0 text-destructive" />}
+        <div>
+          <div className="text-lg font-bold leading-tight">{title}</div>
+          <p className="text-sm text-muted-foreground">{subtitle}</p>
+        </div>
+      </div>
+      <div className="flex shrink-0 gap-2">
+        {reportUrl && (
+          <Button asChild size="sm" className={cn('gap-1.5', pass && 'bg-green-600 text-white hover:bg-green-700')}>
+            <a href={reportUrl} target="_blank" rel="noopener noreferrer">
+              <ExternalLink className="h-3.5 w-3.5" /> View Report
+            </a>
+          </Button>
+        )}
+        {logUrl && (
+          <Button asChild variant="outline" size="sm" className="gap-1.5">
+            <a href={logUrl} target="_blank" rel="noopener noreferrer">
+              <FileText className="h-3.5 w-3.5" /> Detailed Log
+            </a>
+          </Button>
+        )}
+      </div>
+    </div>
+  )
+}
+
+/* ── Per-test breakdown. Renders nothing for a single-test run: the banner
+   already says everything a one-line list could add ── */
+function ResultTestList({ tests }: Readonly<{ tests: RobotSummary['tests'] }>) {
+  if (tests.length <= 1) return null
+  return (
+    <div className="max-h-36 divide-y overflow-y-auto rounded-lg border bg-background/70">
+      {/* Index is a correct key: `tests` is written once, at the same
+          moment `outcome` turns truthy, and the parent's `{outcome &&
+          ...}` gate (GeneratePage) unmounts this whole card at the
+          start of every new run — so this array is never reordered or
+          filtered while a single instance of this list stays mounted. */}
+      {tests.map((t, i) => (
+        <div key={i} className="flex items-center gap-2.5 px-3 py-2 text-sm">
+          {t.status === 'PASS'
+            ? <Check className="h-4 w-4 shrink-0 text-green-500" />
+            : <X className="h-4 w-4 shrink-0 text-destructive" />}
+          <span className="min-w-0 truncate">{t.name}</span>
+          <span className={cn('ml-auto shrink-0 text-xs font-bold tracking-wide',
+            t.status === 'PASS' ? 'text-green-600 dark:text-green-400' : 'text-destructive')}>
+            {t.status}
+          </span>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+/* ── The first three failure messages. Renders nothing when the run recorded
+   no failure message at all, so a failed run with an empty list stays silent
+   rather than drawing an empty red box ── */
+function ResultFailureList({ failures, withTestName }: Readonly<{
+  failures: RobotSummary['failures']; withTestName: boolean
+}>) {
+  if (failures.length === 0) return null
+  return (
+    <div className="space-y-1 rounded-lg border border-destructive/30 bg-destructive/5 px-3 py-2 font-mono text-xs text-destructive">
+      {/* Index is a correct key here for the same reason as the tests
+          list above: `failures` comes from the same once-per-run
+          `summary`, and this card remounts before a next one exists. */}
+      {failures.slice(0, 3).map((f, i) => (
+        <div key={i} className="break-words">
+          {withTestName ? `${f.test}: ` : ''}{f.message}
+        </div>
+      ))}
+      {failures.length > 3 && (
+        <div className="text-destructive/70">…and {failures.length - 3} more — see the detailed log</div>
+      )}
+    </div>
+  )
+}
+
 /* ── Post-run result card: outcome banner, per-test breakdown, report links,
    and an optional feedback footer (children) ── */
 function ExecutionResult({ outcome, summary, secs, reportUrl, logUrl, children }: Readonly<{
@@ -405,11 +503,6 @@ function ExecutionResult({ outcome, summary, secs, reportUrl, logUrl, children }
   const total = summary?.passed != null && summary?.failed != null
     ? summary.passed + summary.failed
     : tests.length || null
-  const title = resultTitle(pass, total, summary?.failed)
-  const subtitle = pass
-    ? [total && total > 1 ? `${total} tests` : null, secs != null ? `finished in ${secs.toFixed(1)}s` : null]
-        .filter(Boolean).join(' · ') || 'Execution finished'
-    : 'Open the detailed log to see exactly which step went wrong.'
   return (
     <Card className={cn('result-pop relative overflow-hidden', pass ? 'border-green-500/40' : 'border-destructive/40')}>
       <div
@@ -422,69 +515,15 @@ function ExecutionResult({ outcome, summary, secs, reportUrl, logUrl, children }
       />
       {pass && <ConfettiBurst />}
       <CardContent className="relative space-y-3 p-5">
-        <div className="flex flex-wrap items-center justify-between gap-3">
-          <div className="flex items-center gap-3">
-            {pass
-              ? <CheckCircle2 className="check-pop h-10 w-10 shrink-0 text-green-500" />
-              : <XCircle className="h-10 w-10 shrink-0 text-destructive" />}
-            <div>
-              <div className="text-lg font-bold leading-tight">{title}</div>
-              <p className="text-sm text-muted-foreground">{subtitle}</p>
-            </div>
-          </div>
-          <div className="flex shrink-0 gap-2">
-            {reportUrl && (
-              <Button asChild size="sm" className={cn('gap-1.5', pass && 'bg-green-600 text-white hover:bg-green-700')}>
-                <a href={reportUrl} target="_blank" rel="noopener noreferrer">
-                  <ExternalLink className="h-3.5 w-3.5" /> View Report
-                </a>
-              </Button>
-            )}
-            {logUrl && (
-              <Button asChild variant="outline" size="sm" className="gap-1.5">
-                <a href={logUrl} target="_blank" rel="noopener noreferrer">
-                  <FileText className="h-3.5 w-3.5" /> Detailed Log
-                </a>
-              </Button>
-            )}
-          </div>
-        </div>
-        {tests.length > 1 && (
-          <div className="max-h-36 divide-y overflow-y-auto rounded-lg border bg-background/70">
-            {/* Index is a correct key: `tests` is written once, at the same
-                moment `outcome` turns truthy, and the parent's `{outcome &&
-                ...}` gate (GeneratePage) unmounts this whole card at the
-                start of every new run — so this array is never reordered or
-                filtered while a single instance of this list stays mounted. */}
-            {tests.map((t, i) => (
-              <div key={i} className="flex items-center gap-2.5 px-3 py-2 text-sm">
-                {t.status === 'PASS'
-                  ? <Check className="h-4 w-4 shrink-0 text-green-500" />
-                  : <X className="h-4 w-4 shrink-0 text-destructive" />}
-                <span className="min-w-0 truncate">{t.name}</span>
-                <span className={cn('ml-auto shrink-0 text-xs font-bold tracking-wide',
-                  t.status === 'PASS' ? 'text-green-600 dark:text-green-400' : 'text-destructive')}>
-                  {t.status}
-                </span>
-              </div>
-            ))}
-          </div>
-        )}
-        {!pass && failures.length > 0 && (
-          <div className="space-y-1 rounded-lg border border-destructive/30 bg-destructive/5 px-3 py-2 font-mono text-xs text-destructive">
-            {/* Index is a correct key here for the same reason as the tests
-                list above: `failures` comes from the same once-per-run
-                `summary`, and this card remounts before a next one exists. */}
-            {failures.slice(0, 3).map((f, i) => (
-              <div key={i} className="break-words">
-                {tests.length > 1 ? `${f.test}: ` : ''}{f.message}
-              </div>
-            ))}
-            {failures.length > 3 && (
-              <div className="text-destructive/70">…and {failures.length - 3} more — see the detailed log</div>
-            )}
-          </div>
-        )}
+        <ResultBanner
+          pass={pass}
+          title={resultTitle(pass, total, summary?.failed)}
+          subtitle={resultSubtitle(pass, total, secs)}
+          reportUrl={reportUrl}
+          logUrl={logUrl}
+        />
+        <ResultTestList tests={tests} />
+        {!pass && <ResultFailureList failures={failures} withTestName={tests.length > 1} />}
         {children && (
           <div className={cn('border-t pt-3', pass ? 'border-green-500/20' : 'border-destructive/20')}>
             {children}

--- a/src/frontend-react/src/pages/GeneratePage.tsx
+++ b/src/frontend-react/src/pages/GeneratePage.tsx
@@ -9,6 +9,7 @@ import { api, isAccessLoss } from '@/lib/api'
 import { streamSSE } from '@/lib/sse'
 import { Zap, Play, Plus, Download, Copy, Check, ChevronDown, ExternalLink, CheckCircle2, XCircle, FileText, X, ThumbsUp, ThumbsDown, Brain, ScanSearch, Code2, ShieldCheck, Crosshair, AlertTriangle, Info } from 'lucide-react'
 import RobotCodeEditor from '@/components/RobotCodeEditor'
+import { ALREADY_RECORDED_HEADING, SWITCHED_OFF_MARKER } from '@/components/RecordedCorrections'
 
 /* ── Types ── */
 type Phase = 'idle' | 'generating' | 'executing'
@@ -768,7 +769,7 @@ export function FeedbackPanel({ outcome, workflowId }: { outcome: Exclude<Outcom
       ))}
       {recorded.length > 0 && (
         <div className="rounded-md border bg-muted/40 px-3 py-2 text-xs">
-          <div className="font-medium">Already recorded for this run</div>
+          <div className="font-medium">{ALREADY_RECORDED_HEADING}</div>
           <ul className="mt-1 space-y-0.5 text-muted-foreground">
             {recorded.map(c => (
               <li key={c.hint_id}>
@@ -788,7 +789,7 @@ export function FeedbackPanel({ outcome, workflowId }: { outcome: Exclude<Outcom
                         {c.retracted === 'already' ? '— already retracted' : '— retracted'}
                       </span>
                     ) : c.active === false ? (
-                      <span className="ml-1.5 italic">— switched off</span>
+                      <span className="ml-1.5 italic">{SWITCHED_OFF_MARKER}</span>
                     ) : null}
                   </span>
                   {/* can_retract is absent or false on an older backend and on

--- a/src/frontend-react/src/pages/GeneratePage.tsx
+++ b/src/frontend-react/src/pages/GeneratePage.tsx
@@ -1013,6 +1013,35 @@ export function FeedbackPanel({ outcome, workflowId }: Readonly<{ outcome: Exclu
   )
 }
 
+/**
+ * The generation-log lines a completed /generate-test event has to record,
+ * in the order they must appear.
+ *
+ * Do NOT name a cause for 'unverified'. It means the dryrun gate could not
+ * run, and Docker being down is only one of several reasons — the backend
+ * sends the actual one as dryrun_message. Asserting "Docker unavailable" sent
+ * people to check a healthy Docker while the real fault was elsewhere.
+ */
+function generationCompleteLogs(data: {
+  robot_code?: unknown
+  dryrun_status?: unknown
+  dryrun_message?: unknown
+  dryrun_errors?: unknown
+}): { kind: LogEntry['kind']; msg: string }[] {
+  if (data.dryrun_status !== 'failed' && data.dryrun_status !== 'unverified') {
+    return [{ kind: 'success', msg: `Generated test.robot (${String(data.robot_code).split('\n').length} lines)` }]
+  }
+  const lines: { kind: LogEntry['kind']; msg: string }[] = [{
+    kind: 'error',
+    msg: data.dryrun_status === 'failed'
+      ? 'Delivered — dryrun found issues you may want to review'
+      : 'Delivered — this test was NOT verified, because the dryrun could not run',
+  }]
+  if (data.dryrun_message) lines.push({ kind: 'error', msg: String(data.dryrun_message) })
+  if (data.dryrun_errors) lines.push({ kind: 'error', msg: String(data.dryrun_errors) })
+  return lines
+}
+
 /* ── The single adaptive action button: code present → Run Test; otherwise
    a query → Generate Test (see the button's own comment at its call site
    for why this stays one control rather than a combined generate-and-run) ── */
@@ -1107,20 +1136,7 @@ export default function GeneratePage() {
           setGenProgress(100)
           setCode(data.robot_code)
           workflowId.current = data.workflow_id || null
-          if (data.dryrun_status === 'failed' || data.dryrun_status === 'unverified') {
-            // Do NOT name a cause here. 'unverified' means the gate could not
-            // run, and Docker being down is only one of several reasons — the
-            // backend sends the actual one as dryrun_message. Asserting
-            // "Docker unavailable" sent people to check a healthy Docker while
-            // the real fault was elsewhere.
-            addGen('error', data.dryrun_status === 'failed'
-              ? 'Delivered — dryrun found issues you may want to review'
-              : 'Delivered — this test was NOT verified, because the dryrun could not run')
-            if (data.dryrun_message) addGen('error', String(data.dryrun_message))
-            if (data.dryrun_errors) addGen('error', String(data.dryrun_errors))
-          } else {
-            addGen('success', `Generated test.robot (${String(data.robot_code).split('\n').length} lines)`)
-          }
+          generationCompleteLogs(data).forEach(line => addGen(line.kind, line.msg))
         } else if (data.status === 'error') {
           addGen('error', data.message || 'Generation failed')
           setError(data.message || 'Generation failed')

--- a/src/frontend-react/src/pages/GeneratePage.tsx
+++ b/src/frontend-react/src/pages/GeneratePage.tsx
@@ -124,6 +124,10 @@ function LogsSection({ title, desc, logs, running, collapseOnDone }: Readonly<{
             </div>
           )}
           <div ref={listRef} className="max-h-56 overflow-y-auto font-mono text-xs">
+            {/* Index is a correct key: addGen/addExec only ever append, this
+                array is reset to [] (not spliced or resorted) at the start of
+                the next run, so no index here is ever reused for a different
+                line. */}
             {logs.map((log, i) => (
               <div
                 key={i}
@@ -207,6 +211,9 @@ const ASSEMBLE_LINES: { header?: string; w?: string; indent?: boolean }[] = [
 function AssembleActivity() {
   return (
     <div>
+      {/* Index is a correct key: ASSEMBLE_LINES is a fixed module-level
+          constant, mapped in full and in the same order on every render —
+          there is no filter, reorder or runtime source that could shift it. */}
       {ASSEMBLE_LINES.map((l, i) => (
         <div key={i} className="ghost-line flex h-[20px] items-center" style={{ animationDelay: `${i * 110}ms` }}>
           {/* Muted gray, NOT the editor's red section-header token: in a
@@ -444,6 +451,11 @@ function ExecutionResult({ outcome, summary, secs, reportUrl, logUrl, children }
         </div>
         {tests.length > 1 && (
           <div className="max-h-36 divide-y overflow-y-auto rounded-lg border bg-background/70">
+            {/* Index is a correct key: `tests` is written once, at the same
+                moment `outcome` turns truthy, and the parent's `{outcome &&
+                ...}` gate (GeneratePage) unmounts this whole card at the
+                start of every new run — so this array is never reordered or
+                filtered while a single instance of this list stays mounted. */}
             {tests.map((t, i) => (
               <div key={i} className="flex items-center gap-2.5 px-3 py-2 text-sm">
                 {t.status === 'PASS'
@@ -460,6 +472,9 @@ function ExecutionResult({ outcome, summary, secs, reportUrl, logUrl, children }
         )}
         {!pass && failures.length > 0 && (
           <div className="space-y-1 rounded-lg border border-destructive/30 bg-destructive/5 px-3 py-2 font-mono text-xs text-destructive">
+            {/* Index is a correct key here for the same reason as the tests
+                list above: `failures` comes from the same once-per-run
+                `summary`, and this card remounts before a next one exists. */}
             {failures.slice(0, 3).map((f, i) => (
               <div key={i} className="break-words">
                 {tests.length > 1 ? `${f.test}: ` : ''}{f.message}

--- a/src/frontend-react/src/pages/GeneratePage.tsx
+++ b/src/frontend-react/src/pages/GeneratePage.tsx
@@ -508,11 +508,18 @@ function correctionMarker(c: PanelCorrection): string | null {
  *
  * The first two say the same "won't come back" fact; only the first claims WHO.
  * `active === false` alone does not know the retract was this user's own, so
- * the second must not say "you".
+ * the second must not say "you" — and neither may `retracted: 'already'`, which
+ * is the route answering that the hint was inactive BEFORE this click. The
+ * click happened; it is not what switched the correction off. It cannot fall
+ * through to the third sentence either: `active` is whatever the GET said and
+ * is not refreshed by the retract, so a stale `active: true` would drop the
+ * "won't come back" fact altogether.
  */
 function alreadySentNotice(c: PanelCorrection): string {
-  if (c.retracted) return 'You retracted this correction. Sending it again on this run won’t restore it.'
-  if (c.active === false) return 'This correction is switched off. Sending it again on this run won’t turn it back on.'
+  if (c.retracted === 'now') return 'You retracted this correction. Sending it again on this run won’t restore it.'
+  if (c.retracted === 'already' || c.active === false) {
+    return 'This correction is switched off. Sending it again on this run won’t turn it back on.'
+  }
   return 'You already sent this for this run — it won’t be counted again.'
 }
 

--- a/src/frontend-react/src/pages/HistoryPage.test.tsx
+++ b/src/frontend-react/src/pages/HistoryPage.test.tsx
@@ -512,6 +512,9 @@ describe('HistoryPage — who ran it', () => {
     await screen.findByText('search flipkart for shoes')
 
     expect(screen.queryByText('Ran by')).toBeNull()
+    // With no other author on screen there is nothing to search users BY,
+    // so the placeholder must not offer it.
+    expect(screen.getByPlaceholderText('Search description or id…')).toBeInTheDocument()
   })
 
   it('shows "Ran by" once any row belongs to someone else, and filters by that email on click', async () => {
@@ -519,6 +522,7 @@ describe('HistoryPage — who ran it', () => {
     renderPage()
     await screen.findByText('search flipkart for shoes')
     expect(screen.getByText('Ran by')).toBeInTheDocument()
+    expect(screen.getByPlaceholderText('Search description, user or id…')).toBeInTheDocument()
 
     fireEvent.click(screen.getByText('colleague@x.com'))
 
@@ -783,6 +787,33 @@ describe('HistoryPage — the drawer’s remaining actions', () => {
     expect(screen.getByText('You cannot read this run')).toBeInTheDocument()
     expect(screen.queryByText('Loading…')).toBeNull()
   })
+
+  // Run again needs stored code, an open row, no re-run of that row already
+  // in flight, and a run that is not still executing. The last of those is
+  // the only one no other test reaches: this run HAS code, so nothing but its
+  // status can be what disables the button.
+  it('disables Run again while the open run is still executing, even with code stored', async () => {
+    setupList([RUN_A])
+    withDetail('run-A', { status: 'running' })
+    renderPage()
+
+    fireEvent.click(await screen.findByText('search flipkart for shoes'))
+
+    const runAgain = await screen.findByRole('button', { name: 'Run again' })
+    expect(runAgain).toBeDisabled()
+  })
+
+  it('enables Run again for a finished run with code stored', async () => {
+    setupList([RUN_A])
+    withDetail('run-A')
+    renderPage()
+
+    fireEvent.click(await screen.findByText('search flipkart for shoes'))
+
+    const runAgain = await screen.findByRole('button', { name: 'Run again' })
+    expect(runAgain).toBeEnabled()
+  })
+
 
   it('shows "Loading…" while the run detail fetch is still pending, with no stale code and no error', async () => {
     setupList([RUN_A])

--- a/src/frontend-react/src/pages/HistoryPage.test.tsx
+++ b/src/frontend-react/src/pages/HistoryPage.test.tsx
@@ -1,0 +1,118 @@
+/**
+ * HistoryPage — the drawer's corrections fetch (Task 2 of
+ * feedback-visibility). One thin wiring test, not page coverage: this file
+ * had no test before this task. The fixture is the minimum needed to render
+ * the page — MemoryRouter (HistoryPage calls useNavigate for Regenerate),
+ * plus useAuth/useRunGroups/useFetch/api mocked so nothing here makes a real
+ * network call — mirroring the mock shape LearningPage.test.tsx and
+ * HintDrawer.test.tsx already use for the same three hooks.
+ *
+ * What this pins: opening a run in the drawer fires
+ * GET /api/feedback/{run_id}, and a refused (or still-pending) read renders
+ * no error text — the two behaviours HistoryPage.tsx's corrections block
+ * promises and GeneratePage's FeedbackPanel already proved once for its own
+ * surface. It does not re-test RecordedCorrections' own rendering rules
+ * (RecordedCorrections.test.tsx already does that) or the rest of the page.
+ */
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/auth/AuthContext', () => ({ useAuth: vi.fn() }))
+vi.mock('@/components/history/RunGroupsContext', () => ({ useRunGroups: vi.fn() }))
+vi.mock('@/lib/useFetch', () => ({ useFetch: vi.fn() }))
+vi.mock('@/lib/api', async importOriginal => ({
+  ...(await importOriginal<typeof import('@/lib/api')>()),
+  api: vi.fn(),
+}))
+
+import { useAuth } from '@/auth/AuthContext'
+import { useRunGroups } from '@/components/history/RunGroupsContext'
+import { useFetch } from '@/lib/useFetch'
+import { api } from '@/lib/api'
+import HistoryPage from './HistoryPage'
+
+const mockUseAuth = vi.mocked(useAuth)
+const mockUseRunGroups = vi.mocked(useRunGroups)
+const mockUseFetch = vi.mocked(useFetch)
+const mockApi = vi.mocked(api)
+
+afterEach(() => vi.resetAllMocks())
+
+const RUN = {
+  run_id: 'run-1', status: 'passed' as const, user_query: 'search flipkart for shoes',
+  created_at: '2026-09-01T00:00:00Z', updated_at: '2026-09-01T00:00:00Z',
+  has_report: false, can_move: false,
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function setup(feedbackFetch: { data: any; error: string; loading?: boolean }) {
+  mockUseAuth.mockReturnValue({
+    user: { id: 'u1', email: 'a@b.com', display_name: 'A', role: 'user', status: 'active' },
+    loading: false, isAuthenticated: true, isAdmin: false, status: 'active',
+    isOrgAdmin: false, canViewLearning: false,
+    login: vi.fn(), signup: vi.fn(), loginWithToken: vi.fn(), logout: vi.fn(), logoutAll: vi.fn(),
+  })
+  mockUseRunGroups.mockReturnValue({
+    groups: [], ungroupedCount: 0, error: '', loaded: true,
+    refresh: vi.fn(), createGroup: vi.fn(), renameGroup: vi.fn(),
+    deleteGroup: vi.fn(), assignRuns: vi.fn(),
+    groupFilter: null, setGroupFilter: vi.fn(),
+  })
+  mockApi.mockResolvedValue({ runs: [RUN], total: 1, scope: 'own' })
+  // Keyed by path: the drawer fires useFetch twice (run detail + this
+  // task's corrections fetch), and only the second is this test's subject.
+  mockUseFetch.mockImplementation((path: string | null) => {
+    if (path?.startsWith('/api/feedback/')) {
+      return { data: feedbackFetch.data, loading: feedbackFetch.loading ?? false, error: feedbackFetch.error, reload: vi.fn() }
+    }
+    return { data: null, loading: false, error: '', reload: vi.fn() }
+  })
+}
+
+async function openDrawer() {
+  render(<MemoryRouter><HistoryPage /></MemoryRouter>)
+  fireEvent.click(await screen.findByText('search flipkart for shoes'))
+  await waitFor(() => expect(mockUseFetch).toHaveBeenCalledWith('/api/feedback/run-1'))
+}
+
+describe('HistoryPage drawer — the corrections fetch', () => {
+  it('fires GET /api/feedback/{run_id} when a row is opened', async () => {
+    setup({ data: null, error: '' })
+
+    await openDrawer()
+
+    // openDrawer's own waitFor is the assertion; this is just its
+    // documented restatement.
+    expect(mockUseFetch).toHaveBeenCalledWith('/api/feedback/run-1')
+  })
+
+  it('renders no error text when the corrections read is refused (403 — a published run whose corrections stay private)', async () => {
+    setup({ data: null, error: 'You cannot read feedback for this run' })
+
+    await openDrawer()
+
+    // The page has an unrelated "Error" status filter button, so this checks
+    // the specific refusal text rather than a bare /error/i (which would
+    // false-positive on that button).
+    expect(screen.queryByText(/cannot read feedback/i)).toBeNull()
+  })
+
+  it('does not render a previous row’s corrections while this row’s fetch is still in flight', async () => {
+    // The corrections payload carries no run_id of its own (only
+    // `applied_to`, the resolved ORIGINAL run — see HistoryPage.tsx), so a
+    // just-left row's stale `data` can only be caught via `loading`, not by
+    // comparing an echoed id the way the run-detail fetch does. loading:
+    // true is useFetch's real state for exactly this window: the effect for
+    // the newly-selected row's path has fired, but that fetch has not
+    // resolved yet.
+    setup({
+      data: { applied_to: 'run-1', corrections: [{ hint_id: 1, feedback_text: 'stale from the last row' }] },
+      error: '', loading: true,
+    })
+
+    await openDrawer()
+
+    expect(screen.queryByText(/stale from the last row/)).toBeNull()
+  })
+})

--- a/src/frontend-react/src/pages/HistoryPage.test.tsx
+++ b/src/frontend-react/src/pages/HistoryPage.test.tsx
@@ -657,15 +657,23 @@ describe('HistoryPage — running a row again', () => {
 describe('HistoryPage — the drawer’s remaining actions', () => {
   it('Download builds a .robot file containing the exact stored code, named after the run', async () => {
     const { getParts, getAnchor } = stubDownload()
-    setupList([RUN_A])
-    withDetail('run-A')
+    // Local fixture with id longer than 8 chars to test truncation.
+    const RUN_WITH_LONG_ID = { ...RUN_A, run_id: 'run-A-0123456789abc' }
+    setupList([RUN_WITH_LONG_ID])
+    withDetail('run-A-0123456789abc')
     renderPage()
     fireEvent.click(await screen.findByText('search flipkart for shoes'))
     const downloadBtn = await screen.findByTitle('Download .robot file')
 
     fireEvent.click(downloadBtn)
 
-    expect(getAnchor()?.download).toBe('test-run-A.robot')
+    // Filename truncates run id to 8 chars: test-<first 8>-.robot.
+    // This is a filename convention (not displayed in UI), distinct from the
+    // "never truncate displayed ids" rule.
+    const filename = getAnchor()?.download
+    expect(filename).toBe('test-run-A-01.robot')
+    // Ensure truncation happens: 9th char onward must NOT appear in filename.
+    expect(filename).not.toContain('23456789')
     expect(getParts()).toEqual([CODE])
   })
 

--- a/src/frontend-react/src/pages/HistoryPage.test.tsx
+++ b/src/frontend-react/src/pages/HistoryPage.test.tsx
@@ -27,7 +27,7 @@
  * RecordedCorrections' own rendering rules (RecordedCorrections.test.tsx
  * already does that) or the rest of the page.
  */
-import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
@@ -38,19 +38,22 @@ vi.mock('@/lib/api', async importOriginal => ({
   ...(await importOriginal<typeof import('@/lib/api')>()),
   api: vi.fn(),
 }))
+vi.mock('@/lib/sse', () => ({ streamSSE: vi.fn() }))
 
 import { useAuth } from '@/auth/AuthContext'
 import { useRunGroups } from '@/components/history/RunGroupsContext'
 import { useFetch } from '@/lib/useFetch'
 import { api } from '@/lib/api'
+import { streamSSE } from '@/lib/sse'
 import HistoryPage from './HistoryPage'
 
 const mockUseAuth = vi.mocked(useAuth)
 const mockUseRunGroups = vi.mocked(useRunGroups)
 const mockUseFetch = vi.mocked(useFetch)
 const mockApi = vi.mocked(api)
+const mockStreamSSE = vi.mocked(streamSSE)
 
-afterEach(() => vi.resetAllMocks())
+afterEach(() => { vi.resetAllMocks(); vi.unstubAllGlobals() })
 
 const RUN = {
   run_id: 'run-1', status: 'passed' as const, user_query: 'search flipkart for shoes',
@@ -250,5 +253,479 @@ describe('HistoryPage drawer — the re-run-of id', () => {
     // Copy, not navigate: the accessible branch's button is titled "Open the
     // original run", and this one must not be.
     expect(id.closest('button')!.getAttribute('title')).toMatch(/copy/i)
+  })
+})
+
+/* ────────────────────────────────────────────────────────────────────────
+ * Task 5 (frontend-coverage-gate) — the rest of the page: the runs table,
+ * filters/search/paging, select mode and moving runs, re-running a row, and
+ * the drawer's remaining actions (download/copy/move). The block above only
+ * ever renders ONE row and never opens select mode or clicks a row action,
+ * so none of it is touched by the tests above — this is new coverage, not a
+ * rewrite. Two rows (RUN_A owned by the viewer, RUN_B a colleague's) are the
+ * standard fixture so every "acts on the right row" assertion has a WRONG
+ * row on screen to fail against, not just an absent one.
+ * ──────────────────────────────────────────────────────────────────────── */
+
+const RUN_A = {
+  run_id: 'run-A', status: 'passed' as const, user_query: 'search flipkart for shoes',
+  user_email: 'me@x.com', created_at: '2026-09-01T00:00:00Z', updated_at: '2026-09-01T00:00:00Z',
+  has_report: true, can_move: true,
+}
+const RUN_B = {
+  run_id: 'run-B', status: 'failed' as const, user_query: 'checkout flow',
+  user_email: 'colleague@x.com', created_at: '2026-08-30T00:00:00Z', updated_at: '2026-08-30T00:00:00Z',
+  has_report: false, can_move: false,
+}
+const CHECKOUT = { group_id: 'g-1', name: 'Checkout', created_by: 'u-me', run_count: 0 }
+const CODE = '*** Settings ***\nLibrary    Browser\n\n*** Test Cases ***\nSearch\n    New Page    https://example.com'
+
+function stubClipboard() {
+  const writeText = vi.fn().mockResolvedValue(undefined)
+  Object.defineProperty(navigator, 'clipboard', { value: { writeText }, configurable: true, writable: true })
+  return writeText
+}
+
+/** URL.createObjectURL/revokeObjectURL don't exist in jsdom, jsdom's own
+ *  Blob has no .text()/.arrayBuffer() to read one back with, and a real
+ *  anchor .click() logs a "Not implemented: navigation" jsdom error. Replace
+ *  Blob with a constructor that just records what it was built from —
+ *  nothing downstream needs a real blob, since createObjectURL is stubbed
+ *  too (mirrors GeneratePage.test.tsx's stubDownload). */
+function stubDownload() {
+  let parts: unknown[] | null = null
+  let anchor: HTMLAnchorElement | null = null
+  vi.stubGlobal('Blob', vi.fn().mockImplementation((p: unknown[]) => { parts = p; return {} }))
+  URL.createObjectURL = vi.fn(() => 'blob:mock-url') as typeof URL.createObjectURL
+  URL.revokeObjectURL = vi.fn()
+  vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(function (this: HTMLAnchorElement) { anchor = this })
+  return { getParts: () => parts, getAnchor: () => anchor }
+}
+
+// Radix's DropdownMenuTrigger (MoveToGroupMenu) opens on pointerdown, not
+// click — see MoveToGroupMenu.test.tsx for why a plain fireEvent.click /
+// fireEvent.pointerDown do not open it under jsdom.
+function pointerDown(el: Element) {
+  fireEvent(el, new MouseEvent('pointerdown', { bubbles: true, cancelable: true, button: 0 }))
+}
+
+/** The table + toolbar fixture: a real (unmocked) useAuth/useRunGroups pair
+ *  wired to spies, and api() answering only /api/history — anything else is
+ *  a bug in the test, not a real endpoint, so it throws loudly instead of
+ *  hanging. mockUseFetch defaults to "nothing" for every path; tests that
+ *  open the drawer and care about its content override it afterwards. */
+function setupList(runs: unknown[], opts: {
+  total?: number; scope?: 'own' | 'all'
+  // Typed off useRunGroups' own return, not `unknown[]`: this fixture is
+  // handed straight to the mocked context, so an unknown[] here silently
+  // stops TypeScript checking every group fixture in this file.
+  groups?: ReturnType<typeof useRunGroups>['groups']; ungroupedCount?: number
+  groupFilter?: string | null; groupsError?: string; isAdmin?: boolean
+  assignRuns?: ReturnType<typeof vi.fn>
+} = {}) {
+  mockUseAuth.mockReturnValue({
+    user: { id: 'u-me', email: 'me@x.com', display_name: 'Me', role: 'user', status: 'active' },
+    loading: false, isAuthenticated: true, isAdmin: opts.isAdmin ?? false, status: 'active',
+    isOrgAdmin: false, canViewLearning: false,
+    login: vi.fn(), signup: vi.fn(), loginWithToken: vi.fn(), logout: vi.fn(), logoutAll: vi.fn(),
+  })
+  const spies = {
+    assignRuns: opts.assignRuns ?? vi.fn().mockResolvedValue(undefined),
+    createGroup: vi.fn().mockResolvedValue({ group_id: 'g-new', name: 'New', created_by: 'u-me', run_count: 0 }),
+    renameGroup: vi.fn().mockResolvedValue(undefined),
+    deleteGroup: vi.fn().mockResolvedValue(undefined),
+    refreshGroups: vi.fn().mockResolvedValue(undefined),
+    setGroupFilter: vi.fn(),
+  }
+  mockUseRunGroups.mockReturnValue({
+    groups: opts.groups ?? [], ungroupedCount: opts.ungroupedCount ?? 0, error: opts.groupsError ?? '', loaded: true,
+    refresh: spies.refreshGroups, createGroup: spies.createGroup, renameGroup: spies.renameGroup,
+    deleteGroup: spies.deleteGroup, assignRuns: spies.assignRuns,
+    groupFilter: opts.groupFilter ?? null, setGroupFilter: spies.setGroupFilter,
+  })
+  mockApi.mockImplementation(async (path: string) => {
+    if (path.startsWith('/api/history')) return { runs, total: opts.total ?? runs.length, scope: opts.scope ?? 'own' }
+    throw new Error(`setupList: unexpected api(${path})`)
+  })
+  mockUseFetch.mockImplementation(() => ({ data: null, loading: false, error: '', reload: vi.fn() }))
+  return spies
+}
+
+function renderPage() {
+  return render(<MemoryRouter><HistoryPage /></MemoryRouter>)
+}
+
+/** Points the /api/history/{runId} useFetch call at a real detail payload
+ *  (robot_code included) for exactly one run — for the drawer actions that
+ *  only appear once `d` has resolved. */
+function withDetail(runId: string, extra: Record<string, unknown> = {}) {
+  mockUseFetch.mockImplementation((path: string | null) => {
+    if (path === `/api/history/${runId}`) {
+      return { data: { ...RUN_A, run_id: runId, robot_code: CODE, ...extra }, loading: false, error: '', reload: vi.fn() }
+    }
+    return { data: null, loading: false, error: '', reload: vi.fn() }
+  })
+}
+
+const RUN_AGAIN_TITLE = 'Run again — execute the saved code as-is (no regeneration)'
+
+describe('HistoryPage — the runs table', () => {
+  it('renders each run’s description and the "N of M" counter', async () => {
+    setupList([RUN_A, RUN_B], { total: 2 })
+    renderPage()
+
+    expect(await screen.findByText('search flipkart for shoes')).toBeInTheDocument()
+    expect(screen.getByText('checkout flow')).toBeInTheDocument()
+    expect(screen.getByText('2 of 2 runs')).toBeInTheDocument()
+  })
+
+  it('shows the loading placeholder before the first page resolves', async () => {
+    setupList([RUN_A])
+    mockApi.mockImplementation(() => new Promise(() => {}))
+    renderPage()
+
+    expect(await screen.findByText('Loading runs…')).toBeInTheDocument()
+  })
+
+  it('shows the server’s error and no rows when the list request fails', async () => {
+    setupList([RUN_A])
+    mockApi.mockRejectedValue(new Error('Server exploded'))
+    renderPage()
+
+    expect(await screen.findByText('Server exploded')).toBeInTheDocument()
+    expect(screen.queryByText('search flipkart for shoes')).toBeNull()
+  })
+
+  it('shows the all-runs empty state with no rows and no error', async () => {
+    setupList([], { total: 0 })
+    renderPage()
+
+    expect(await screen.findByText('No test runs yet — generate your first test from the Generate page.')).toBeInTheDocument()
+  })
+
+  it('re-queries the server, rather than filtering client-side, when a status filter is clicked', async () => {
+    setupList([RUN_A])
+    renderPage()
+    await screen.findByText('search flipkart for shoes')
+
+    fireEvent.click(screen.getByRole('button', { name: 'failed' }))
+
+    await waitFor(() => expect(mockApi).toHaveBeenCalledWith(expect.stringContaining('status=failed')))
+  })
+
+  it('debounces typed search into a q= query parameter', async () => {
+    setupList([RUN_A])
+    renderPage()
+    await screen.findByText('search flipkart for shoes')
+
+    fireEvent.change(screen.getByPlaceholderText(/Search description/), { target: { value: 'flipkart' } })
+
+    await waitFor(() => expect(mockApi).toHaveBeenCalledWith(expect.stringContaining('q=flipkart')), { timeout: 1000 })
+  })
+
+  it('Refresh reloads both the run list and the folder counts', async () => {
+    const spies = setupList([RUN_A])
+    renderPage()
+    await screen.findByText('search flipkart for shoes')
+    const callsBefore = mockApi.mock.calls.length
+
+    fireEvent.click(screen.getByRole('button', { name: /Refresh/ }))
+
+    expect(spies.refreshGroups).toHaveBeenCalled()
+    await waitFor(() => expect(mockApi.mock.calls.length).toBeGreaterThan(callsBefore))
+  })
+
+  it('"Load more" requests the next page at the correct offset', async () => {
+    setupList([RUN_A], { total: 2 })
+    renderPage()
+    await screen.findByText('search flipkart for shoes')
+
+    fireEvent.click(screen.getByRole('button', { name: /Load more/ }))
+
+    await waitFor(() => expect(mockApi).toHaveBeenCalledWith(expect.stringContaining('offset=1')))
+  })
+
+  it.each([
+    [true, /All users. test runs \(admin view\)/],
+    [false, /Every test run in your organization/],
+  ])('shows the right scope=all subtitle for isAdmin=%s', async (isAdmin, expected) => {
+    setupList([RUN_A], { scope: 'all', isAdmin })
+    renderPage()
+
+    expect(await screen.findByText(expected)).toBeInTheDocument()
+  })
+})
+
+describe('HistoryPage — who ran it', () => {
+  it('hides the "Ran by" column when every loaded run is the viewer’s own', async () => {
+    setupList([{ ...RUN_A, user_email: 'me@x.com' }])
+    renderPage()
+    await screen.findByText('search flipkart for shoes')
+
+    expect(screen.queryByText('Ran by')).toBeNull()
+  })
+
+  it('shows "Ran by" once any row belongs to someone else, and filters by that email on click', async () => {
+    setupList([RUN_A, RUN_B])
+    renderPage()
+    await screen.findByText('search flipkart for shoes')
+    expect(screen.getByText('Ran by')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByText('colleague@x.com'))
+
+    expect(screen.getByPlaceholderText(/Search description/)).toHaveValue('colleague@x.com')
+  })
+})
+
+describe('HistoryPage — the table’s run id column (never truncated, click-to-copy)', () => {
+  it('shows each row’s FULL id and copies the CLICKED row’s id, without opening its drawer', async () => {
+    const writeText = stubClipboard()
+    setupList([RUN_A, RUN_B])
+    renderPage()
+    const rowB = (await screen.findByText('checkout flow')).closest('tr')!
+    // Full id on screen, not an 8-char prefix.
+    expect(within(rowB).getByText('run-B')).toBeInTheDocument()
+
+    fireEvent.click(within(rowB).getByTitle('Click to copy the run id'))
+
+    expect(writeText).toHaveBeenCalledWith('run-B')
+    expect(writeText).not.toHaveBeenCalledWith('run-A')
+    // e.stopPropagation() on the copy button kept the drawer closed.
+    expect(screen.queryByTitle('Copy run id')).toBeNull()
+  })
+
+  it('opens the CLICKED row’s drawer, not a different row’s', async () => {
+    setupList([RUN_A, RUN_B])
+    renderPage()
+    await screen.findByText('search flipkart for shoes')
+
+    fireEvent.click(screen.getByText('checkout flow'))
+
+    const drawerId = await screen.findByTitle('Copy run id')
+    expect(drawerId.textContent).toContain('run-B')
+    expect(drawerId.textContent).not.toContain('run-A')
+  })
+})
+
+describe('HistoryPage — select mode and moving runs', () => {
+  const RUN_C = { ...RUN_A, run_id: 'run-C', user_query: 'add to cart', can_move: true }
+
+  it('disables the checkbox for a row this caller may not move, and select-all skips it', async () => {
+    setupList([RUN_A, RUN_B]) // A can_move true, B can_move false
+    renderPage()
+    await screen.findByText('search flipkart for shoes')
+    fireEvent.click(screen.getByRole('button', { name: 'Select' }))
+
+    const checkboxB = screen.getByLabelText('Select run checkout flow (run-B)')
+    expect(checkboxB).toBeDisabled()
+    expect(checkboxB).not.toBeChecked()
+
+    fireEvent.click(screen.getByLabelText('Select all loaded runs'))
+
+    expect(screen.getByLabelText('Select run search flipkart for shoes (run-A)')).toBeChecked()
+    expect(checkboxB).not.toBeChecked()
+  })
+
+  it('moves only the checked, movable runs — with all of their ids — into the chosen group', async () => {
+    const spies = setupList([RUN_A, RUN_C], { groups: [CHECKOUT] })
+    renderPage()
+    await screen.findByText('search flipkart for shoes')
+    fireEvent.click(screen.getByRole('button', { name: 'Select' }))
+    fireEvent.click(screen.getByLabelText('Select run search flipkart for shoes (run-A)'))
+    fireEvent.click(screen.getByLabelText('Select run add to cart (run-C)'))
+
+    pointerDown(screen.getByRole('button', { name: /Move 2 to…/ }))
+    fireEvent.click(screen.getByText('Checkout'))
+
+    await waitFor(() => expect(spies.assignRuns).toHaveBeenCalled())
+    const [ids, groupId] = spies.assignRuns.mock.calls[0]
+    expect(new Set(ids)).toEqual(new Set(['run-A', 'run-C']))
+    expect(groupId).toBe('g-1')
+    // A successful bulk move exits select mode.
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Select' })).toBeInTheDocument())
+  })
+
+  it('Cancel clears the selection and exits select mode without moving anything', async () => {
+    const spies = setupList([RUN_A], { groups: [CHECKOUT] })
+    renderPage()
+    await screen.findByText('search flipkart for shoes')
+    fireEvent.click(screen.getByRole('button', { name: 'Select' }))
+    fireEvent.click(screen.getByLabelText('Select run search flipkart for shoes (run-A)'))
+
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+
+    expect(spies.assignRuns).not.toHaveBeenCalled()
+    expect(screen.queryByLabelText('Select all loaded runs')).toBeNull()
+    expect(screen.getByRole('button', { name: 'Select' })).toBeInTheDocument()
+  })
+
+  it('shows the server’s rejection and keeps the selection when a move fails', async () => {
+    const assignRuns = vi.fn().mockRejectedValue(new Error('That folder was deleted'))
+    setupList([RUN_A], { groups: [CHECKOUT], assignRuns })
+    renderPage()
+    await screen.findByText('search flipkart for shoes')
+    fireEvent.click(screen.getByRole('button', { name: 'Select' }))
+    fireEvent.click(screen.getByLabelText('Select run search flipkart for shoes (run-A)'))
+    pointerDown(screen.getByRole('button', { name: /Move 1 to…/ }))
+    fireEvent.click(screen.getByText('Checkout'))
+
+    expect(await screen.findByText('That folder was deleted')).toBeInTheDocument()
+    expect(screen.getByLabelText('Select run search flipkart for shoes (run-A)')).toBeChecked()
+  })
+
+  it('per-row move sends only that row’s id, even with other rows on the table', async () => {
+    const spies = setupList([RUN_A, RUN_C], { groups: [CHECKOUT] })
+    renderPage()
+    const rowC = (await screen.findByText('add to cart')).closest('tr')!
+
+    pointerDown(within(rowC).getByTitle('Move to group…'))
+    fireEvent.click(screen.getByText('Checkout'))
+
+    expect(spies.assignRuns).toHaveBeenCalledWith(['run-C'], 'g-1')
+  })
+})
+
+describe('HistoryPage — running a row again', () => {
+  it('sends rerun_of for the CLICKED row’s id, not any other row on the table', async () => {
+    setupList([RUN_A, RUN_B])
+    mockStreamSSE.mockImplementation(() => new Promise(() => {}))
+    renderPage()
+    const rowB = (await screen.findByText('checkout flow')).closest('tr')!
+
+    fireEvent.click(within(rowB).getByTitle(RUN_AGAIN_TITLE))
+
+    await waitFor(() => expect(mockStreamSSE).toHaveBeenCalledWith(
+      '/execute-test', { rerun_of: 'run-B' }, expect.any(Function),
+    ))
+    expect(mockStreamSSE).not.toHaveBeenCalledWith(
+      '/execute-test', { rerun_of: 'run-A' }, expect.any(Function),
+    )
+  })
+
+  it('shows the pass note in the drawer and refreshes the list once the re-run succeeds', async () => {
+    setupList([RUN_A])
+    mockStreamSSE.mockImplementation(async (_path, _body, onEvent) => { onEvent({ test_status: 'passed' }) })
+    renderPage()
+    const rowA = (await screen.findByText('search flipkart for shoes')).closest('tr')!
+    const callsBefore = mockApi.mock.calls.length
+
+    fireEvent.click(within(rowA).getByTitle(RUN_AGAIN_TITLE))
+
+    await screen.findByText('✓ Re-run passed')
+    await waitFor(() => expect(mockApi.mock.calls.length).toBeGreaterThan(callsBefore))
+  })
+
+  it('disables that row’s Run-again button while its re-run is still in flight', async () => {
+    setupList([RUN_A])
+    mockStreamSSE.mockImplementation(() => new Promise(() => {}))
+    renderPage()
+    const rowA = (await screen.findByText('search flipkart for shoes')).closest('tr')!
+    const playBtn = within(rowA).getByTitle(RUN_AGAIN_TITLE)
+
+    fireEvent.click(playBtn)
+
+    await waitFor(() => expect(playBtn).toBeDisabled())
+  })
+
+  it('shows the failure message and re-enables the row when the re-run cannot start', async () => {
+    setupList([RUN_A])
+    mockStreamSSE.mockRejectedValue(new Error('Server refused the re-run'))
+    renderPage()
+    const rowA = (await screen.findByText('search flipkart for shoes')).closest('tr')!
+    const playBtn = within(rowA).getByTitle(RUN_AGAIN_TITLE)
+
+    fireEvent.click(playBtn)
+
+    await screen.findByText('Server refused the re-run')
+    await waitFor(() => expect(playBtn).not.toBeDisabled())
+  })
+
+  it('clicking the Re-run pill opens the ORIGINAL run’s drawer, not the re-run’s own', async () => {
+    const RUN_RERUN = { ...RUN_A, run_id: 'run-RERUN', rerun_of: 'run-ORIGINAL', rerun_of_accessible: true }
+    setupList([RUN_RERUN])
+    renderPage()
+    const row = (await screen.findByText('search flipkart for shoes')).closest('tr')!
+
+    fireEvent.click(within(row).getByTitle('Re-run of run-ORIGINAL — click to open the original run'))
+
+    const idBtn = await screen.findByTitle('Copy run id')
+    expect(idBtn.textContent).toContain('run-ORIGINAL')
+    expect(idBtn.textContent).not.toContain('run-RERUN')
+  })
+})
+
+describe('HistoryPage — the drawer’s remaining actions', () => {
+  it('Download builds a .robot file containing the exact stored code, named after the run', async () => {
+    const { getParts, getAnchor } = stubDownload()
+    setupList([RUN_A])
+    withDetail('run-A')
+    renderPage()
+    fireEvent.click(await screen.findByText('search flipkart for shoes'))
+    const downloadBtn = await screen.findByTitle('Download .robot file')
+
+    fireEvent.click(downloadBtn)
+
+    expect(getAnchor()?.download).toBe('test-run-A.robot')
+    expect(getParts()).toEqual([CODE])
+  })
+
+  it('Copy code copies the exact stored code, not the query text', async () => {
+    const writeText = stubClipboard()
+    setupList([RUN_A])
+    withDetail('run-A')
+    renderPage()
+    fireEvent.click(await screen.findByText('search flipkart for shoes'))
+    const copyBtn = await screen.findByTitle('Copy code')
+
+    fireEvent.click(copyBtn)
+
+    expect(writeText).toHaveBeenCalledWith(CODE)
+    expect(writeText).not.toHaveBeenCalledWith(RUN_A.user_query)
+  })
+
+  it('Move-to-group from the drawer moves only the OPEN run’s id', async () => {
+    const spies = setupList([RUN_A, RUN_B], { groups: [CHECKOUT] })
+    withDetail('run-A', { group_id: null, group_name: null, can_move: true })
+    renderPage()
+    fireEvent.click(await screen.findByText('search flipkart for shoes'))
+    const trigger = await screen.findByRole('button', { name: /Move to group…/ })
+
+    pointerDown(trigger)
+    fireEvent.click(await screen.findByText('Checkout'))
+
+    expect(spies.assignRuns).toHaveBeenCalledWith(['run-A'], 'g-1')
+  })
+
+  it('shows the run’s group as a read-only label, not a control, when this caller may not move it', async () => {
+    setupList([RUN_B])
+    withDetail('run-B', { group_name: 'Marketing', group_id: 'g-9', can_move: false })
+    renderPage()
+    fireEvent.click(await screen.findByText('checkout flow'))
+
+    const label = await screen.findByTitle('Only the owner of a run, or an org admin, can move it')
+    expect(label.textContent).toContain('Marketing')
+    expect(label.closest('button')).toBeNull()
+  })
+
+  it('shows the refusal text when the detail fetch is refused, with no stale code and no "Loading…"', async () => {
+    setupList([RUN_A])
+    mockUseFetch.mockImplementation((path: string | null) => {
+      if (path === '/api/history/run-A') return { data: null, loading: false, error: 'You cannot read this run', reload: vi.fn() }
+      return { data: null, loading: false, error: '', reload: vi.fn() }
+    })
+    renderPage()
+
+    fireEvent.click(await screen.findByText('search flipkart for shoes'))
+
+    expect(await screen.findByText('Run unavailable')).toBeInTheDocument()
+    expect(screen.getByText('You cannot read this run')).toBeInTheDocument()
+    expect(screen.queryByText('Loading…')).toBeNull()
+  })
+
+  it('shows a message above the table when the groups list fails to load', async () => {
+    setupList([RUN_A], { groupsError: 'network down' })
+    renderPage()
+
+    expect(await screen.findByText(/Couldn.t load groups — network down/)).toBeInTheDocument()
   })
 })

--- a/src/frontend-react/src/pages/HistoryPage.test.tsx
+++ b/src/frontend-react/src/pages/HistoryPage.test.tsx
@@ -403,6 +403,48 @@ describe('HistoryPage — the runs table', () => {
     expect(await screen.findByText('No test runs yet — generate your first test from the Generate page.')).toBeInTheDocument()
   })
 
+  it('shows "No runs match your search." when a text search returns nothing', async () => {
+    setupList([RUN_A])
+    renderPage()
+    await screen.findByText('search flipkart for shoes')
+    mockApi.mockImplementation(async (path: string) => {
+      if (path.startsWith('/api/history')) return { runs: [], total: 0, scope: 'own' }
+      throw new Error(`unexpected api(${path})`)
+    })
+
+    fireEvent.change(screen.getByPlaceholderText(/Search description/), { target: { value: 'nonexistent' } })
+
+    expect(await screen.findByText('No runs match your search.', {}, { timeout: 1000 })).toBeInTheDocument()
+  })
+
+  it('shows the ungrouped-empty message when the Ungrouped filter has no runs', async () => {
+    setupList([], { total: 0, groupFilter: 'ungrouped' })
+    renderPage()
+
+    expect(await screen.findByText('No ungrouped runs — everything is filed.')).toBeInTheDocument()
+  })
+
+  it('shows the group-empty message when a specific group has no runs', async () => {
+    setupList([], { total: 0, groupFilter: 'g-1' })
+    renderPage()
+
+    expect(await screen.findByText('No runs in this group yet — move runs here with the folder button on any row.')).toBeInTheDocument()
+  })
+
+  it('falls back to "No {filter} runs yet." for a non-all filter with no matches', async () => {
+    setupList([RUN_A])
+    renderPage()
+    await screen.findByText('search flipkart for shoes')
+    mockApi.mockImplementation(async (path: string) => {
+      if (path.startsWith('/api/history')) return { runs: [], total: 0, scope: 'own' }
+      throw new Error(`unexpected api(${path})`)
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: 'failed' }))
+
+    expect(await screen.findByText('No failed runs yet.')).toBeInTheDocument()
+  })
+
   it('re-queries the server, rather than filtering client-side, when a status filter is clicked', async () => {
     setupList([RUN_A])
     renderPage()
@@ -453,6 +495,13 @@ describe('HistoryPage — the runs table', () => {
     renderPage()
 
     expect(await screen.findByText(expected)).toBeInTheDocument()
+  })
+
+  it('shows the "your work in progress" subtitle for scope=own', async () => {
+    setupList([RUN_A])
+    renderPage()
+
+    expect(await screen.findByText(/Your work in progress, plus every test your team has filed/)).toBeInTheDocument()
   })
 })
 
@@ -665,6 +714,11 @@ describe('HistoryPage — the drawer’s remaining actions', () => {
     fireEvent.click(await screen.findByText('search flipkart for shoes'))
     const downloadBtn = await screen.findByTitle('Download .robot file')
 
+    // The drawer's code panel itself renders the stored code, not just the
+    // download it produces. Radix's Sheet portals its content onto
+    // document.body, outside the render container, so query the document.
+    expect(document.querySelector('pre')?.textContent).toBe(CODE)
+
     fireEvent.click(downloadBtn)
 
     // Filename truncates run id to 8 chars: test-<first 8>-.robot.
@@ -728,6 +782,31 @@ describe('HistoryPage — the drawer’s remaining actions', () => {
     expect(await screen.findByText('Run unavailable')).toBeInTheDocument()
     expect(screen.getByText('You cannot read this run')).toBeInTheDocument()
     expect(screen.queryByText('Loading…')).toBeNull()
+  })
+
+  it('shows "Loading…" while the run detail fetch is still pending, with no stale code and no error', async () => {
+    setupList([RUN_A])
+    mockUseFetch.mockImplementation((path: string | null) => {
+      if (path === '/api/history/run-A') return { data: null, loading: true, error: '', reload: vi.fn() }
+      return { data: null, loading: false, error: '', reload: vi.fn() }
+    })
+    renderPage()
+
+    fireEvent.click(await screen.findByText('search flipkart for shoes'))
+
+    expect(await screen.findByText('Loading…')).toBeInTheDocument()
+    expect(screen.queryByText('Run unavailable')).toBeNull()
+  })
+
+  it('shows "No stored code" with the Regenerate hint for a run with a query but nothing saved', async () => {
+    setupList([RUN_A])
+    withDetail('run-A', { robot_code: null })
+    renderPage()
+
+    fireEvent.click(await screen.findByText('search flipkart for shoes'))
+
+    expect(await screen.findByText(/No stored code — this run predates code persistence\./)).toBeInTheDocument()
+    expect(screen.getByText(/Use Regenerate to produce it again\./)).toBeInTheDocument()
   })
 
   it('shows a message above the table when the groups list fails to load', async () => {

--- a/src/frontend-react/src/pages/HistoryPage.test.tsx
+++ b/src/frontend-react/src/pages/HistoryPage.test.tsx
@@ -8,11 +8,16 @@
  * HintDrawer.test.tsx already use for the same three hooks.
  *
  * What this pins: opening a run in the drawer fires
- * GET /api/feedback/{run_id}, and a refused (or still-pending) read renders
- * no error text — the two behaviours HistoryPage.tsx's corrections block
- * promises and GeneratePage's FeedbackPanel already proved once for its own
- * surface. It does not re-test RecordedCorrections' own rendering rules
- * (RecordedCorrections.test.tsx already does that) or the rest of the page.
+ * GET /api/feedback/{run_id}; a refused read renders no error text (the
+ * behaviour GeneratePage's FeedbackPanel already proved once for its own
+ * surface); and a row switch never shows a PREVIOUS row's corrections under
+ * the newly-selected row — neither while that row's own fetch is still in
+ * flight, nor once it has settled to an error (useFetch clears neither
+ * `data` nor, on the error path, anything at all beyond `error` itself —
+ * see HistoryPage.tsx's comment above `feedbackPath` for why both `loading`
+ * and `error` have to gate `corrections`). It does not re-test
+ * RecordedCorrections' own rendering rules (RecordedCorrections.test.tsx
+ * already does that) or the rest of the page.
  */
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
@@ -114,5 +119,32 @@ describe('HistoryPage drawer — the corrections fetch', () => {
     await openDrawer()
 
     expect(screen.queryByText(/stale from the last row/)).toBeNull()
+  })
+
+  it('does not render a previous row’s stale corrections when this row’s fetch fails (e.g. a 403 refusing a colleague’s shared run)', async () => {
+    // useFetch never clears `data` in its catch branch (useFetch.ts) — only
+    // `error` is set, and `loading` is already back to false by then. This
+    // is the fix-round-1 repro: open an owned run with corrections on
+    // file, then a colleague's shared run whose corrections read the
+    // server refuses (GET /api/history/{id} passes is_grouped=true and
+    // 200s; GET /api/feedback/{id} deliberately does not and 403s). A
+    // loading-only guard is blind to this: `loading` has already settled
+    // false by the time the failure lands, so the FIRST run's stale `data`
+    // — its correction text, and a "filed against" notice that may
+    // describe a run that isn't even a re-run — would render under the
+    // SECOND run's drawer.
+    setup({
+      data: {
+        applied_to: 'run-A',
+        corrections: [{ hint_id: 1, feedback_text: 'ROW A STALE TEXT MUST NOT APPEAR' }],
+      },
+      error: 'You cannot read feedback for this run',
+      loading: false,
+    })
+
+    await openDrawer()
+
+    expect(screen.queryByText(/ROW A STALE TEXT MUST NOT APPEAR/)).toBeNull()
+    expect(screen.queryByText(/Filed against the original run/)).toBeNull()
   })
 })

--- a/src/frontend-react/src/pages/HistoryPage.test.tsx
+++ b/src/frontend-react/src/pages/HistoryPage.test.tsx
@@ -8,14 +8,20 @@
  * HintDrawer.test.tsx already use for the same three hooks.
  *
  * What this pins: opening a run in the drawer fires
- * GET /api/feedback/{run_id}; a refused read renders no error text (the
- * behaviour GeneratePage's FeedbackPanel already proved once for its own
- * surface); and a row switch never shows a PREVIOUS row's corrections under
- * the newly-selected row — neither while that row's own fetch is still in
- * flight, nor once it has settled to an error (useFetch clears neither
- * `data` nor, on the error path, anything at all beyond `error` itself —
- * see HistoryPage.tsx's comment above `feedbackPath` for why both `loading`
- * and `error` have to gate `corrections`). It does not re-test
+ * GET /api/feedback/{run_id}; a successful read renders the correction
+ * text on screen, and — when `applied_to` differs from the open row — the
+ * "filed against the original run" notice with its full, untruncated id;
+ * a refused read renders no error text (the behaviour GeneratePage's
+ * FeedbackPanel already proved once for its own surface); and a row
+ * switch never shows a PREVIOUS row's corrections under the newly-selected
+ * row — neither while that row's own fetch is still in flight, nor once it
+ * has settled to an error (useFetch clears neither `data` nor, on the
+ * error path, anything at all beyond `error` itself — see HistoryPage.tsx's
+ * comment above `feedbackPath` for why both `loading` and `error` have to
+ * gate `corrections`). The two positive-rendering tests exist because the
+ * others are all absence-assertions, which a mutation that hardcodes
+ * `corrections` to `[]` sails through undetected — see the `it`s below for
+ * that finding's own account. This file does not re-test
  * RecordedCorrections' own rendering rules (RecordedCorrections.test.tsx
  * already does that) or the rest of the page.
  */
@@ -146,5 +152,37 @@ describe('HistoryPage drawer — the corrections fetch', () => {
 
     expect(screen.queryByText(/ROW A STALE TEXT MUST NOT APPEAR/)).toBeNull()
     expect(screen.queryByText(/Filed against the original run/)).toBeNull()
+  })
+
+  // The four tests above are all absence-assertions (no fetch call target,
+  // no error text, no stale text twice) — every one of them still passes if
+  // `corrections` were hardcoded to [], which would silently disable this
+  // task's whole feature. These two are the ones that actually prove a
+  // correction reaches the screen.
+  it('renders a correction’s text once the fetch succeeds', async () => {
+    setup({
+      data: { applied_to: 'run-1', corrections: [{ hint_id: 1, feedback_text: 'the search box locator was off' }] },
+      error: '', loading: false,
+    })
+
+    await openDrawer()
+
+    expect(await screen.findByText(/the search box locator was off/)).toBeInTheDocument()
+  })
+
+  it('renders the "filed against the original run" notice with the full, untruncated id', async () => {
+    // Long and clearly not an 8-char prefix, so a truncation regression
+    // (the owner's standing "never truncate a run id" rule) would be
+    // visible as a failed exact-text match, not just a shorter match.
+    const ORIGINAL_ID = 'run-A-0123456789abcdef0123456789'
+    setup({
+      data: { applied_to: ORIGINAL_ID, corrections: [{ hint_id: 1, feedback_text: 'x' }] },
+      error: '', loading: false,
+    })
+
+    await openDrawer()
+
+    expect(await screen.findByText(/Filed against the original run/)).toBeInTheDocument()
+    expect(screen.getByText(ORIGINAL_ID)).toBeInTheDocument()
   })
 })

--- a/src/frontend-react/src/pages/HistoryPage.test.tsx
+++ b/src/frontend-react/src/pages/HistoryPage.test.tsx
@@ -59,7 +59,7 @@ const RUN = {
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-function setup(feedbackFetch: { data: any; error: string; loading?: boolean }, detailRunId: string = RUN.run_id) {
+function setup(feedbackFetch: { data: any; error: string; loading?: boolean }, detailRunId: string = RUN.run_id, detailExtra: Record<string, unknown> = {}) {
   mockUseAuth.mockReturnValue({
     user: { id: 'u1', email: 'a@b.com', display_name: 'A', role: 'user', status: 'active' },
     loading: false, isAuthenticated: true, isAdmin: false, status: 'active',
@@ -84,7 +84,7 @@ function setup(feedbackFetch: { data: any; error: string; loading?: boolean }, d
     if (path?.startsWith('/api/feedback/')) {
       return { data: feedbackFetch.data, loading: feedbackFetch.loading ?? false, error: feedbackFetch.error, reload: vi.fn() }
     }
-    return { data: { ...RUN, run_id: detailRunId, robot_code: null }, loading: false, error: '', reload: vi.fn() }
+    return { data: { ...RUN, run_id: detailRunId, robot_code: null, ...detailExtra }, loading: false, error: '', reload: vi.fn() }
   })
 }
 
@@ -216,5 +216,39 @@ describe('HistoryPage drawer — the corrections fetch', () => {
 
     expect(await screen.findByText(/Filed against the original run/)).toBeInTheDocument()
     expect(screen.getByText(ORIGINAL_ID)).toBeInTheDocument()
+  })
+})
+
+describe('HistoryPage drawer — the re-run-of id', () => {
+  // The owner's standing rule is unconditional: a run/workflow id shown in
+  // any UI is full AND click-to-copy. The accessible branch already satisfies
+  // it — that id is a button (it opens the original). The INACCESSIBLE
+  // branch deliberately is not a link, because it would 404, and it lost the
+  // copy control along with the navigation. Losing the link is right; losing
+  // the copy is not, and this is the case where copying matters most: the
+  // only thing a user can still do with an id they cannot open is paste it to
+  // someone who can.
+  const ORIGINAL_ID = 'run-orig-0123456789abcdef0123456789'
+
+  it('gives the id a copy control even when the original is inaccessible', async () => {
+    setup({ data: null, error: '' }, RUN.run_id, { rerun_of: ORIGINAL_ID, rerun_of_accessible: false })
+
+    await openDrawer()
+
+    const id = await screen.findByText(ORIGINAL_ID)
+    expect(id.closest('button')).not.toBeNull()
+  })
+
+  it('still shows that id in full, and does not turn it into an open-the-original link', async () => {
+    setup({ data: null, error: '' }, RUN.run_id, { rerun_of: ORIGINAL_ID, rerun_of_accessible: false })
+
+    await openDrawer()
+
+    // Full id, not a prefix.
+    const id = await screen.findByText(ORIGINAL_ID)
+    expect(id.textContent).toContain(ORIGINAL_ID)
+    // Copy, not navigate: the accessible branch's button is titled "Open the
+    // original run", and this one must not be.
+    expect(id.closest('button')!.getAttribute('title')).toMatch(/copy/i)
   })
 })

--- a/src/frontend-react/src/pages/HistoryPage.test.tsx
+++ b/src/frontend-react/src/pages/HistoryPage.test.tsx
@@ -14,12 +14,14 @@
  * a refused read renders no error text (the behaviour GeneratePage's
  * FeedbackPanel already proved once for its own surface); and a row
  * switch never shows a PREVIOUS row's corrections under the newly-selected
- * row — neither while that row's own fetch is still in flight, nor once it
- * has settled to an error (useFetch clears neither `data` nor, on the
- * error path, anything at all beyond `error` itself — see HistoryPage.tsx's
- * comment above `feedbackPath` for why both `loading` and `error` have to
- * gate `corrections`). The two positive-rendering tests exist because the
- * others are all absence-assertions, which a mutation that hardcodes
+ * row — not while that row's own fetch is still in flight, not once it has
+ * settled to an error, and not in the single stale commit between the row
+ * changing and the run-detail fetch catching up to it (useFetch clears
+ * neither `data` nor, on the error path, anything at all beyond `error`
+ * itself — see HistoryPage.tsx's comment above `feedbackPath` for why
+ * `loading`, `error` AND `d` all have to gate `corrections`). The two
+ * positive-rendering tests exist because the others are all
+ * absence-assertions, which a mutation that hardcodes
  * `corrections` to `[]` sails through undetected — see the `it`s below for
  * that finding's own account. This file does not re-test
  * RecordedCorrections' own rendering rules (RecordedCorrections.test.tsx
@@ -57,7 +59,7 @@ const RUN = {
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-function setup(feedbackFetch: { data: any; error: string; loading?: boolean }) {
+function setup(feedbackFetch: { data: any; error: string; loading?: boolean }, detailRunId: string = RUN.run_id) {
   mockUseAuth.mockReturnValue({
     user: { id: 'u1', email: 'a@b.com', display_name: 'A', role: 'user', status: 'active' },
     loading: false, isAuthenticated: true, isAdmin: false, status: 'active',
@@ -73,11 +75,16 @@ function setup(feedbackFetch: { data: any; error: string; loading?: boolean }) {
   mockApi.mockResolvedValue({ runs: [RUN], total: 1, scope: 'own' })
   // Keyed by path: the drawer fires useFetch twice (run detail + this
   // task's corrections fetch), and only the second is this test's subject.
+  // The detail fetch defaults to a payload for the OPENED row itself
+  // (detailRunId defaults to RUN.run_id) — HistoryPage.tsx only trusts
+  // `detail` once its own run_id echoes `selected` (its `d`), and now folds
+  // `d` into `corrections` too, so a caller that passes a mismatched
+  // detailRunId reproduces the stale-commit window on demand.
   mockUseFetch.mockImplementation((path: string | null) => {
     if (path?.startsWith('/api/feedback/')) {
       return { data: feedbackFetch.data, loading: feedbackFetch.loading ?? false, error: feedbackFetch.error, reload: vi.fn() }
     }
-    return { data: null, loading: false, error: '', reload: vi.fn() }
+    return { data: { ...RUN, run_id: detailRunId, robot_code: null }, loading: false, error: '', reload: vi.fn() }
   })
 }
 
@@ -154,11 +161,36 @@ describe('HistoryPage drawer — the corrections fetch', () => {
     expect(screen.queryByText(/Filed against the original run/)).toBeNull()
   })
 
-  // The four tests above are all absence-assertions (no fetch call target,
-  // no error text, no stale text twice) — every one of them still passes if
-  // `corrections` were hardcoded to [], which would silently disable this
-  // task's whole feature. These two are the ones that actually prove a
-  // correction reaches the screen.
+  it('does not render a previous row’s corrections in the single stale commit before the detail fetch has caught up to the newly-selected row', async () => {
+    // This is the one window `loading`/`error` alone cannot see: feedback
+    // for the new row has already landed and settled (loading: false,
+    // error: '') carrying a real correction, but the run-detail fetch
+    // (mocked via detailRunId below) still names a DIFFERENT run — the
+    // render between `selected` changing and useFetch's own effect firing,
+    // where useFetch still returns the PREVIOUS path's fully settled state.
+    // Only `d`, folded into `corrections` in HistoryPage.tsx, catches this.
+    setup(
+      {
+        data: {
+          applied_to: 'run-9',
+          corrections: [{ hint_id: 1, feedback_text: 'STALE COMMIT TEXT MUST NOT APPEAR' }],
+        },
+        error: '', loading: false,
+      },
+      'run-DIFFERENT-FROM-OPENED-ROW',
+    )
+
+    await openDrawer()
+
+    expect(screen.queryByText(/STALE COMMIT TEXT MUST NOT APPEAR/)).toBeNull()
+    expect(screen.queryByText(/Filed against the original run/)).toBeNull()
+  })
+
+  // The five tests above are all absence-assertions (no fetch call target,
+  // no error text, no stale text across three different staleness windows)
+  // — every one of them still passes if `corrections` were hardcoded to
+  // [], which would silently disable this task's whole feature. These two
+  // are the ones that actually prove a correction reaches the screen.
   it('renders a correction’s text once the fetch succeeds', async () => {
     setup({
       data: { applied_to: 'run-1', corrections: [{ hint_id: 1, feedback_text: 'the search box locator was off' }] },

--- a/src/frontend-react/src/pages/HistoryPage.tsx
+++ b/src/frontend-react/src/pages/HistoryPage.tsx
@@ -33,6 +33,7 @@ import { MoveToGroupMenu } from '@/components/history/MoveToGroupMenu'
 import { useRunGroups } from '@/components/history/RunGroupsContext'
 import type { RunGroup } from '@/components/history/useGroups'
 import { useAuth } from '@/auth/AuthContext'
+import { RecordedCorrections, type RecordedCorrectionItem } from '@/components/RecordedCorrections'
 
 type RunStatus = 'generated' | 'running' | 'passed' | 'failed' | 'error'
 
@@ -70,6 +71,17 @@ interface HistoryResponse {
   runs: Run[]
   total: number
   scope: 'own' | 'all'
+}
+
+/** GET /api/feedback/{run_id} — see GeneratePage.tsx's RecordedResponse for
+    the full contract (can_retract, absent-field semantics, etc.); the
+    drawer is read-only, so it only needs `applied_to` and the corrections
+    themselves. `applied_to` names the run these corrections are actually
+    filed against — the ORIGINAL run when the one being viewed is a re-run
+    (endpoints.py, get_run_corrections). */
+interface FeedbackCorrectionsResponse {
+  applied_to?: string
+  corrections?: RecordedCorrectionItem[]
 }
 
 const PAGE = 100
@@ -290,6 +302,32 @@ export default function HistoryPage() {
   // briefly render the PREVIOUS run's code/query. Only trust detail once it
   // matches the open row.
   const d = detail && detail.run_id === selected ? detail : null
+
+  // What this run has already contributed to the learning store — the
+  // History drawer's read of the same data GeneratePage's FeedbackPanel
+  // shows while the run is still on screen.
+  //
+  // Unlike detail above, this payload carries no run_id of its own to check
+  // against `selected` (only `applied_to`, the resolved ORIGINAL run, which
+  // legitimately differs from `selected` on a re-run — see the block below),
+  // so the same "does the response match the open row" trick doesn't apply
+  // here. `loading` is the substitute: useFetch holds it true from the
+  // moment `feedbackPath` changes until the fetch for THAT path lands, so
+  // forcing `corrections` empty while it is true stops a just-left row's
+  // corrections rendering under the newly-selected row while its own fetch
+  // is still catching up.
+  //
+  // Errors are read but never rendered. A 403 here is EXPECTED and correct:
+  // GET /api/history/{run_id} above passes is_grouped=true (a colleague's
+  // run published into a shared folder opens in this drawer), while
+  // GET /api/feedback/{run_id} deliberately does not — publishing a test
+  // does not publish the corrections filed against it (get_run_corrections,
+  // endpoints.py). An error banner would put a red box on every shared run
+  // in the org. An empty list degrades the same way, silently: silence
+  // claims nothing either way.
+  const feedbackPath = selected ? `/api/feedback/${selected}` : null
+  const { data: feedback, loading: feedbackLoading } = useFetch<FeedbackCorrectionsResponse>(feedbackPath)
+  const corrections = feedbackLoading || !Array.isArray(feedback?.corrections) ? [] : feedback.corrections
 
   // fromBulk: the toolbar's multi-select move — only that path exits select
   // mode, and only on success. A failed move keeps the selection so the user
@@ -974,6 +1012,31 @@ export default function HistoryPage() {
           {/* The card header's copy of this sits BEHIND the drawer overlay, so
               a move that failed from in here would otherwise be silent. */}
           {moveError && <p className="text-xs text-destructive">{moveError}</p>}
+
+          {/* What this run has already told the learning system — read-only
+              here; Retract stays the Generate panel's action alone (see
+              feedbackPath above). `corrections` above is already [] for
+              every case that must render nothing — still loading, refused,
+              or genuinely empty — so this needs no separate loading/error
+              check: silence claims nothing, same as RecordedCorrections'
+              own empty-array case. */}
+          {corrections.length > 0 && (
+            <div className="space-y-1.5">
+              {feedback?.applied_to && feedback.applied_to !== selected && (
+                /* Same treatment as the header's "re-run of" id above:
+                   font-mono, never truncated. This run is a re-run, so the
+                   corrections just listed are filed against the run the
+                   code was cloned from, not this one. */
+                <p className="text-xs text-muted-foreground">
+                  Filed against the original run{' '}
+                  <span className="font-mono" title="Corrections on a re-run are recorded against the run the code was cloned from">
+                    {feedback.applied_to}
+                  </span>
+                </p>
+              )}
+              <RecordedCorrections corrections={corrections} />
+            </div>
+          )}
 
           <Separator />
 

--- a/src/frontend-react/src/pages/HistoryPage.tsx
+++ b/src/frontend-react/src/pages/HistoryPage.tsx
@@ -439,6 +439,215 @@ function RunDrawerCode({ d, detailError, copied, onCopy, onDownload }: Readonly<
   )
 }
 
+/**
+ * The corrections the drawer may show for the open row, or [] for every case
+ * that must render nothing.
+ *
+ * `d` is borrowed on purpose. This payload carries no run_id of its own to
+ * check against `selected` (only `applied_to`, the resolved ORIGINAL run,
+ * which legitimately differs from `selected` on a re-run), so the "does the
+ * response match the open row" trick doesn't apply to it directly. `loading`
+ * and `error` are the first substitute, and BOTH are required: useFetch's
+ * reload() sets loading true and error '' at the START of every attempt for
+ * the CURRENT path (useFetch.ts) — from inside an EFFECT, so for the one
+ * render between `feedbackPath` changing and that effect firing, both still
+ * describe the PREVIOUS path. useFetch never clears `data` in either case, in
+ * its catch branch least of all (only setError runs there), so a fetch that
+ * FAILS for a freshly-selected row — the 403 case below is the everyday one,
+ * not an edge one — leaves the PREVIOUS row's data sitting there with loading
+ * already back to false. Gating on loading alone closes only the in-flight
+ * window; without error too, opening an owned run with corrections on file
+ * and then a colleague's shared run (whose corrections read the server
+ * refuses) would go on showing the FIRST run's corrections, and a "filed
+ * against" notice that may be entirely fabricated, under the SECOND run's
+ * drawer.
+ *
+ * That leaves exactly the one render loading/error can't cover on their own —
+ * and it is exactly the render where `d` is ALSO null, for the same reason
+ * (detail hasn't caught up to `selected` either). Requiring `d` closes it,
+ * and costs nothing on the success path: GET /api/history/{run_id} passes
+ * is_grouped=true while GET /api/feedback/{run_id} deliberately does not, and
+ * is_grouped only ADDS an allow rule (caller_can_access, ownership.py) — so
+ * feedback-allowed strictly implies detail-allowed, and `d` is never null for
+ * permission reasons while the corrections fetch itself succeeds.
+ */
+function visibleCorrections(
+  d: RunDetail | null,
+  feedbackLoading: boolean,
+  feedbackError: string,
+  feedback: FeedbackCorrectionsResponse | null,
+): RecordedCorrectionItem[] {
+  if (!d) return []
+  if (feedbackLoading || feedbackError) return []
+  return Array.isArray(feedback?.corrections) ? feedback.corrections : []
+}
+
+/** Run again needs stored code, an open row, no re-run of that row already in
+    flight, and a run that is not still executing. */
+function isRerunDisabled(d: RunDetail | null, selected: string | null, inFlight: Set<string>): boolean {
+  if (!selected) return true
+  return !d?.robot_code || inFlight.has(selected) || d?.status === 'running'
+}
+
+/* ── Status tabs, the text search and the "N of M runs" counter. Status AND
+   text search are both SERVER-side, so the counter is that filter+search's
+   own truth rather than a count of the loaded page ── */
+function HistoryFilterBar({ filter, onFilter, search, onSearch, showAuthor, shown, total }: Readonly<{
+  filter: Filter
+  onFilter: (next: Filter) => void
+  search: string
+  onSearch: (next: string) => void
+  showAuthor: boolean
+  shown: number
+  total: number
+}>) {
+  return (
+    <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+      <div className="flex flex-wrap items-center gap-1.5">
+        {FILTERS.map(f => (
+          <Button
+            key={f}
+            size="sm"
+            variant={filter === f ? 'default' : 'outline'}
+            className="h-7 w-24 text-xs capitalize"
+            onClick={() => onFilter(f)}
+          >
+            {f === 'all' ? 'All Runs' : f}
+          </Button>
+        ))}
+      </div>
+      <div className="flex items-center gap-3">
+        <div className="relative">
+          <Search className="absolute left-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground" />
+          <Input
+            value={search}
+            onChange={e => onSearch(e.target.value)}
+            placeholder={showAuthor ? 'Search description, user or id…' : 'Search description or id…'}
+            className="h-7 w-56 pl-8 text-xs"
+          />
+        </div>
+        <span className="whitespace-nowrap text-xs text-muted-foreground">
+          {shown} of {total} run{total === 1 ? '' : 's'}
+        </span>
+      </div>
+    </div>
+  )
+}
+
+/* ── The bulk-move toolbar. Everything in here is a mutation, and every one of
+   them answers 403 without an identity — so with no user they are not offered
+   at all ── */
+function BulkSelectControls({ hasUser, selectMode, groups, checkedCount, onMoveChecked, onCreateGroup, onEnterSelectMode, onExitSelectMode }: Readonly<{
+  hasUser: boolean
+  selectMode: boolean
+  groups: RunGroup[]
+  checkedCount: number
+  onMoveChecked: (groupId: string | null) => void
+  onCreateGroup: (name: string) => Promise<RunGroup>
+  onEnterSelectMode: () => void
+  onExitSelectMode: () => void
+}>) {
+  if (!hasUser) return null
+  if (!selectMode) {
+    return (
+      <Button
+        size="sm" variant="outline" className="h-7 text-xs gap-1.5"
+        title="Select multiple runs to move them into a group"
+        onClick={onEnterSelectMode}
+      >
+        <ListChecks className="h-3 w-3" /> Select
+      </Button>
+    )
+  }
+  return (
+    <>
+      <MoveToGroupMenu
+        groups={groups}
+        showRemove
+        onMove={onMoveChecked}
+        onCreateGroup={onCreateGroup}
+        trigger={
+          <Button size="sm" className="h-7 text-xs gap-1.5" disabled={checkedCount === 0}>
+            <FolderInput className="h-3 w-3" />
+            Move{checkedCount ? ` ${checkedCount}` : ''} to…
+          </Button>
+        }
+      />
+      <Button
+        size="sm" variant="outline" className="h-7 text-xs"
+        onClick={onExitSelectMode}
+      >
+        Cancel
+      </Button>
+    </>
+  )
+}
+
+/* ── The three mutually exclusive things the table area says when it has no
+   rows to draw: still loading, failed to load, or genuinely empty ── */
+function HistoryEmptyState({ loading, error, isEmpty, debouncedSearch, groupFilter, filter }: Readonly<{
+  loading: boolean
+  error: string
+  isEmpty: boolean
+  debouncedSearch: string
+  groupFilter: GroupFilter
+  filter: Filter
+}>) {
+  if (loading && isEmpty) {
+    return <p className="flex min-h-[420px] items-center justify-center text-sm text-muted-foreground">Loading runs…</p>
+  }
+  if (!loading && error) {
+    return <p className="flex min-h-[420px] items-center justify-center text-sm text-destructive">{error}</p>
+  }
+  if (!loading && !error && isEmpty) {
+    return (
+      <p className="flex min-h-[420px] items-center justify-center text-sm text-muted-foreground">
+        {noRunsMessage(debouncedSearch, groupFilter, filter)}
+      </p>
+    )
+  }
+  return null
+}
+
+/* ── The runs table's header row. Column geometry is constant (table-fixed),
+   so only the select-all and Ran-by columns come and go ── */
+function RunsTableHead({ selectMode, showAuthor, allVisibleSelected, someVisibleSelected, onToggleAll }: Readonly<{
+  selectMode: boolean
+  showAuthor: boolean
+  allVisibleSelected: boolean
+  someVisibleSelected: boolean
+  onToggleAll: () => void
+}>) {
+  return (
+    <thead className="sticky top-0 z-10 bg-background shadow-[inset_0_-1px_0_hsl(var(--border))]">
+      <tr className="bg-muted/40">
+        {selectMode && (
+          <th className="w-10 py-2.5 pl-4">
+            <input
+              type="checkbox"
+              className="h-3.5 w-3.5 cursor-pointer accent-primary align-middle"
+              title="Select all loaded runs"
+              aria-label="Select all loaded runs"
+              checked={allVisibleSelected}
+              ref={el => { if (el) el.indeterminate = someVisibleSelected && !allVisibleSelected }}
+              onChange={onToggleAll}
+            />
+          </th>
+        )}
+        <th className="w-28 py-2.5 px-4 text-left text-xs font-semibold uppercase tracking-wider text-muted-foreground">Status</th>
+        <th className="py-2.5 px-4 text-left text-xs font-semibold uppercase tracking-wider text-muted-foreground">Description</th>
+        {showAuthor && (
+          <th className="w-44 py-2.5 px-4 text-left text-xs font-semibold uppercase tracking-wider text-muted-foreground hidden lg:table-cell">Ran by</th>
+        )}
+        <th className="w-[320px] py-2.5 px-4 text-left text-xs font-semibold uppercase tracking-wider text-muted-foreground hidden md:table-cell">ID</th>
+        <th className="w-24 py-2.5 px-4 text-left text-xs font-semibold uppercase tracking-wider text-muted-foreground hidden sm:table-cell">When</th>
+        <th className="w-20 py-2.5 px-4"></th>
+        <th className="w-9 py-2.5 pr-3"></th>
+      </tr>
+    </thead>
+  )
+}
+
 export default function HistoryPage() {
   const navigate = useNavigate()
 
@@ -622,37 +831,9 @@ export default function HistoryPage() {
   // History drawer's read of the same data GeneratePage's FeedbackPanel
   // shows while the run is still on screen.
   //
-  // Unlike detail above, this payload carries no run_id of its own to check
-  // against `selected` (only `applied_to`, the resolved ORIGINAL run, which
-  // legitimately differs from `selected` on a re-run — see the block below),
-  // so the same "does the response match the open row" trick doesn't apply
-  // to it directly. `loading` and `error` are the first substitute, and
-  // BOTH are required: useFetch's reload() sets loading true and error ''
-  // at the START of every attempt for the CURRENT path (useFetch.ts) — from
-  // inside an EFFECT, so for the one render between `feedbackPath` changing
-  // and that effect firing, both still describe the PREVIOUS path; only
-  // from the render after that on do they answer "is THIS path's fetch
-  // still in flight, or did IT fail". useFetch never clears `data` in
-  // either case, in its catch branch least of all (only setError runs
-  // there), so a fetch that FAILS for a freshly-selected row — the 403
-  // below is the everyday case, not an edge one — leaves the PREVIOUS
-  // row's data sitting there with loading already back to false. Gating on
-  // loading alone closes only the in-flight window; without error too,
-  // opening an owned run with corrections on file and then a colleague's
-  // shared run (whose corrections read the gate below refuses) would go on
-  // showing the FIRST run's corrections, and a "filed against" notice that
-  // may be entirely fabricated, under the SECOND run's drawer.
-  //
-  // That leaves exactly the one render loading/error can't cover on their
-  // own — and it is exactly the render where `d` (above) is ALSO null, for
-  // the same reason (detail hasn't caught up to `selected` either).
-  // `corrections` below requires `d` too, which closes it. Borrowing it
-  // costs nothing on the success path: GET /api/history/{run_id} passes
-  // is_grouped=true while GET /api/feedback/{run_id} deliberately does not
-  // (see below), and is_grouped only ADDS an allow rule (caller_can_access,
-  // ownership.py) — so feedback-allowed strictly implies detail-allowed,
-  // and `d` is never null for permission reasons while the corrections
-  // fetch itself succeeds.
+  // Which of those rows may actually be shown for the open drawer is a
+  // question about staleness rather than about fetching — visibleCorrections
+  // above states the rule and why each half of it is required.
   //
   // Errors are read but never rendered as their own text. A 403 here is
   // EXPECTED and correct: GET /api/history/{run_id} above passes
@@ -664,7 +845,7 @@ export default function HistoryPage() {
   // way, silently: silence claims nothing either way.
   const feedbackPath = selected ? `/api/feedback/${selected}` : null
   const { data: feedback, loading: feedbackLoading, error: feedbackError } = useFetch<FeedbackCorrectionsResponse>(feedbackPath)
-  const corrections = !d || feedbackLoading || feedbackError || !Array.isArray(feedback?.corrections) ? [] : feedback.corrections
+  const corrections = visibleCorrections(d, feedbackLoading, feedbackError, feedback)
 
   // fromBulk: the toolbar's multi-select move — only that path exits select
   // mode, and only on success. A failed move keeps the selection so the user
@@ -833,7 +1014,7 @@ export default function HistoryPage() {
   }, [])
 
   const selectedNote = selected ? rerunNote[selected] : undefined
-  const rerunDisabled = !d?.robot_code || !selected || inFlight.has(selected) || d?.status === 'running'
+  const rerunDisabled = isRerunDisabled(d, selected, inFlight)
 
   return (
     <div className="mx-auto max-w-6xl">
@@ -854,35 +1035,15 @@ export default function HistoryPage() {
 
       <Card>
         <CardHeader className="gap-3 space-y-0 pb-3 px-5">
-          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-            <div className="flex flex-wrap items-center gap-1.5">
-              {FILTERS.map(f => (
-                <Button
-                  key={f}
-                  size="sm"
-                  variant={filter === f ? 'default' : 'outline'}
-                  className="h-7 w-24 text-xs capitalize"
-                  onClick={() => setFilter(f)}
-                >
-                  {f === 'all' ? 'All Runs' : f}
-                </Button>
-              ))}
-            </div>
-            <div className="flex items-center gap-3">
-              <div className="relative">
-                <Search className="absolute left-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground" />
-                <Input
-                  value={search}
-                  onChange={e => setSearch(e.target.value)}
-                  placeholder={showAuthor ? 'Search description, user or id…' : 'Search description or id…'}
-                  className="h-7 w-56 pl-8 text-xs"
-                />
-              </div>
-              <span className="whitespace-nowrap text-xs text-muted-foreground">
-                {visible.length} of {total} run{total === 1 ? '' : 's'}
-              </span>
-            </div>
-          </div>
+          <HistoryFilterBar
+            filter={filter}
+            onFilter={setFilter}
+            search={search}
+            onSearch={setSearch}
+            showAuthor={showAuthor}
+            shown={visible.length}
+            total={total}
+          />
           {/* Group chips row (design option C) + the bulk-move toolbar. The
               toolbar is pinned top-right: only the CHIPS wrap onto new lines
               (min-w-0 flex-1), so Select/Move never drift down as groups grow. */}
@@ -904,36 +1065,16 @@ export default function HistoryPage() {
             {/* Everything in here is a mutation, and every one of them answers
                 403 without an identity — so they are not offered at all. */}
             <div className="flex shrink-0 items-center gap-1.5">
-              {user && (selectMode ? (
-                <>
-                  <MoveToGroupMenu
-                    groups={groups}
-                    showRemove
-                    onMove={gid => { if (checkedIds.size) void moveRuns([...checkedIds], gid, true) }}
-                    onCreateGroup={createGroup}
-                    trigger={
-                      <Button size="sm" className="h-7 text-xs gap-1.5" disabled={checkedIds.size === 0}>
-                        <FolderInput className="h-3 w-3" />
-                        Move{checkedIds.size ? ` ${checkedIds.size}` : ''} to…
-                      </Button>
-                    }
-                  />
-                  <Button
-                    size="sm" variant="outline" className="h-7 text-xs"
-                    onClick={() => { setSelectMode(false); setCheckedIds(new Set()) }}
-                  >
-                    Cancel
-                  </Button>
-                </>
-              ) : (
-                <Button
-                  size="sm" variant="outline" className="h-7 text-xs gap-1.5"
-                  title="Select multiple runs to move them into a group"
-                  onClick={() => setSelectMode(true)}
-                >
-                  <ListChecks className="h-3 w-3" /> Select
-                </Button>
-              ))}
+              <BulkSelectControls
+                hasUser={!!user}
+                selectMode={selectMode}
+                groups={groups}
+                checkedCount={checkedIds.size}
+                onMoveChecked={gid => { if (checkedIds.size) void moveRuns([...checkedIds], gid, true) }}
+                onCreateGroup={createGroup}
+                onEnterSelectMode={() => setSelectMode(true)}
+                onExitSelectMode={() => { setSelectMode(false); setCheckedIds(new Set()) }}
+              />
             </div>
           </div>
           {/* A failed /api/groups leaves the chips showing whatever the last
@@ -957,17 +1098,14 @@ export default function HistoryPage() {
               collapsing the card. Column geometry is constant (table-fixed),
               so switching filters only changes the values. */}
           <div className="min-h-[420px]">
-          {loading && visible.length === 0 && (
-            <p className="flex min-h-[420px] items-center justify-center text-sm text-muted-foreground">Loading runs…</p>
-          )}
-          {!loading && error && (
-            <p className="flex min-h-[420px] items-center justify-center text-sm text-destructive">{error}</p>
-          )}
-          {!loading && !error && visible.length === 0 && (
-            <p className="flex min-h-[420px] items-center justify-center text-sm text-muted-foreground">
-              {noRunsMessage(debouncedSearch, groupFilter, filter)}
-            </p>
-          )}
+          <HistoryEmptyState
+            loading={loading}
+            error={error}
+            isEmpty={visible.length === 0}
+            debouncedSearch={debouncedSearch}
+            groupFilter={groupFilter}
+            filter={filter}
+          />
 
           {/* Filter/search changes keep the PREVIOUS rows on screen and dim
               them while the refetch is in flight, then swap in place — no
@@ -979,32 +1117,13 @@ export default function HistoryPage() {
                   recomputed from row content, so switching status filters
                   keeps the exact same grid — only the values change. */}
               <table className="w-full table-fixed text-sm">
-                <thead className="sticky top-0 z-10 bg-background shadow-[inset_0_-1px_0_hsl(var(--border))]">
-                  <tr className="bg-muted/40">
-                    {selectMode && (
-                      <th className="w-10 py-2.5 pl-4">
-                        <input
-                          type="checkbox"
-                          className="h-3.5 w-3.5 cursor-pointer accent-primary align-middle"
-                          title="Select all loaded runs"
-                          aria-label="Select all loaded runs"
-                          checked={allVisibleSelected}
-                          ref={el => { if (el) el.indeterminate = someVisibleSelected && !allVisibleSelected }}
-                          onChange={toggleAllVisible}
-                        />
-                      </th>
-                    )}
-                    <th className="w-28 py-2.5 px-4 text-left text-xs font-semibold uppercase tracking-wider text-muted-foreground">Status</th>
-                    <th className="py-2.5 px-4 text-left text-xs font-semibold uppercase tracking-wider text-muted-foreground">Description</th>
-                    {showAuthor && (
-                      <th className="w-44 py-2.5 px-4 text-left text-xs font-semibold uppercase tracking-wider text-muted-foreground hidden lg:table-cell">Ran by</th>
-                    )}
-                    <th className="w-[320px] py-2.5 px-4 text-left text-xs font-semibold uppercase tracking-wider text-muted-foreground hidden md:table-cell">ID</th>
-                    <th className="w-24 py-2.5 px-4 text-left text-xs font-semibold uppercase tracking-wider text-muted-foreground hidden sm:table-cell">When</th>
-                    <th className="w-20 py-2.5 px-4"></th>
-                    <th className="w-9 py-2.5 pr-3"></th>
-                  </tr>
-                </thead>
+                <RunsTableHead
+                  selectMode={selectMode}
+                  showAuthor={showAuthor}
+                  allVisibleSelected={allVisibleSelected}
+                  someVisibleSelected={someVisibleSelected}
+                  onToggleAll={toggleAllVisible}
+                />
                 <tbody>
                   {visible.map(row => (
                     <tr

--- a/src/frontend-react/src/pages/HistoryPage.tsx
+++ b/src/frontend-react/src/pages/HistoryPage.tsx
@@ -170,6 +170,275 @@ function drawerCodeBody(detailError: string, d: RunDetail | null): ReactNode {
   )
 }
 
+/* ── The drawer's "re-run of {id}" trail. The original id is always shown in
+   full; whether it is a link depends on rerun_of_accessible, and the
+   inaccessible branch keeps a copy control so an id you cannot open can still
+   be handed to someone who can ── */
+function RerunOriginLine({ d, copied, onCopy, onOpenRun }: Readonly<{
+  d: RunDetail | null
+  copied: string | null
+  onCopy: (text: string, key: string) => void
+  onOpenRun: (runId: string) => void
+}>) {
+  if (!d?.rerun_of) return null
+  return (
+    <span className="basis-full">
+      re-run of{' '}
+      {d.rerun_of_accessible ? (
+        <button
+          type="button"
+          className="font-mono hover:text-foreground hover:underline"
+          title="Open the original run — feedback on this re-run applies to it"
+          onClick={() => onOpenRun(d.rerun_of!)}
+        >
+          {d.rerun_of}
+        </button>
+      ) : (
+        /* The same rule as the row pill: the id is still shown in
+           full, but it is not a link, because that link would
+           404. It keeps the copy control the accessible branch
+           gets for free from being a button — the id rule is
+           full-AND-copyable unconditionally, and this is the case
+           where copying earns the most: the only thing left to do
+           with an id you cannot open is hand it to someone who
+           can. */
+        <button
+          type="button"
+          className="inline-flex items-center gap-1 font-mono hover:text-foreground"
+          title="Copy the original run’s id — you no longer have access to open it"
+          onClick={() => onCopy(d.rerun_of!, 'drawer-rerun-of')}
+        >
+          {d.rerun_of}
+          {copied === 'drawer-rerun-of' ? <Check className="h-3 w-3" /> : <Copy className="h-3 w-3" />}
+        </button>
+      )}
+      {/* The leading space in the string below is load-bearing.
+          JSX strips the newline between two adjacent elements, so
+          without it textContent, a copy-paste and every screen
+          reader read "…b05c23967b51(no longer available to you)".
+          The ml-2 that used to sit here moved 8px on screen and
+          nothing anywhere else. */}
+      {!d.rerun_of_accessible && (
+        <span className="text-muted-foreground">
+          {' (no longer available to you)'}
+        </span>
+      )}
+    </span>
+  )
+}
+
+/* ── The drawer's header: status, who ran it, the description, and the id and
+   timestamp line ── */
+function RunDrawerHeader({ selected, d, detailError, viewerEmail, copied, onCopy, onOpenRun }: Readonly<{
+  selected: string | null
+  d: RunDetail | null
+  detailError: string
+  viewerEmail: string | undefined
+  copied: string | null
+  onCopy: (text: string, key: string) => void
+  onOpenRun: (runId: string) => void
+}>) {
+  return (
+    <SheetHeader className="space-y-2 pr-6 text-left">
+      <div className="flex items-center gap-2">
+        {d && STATUS_BADGE[d.status]}
+        {d?.rerun_of && (
+          <Badge className="gap-1 border-blue-200 bg-blue-100 text-xs text-blue-700 hover:bg-blue-100">
+            <Repeat2 className="h-3 w-3" />
+            <span>Re-run</span>
+          </Badge>
+        )}
+        {d?.user_email && d.user_email !== viewerEmail && (
+          <span className="text-xs text-muted-foreground" title="Who ran this test">
+            {d.user_email}
+          </span>
+        )}
+      </div>
+      {/* detailError means d is null because the fetch was REFUSED,
+          not because the run has no description — so the "Pasted code
+          run" fallback would assert something false about a run we
+          could not read at all. The reason itself renders in the body
+          (see RunDrawerCode); the header only stops lying. */}
+      <SheetTitle className="text-base leading-snug">
+        {detailError ? 'Run unavailable' : d?.user_query || 'Pasted code run'}
+      </SheetTitle>
+      <SheetDescription className="flex flex-wrap items-center gap-x-3 gap-y-1 text-xs">
+        {selected && (
+          <button
+            type="button"
+            className="inline-flex items-center gap-1 font-mono hover:text-foreground"
+            title="Copy run id"
+            onClick={() => onCopy(selected, 'drawer-id')}
+          >
+            {selected}
+            {copied === 'drawer-id' ? <Check className="h-3 w-3" /> : <Copy className="h-3 w-3" />}
+          </button>
+        )}
+        {d && <span>created {formatDate(d.created_at)}</span>}
+        {d && d.updated_at !== d.created_at && (
+          <span>last update {formatDate(d.updated_at)}</span>
+        )}
+        <RerunOriginLine d={d} copied={copied} onCopy={onCopy} onOpenRun={onOpenRun} />
+      </SheetDescription>
+    </SheetHeader>
+  )
+}
+
+/* ── The drawer's action row: re-run, open report, regenerate, and where the
+   run is filed. A run this caller may read but not file still shows WHERE it
+   lives — that is the shared folder doing its job — but as a label rather
+   than a control that could only 404 ── */
+function RunDrawerActions({ d, selected, hasUser, groups, rerunDisabled, onRunAgain, onRegenerate, onMove, onCreateGroup }: Readonly<{
+  d: RunDetail | null
+  selected: string | null
+  hasUser: boolean
+  groups: RunGroup[]
+  rerunDisabled: boolean
+  onRunAgain: (runId: string) => void
+  onRegenerate: (query: string) => void
+  onMove: (runIds: string[], groupId: string | null) => void
+  onCreateGroup: (name: string) => Promise<RunGroup>
+}>) {
+  return (
+    <div className="flex flex-wrap gap-2">
+      <Button
+        size="sm"
+        className="h-8 gap-1.5 text-xs"
+        disabled={rerunDisabled}
+        title={d?.robot_code
+          ? 'Execute this exact saved code as a new run — no regeneration, no LLM cost'
+          : 'No stored code for this run'}
+        onClick={() => selected && onRunAgain(selected)}
+      >
+        <Play className="h-3.5 w-3.5" /> Run again
+      </Button>
+      {d?.has_report && (
+        <Button asChild size="sm" variant="outline" className="h-8 gap-1.5 text-xs">
+          <a href={`/reports/${d.run_id}/log.html`} target="_blank" rel="noreferrer">
+            <FileTerminal className="h-3.5 w-3.5" /> Open report
+          </a>
+        </Button>
+      )}
+      {d?.user_query && (
+        <Button
+          size="sm"
+          variant="outline"
+          className="h-8 gap-1.5 text-xs"
+          title="Start a fresh generation from this description (for when the site changed)"
+          onClick={() => onRegenerate(d.user_query!)}
+        >
+          <RotateCw className="h-3.5 w-3.5" /> Regenerate
+        </Button>
+      )}
+      {d && hasUser && (d.can_move ? (
+        <MoveToGroupMenu
+          groups={groups}
+          currentGroupId={d.group_id}
+          onMove={gid => onMove([d.run_id], gid)}
+          onCreateGroup={onCreateGroup}
+          trigger={
+            <Button size="sm" variant="outline" className="h-8 gap-1.5 text-xs">
+              <FolderInput className="h-3.5 w-3.5" />
+              {d.group_name ? `Group: ${d.group_name}` : 'Move to group…'}
+            </Button>
+          }
+        />
+      ) : d.group_name && (
+        <span
+          className="inline-flex items-center gap-1.5 rounded border px-2 py-1 text-xs text-muted-foreground"
+          title="Only the owner of a run, or an org admin, can move it"
+        >
+          <Folder className="h-3.5 w-3.5" />
+          Group: {d.group_name}
+        </span>
+      ))}
+    </div>
+  )
+}
+
+/**
+ * What this run has already told the learning system — read-only here;
+ * Retract stays the Generate panel's action alone (see feedbackPath in
+ * HistoryPage). `corrections` is already [] for every case that must render
+ * nothing — still loading, stale for this row, refused, or genuinely empty —
+ * so this needs no separate loading/error/staleness check: silence claims
+ * nothing, same as RecordedCorrections' own empty-array case.
+ */
+function RunDrawerCorrections({ corrections, appliedTo, selected, copied, onCopy }: Readonly<{
+  corrections: RecordedCorrectionItem[]
+  appliedTo: string | undefined
+  selected: string | null
+  copied: string | null
+  onCopy: (text: string, key: string) => void
+}>) {
+  if (corrections.length === 0) return null
+  return (
+    <div className="space-y-1.5">
+      {appliedTo && appliedTo !== selected && (
+        /* Same treatment as the header's own id control above
+           (the "Copy run id" button): font-mono, never truncated,
+           click-to-copy. This run is a re-run, so the corrections
+           just listed are filed against the run the code was
+           cloned from, not this one. */
+        <p className="text-xs text-muted-foreground">
+          Filed against the original run{' '}
+          <button
+            type="button"
+            className="inline-flex items-center gap-1 font-mono hover:text-foreground"
+            title="Copy the original run’s id"
+            onClick={() => onCopy(appliedTo, 'drawer-applied-to')}
+          >
+            {appliedTo}
+            {copied === 'drawer-applied-to' ? <Check className="h-3 w-3" /> : <Copy className="h-3 w-3" />}
+          </button>
+        </p>
+      )}
+      <RecordedCorrections corrections={corrections} />
+    </div>
+  )
+}
+
+/* ── The drawer's code panel and its copy/download controls ── */
+function RunDrawerCode({ d, detailError, copied, onCopy, onDownload }: Readonly<{
+  d: RunDetail | null
+  detailError: string
+  copied: string | null
+  onCopy: (text: string, key: string) => void
+  onDownload: (code: string, runId: string) => void
+}>) {
+  return (
+    <div className="flex min-h-0 flex-1 flex-col gap-2">
+      <div className="flex items-center justify-between">
+        <span className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">Robot code</span>
+        {d?.robot_code && (
+          <div className="flex gap-1">
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-7 w-7"
+              title="Copy code"
+              onClick={() => onCopy(d.robot_code!, 'drawer-code')}
+            >
+              {copied === 'drawer-code' ? <Check className="h-3.5 w-3.5" /> : <Copy className="h-3.5 w-3.5" />}
+            </Button>
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-7 w-7"
+              title="Download .robot file"
+              onClick={() => onDownload(d.robot_code!, d.run_id)}
+            >
+              <Download className="h-3.5 w-3.5" />
+            </Button>
+          </div>
+        )}
+      </div>
+
+      {drawerCodeBody(detailError, d)}
+    </div>
+  )
+}
+
 export default function HistoryPage() {
   const navigate = useNavigate()
 
@@ -922,220 +1191,53 @@ export default function HistoryPage() {
 
       <Sheet open={!!selected} onOpenChange={open => { if (!open) setSelected(null) }}>
         <SheetContent className="flex w-full flex-col gap-4 overflow-y-auto sm:max-w-2xl">
-          <SheetHeader className="space-y-2 pr-6 text-left">
-            <div className="flex items-center gap-2">
-              {d && STATUS_BADGE[d.status]}
-              {d?.rerun_of && (
-                <Badge className="gap-1 border-blue-200 bg-blue-100 text-xs text-blue-700 hover:bg-blue-100">
-                  <Repeat2 className="h-3 w-3" />
-                  <span>Re-run</span>
-                </Badge>
-              )}
-              {d?.user_email && d.user_email !== user?.email && (
-                <span className="text-xs text-muted-foreground" title="Who ran this test">
-                  {d.user_email}
-                </span>
-              )}
-            </div>
-            {/* detailError means d is null because the fetch was REFUSED,
-                not because the run has no description — so the "Pasted code
-                run" fallback would assert something false about a run we
-                could not read at all. The reason itself renders in the body
-                (see detailError below); the header only stops lying. */}
-            <SheetTitle className="text-base leading-snug">
-              {detailError ? 'Run unavailable' : d?.user_query || 'Pasted code run'}
-            </SheetTitle>
-            <SheetDescription className="flex flex-wrap items-center gap-x-3 gap-y-1 text-xs">
-              {selected && (
-                <button
-                  type="button"
-                  className="inline-flex items-center gap-1 font-mono hover:text-foreground"
-                  title="Copy run id"
-                  onClick={() => void copyText(selected, 'drawer-id')}
-                >
-                  {selected}
-                  {copied === 'drawer-id' ? <Check className="h-3 w-3" /> : <Copy className="h-3 w-3" />}
-                </button>
-              )}
-              {d && <span>created {formatDate(d.created_at)}</span>}
-              {d && d.updated_at !== d.created_at && (
-                <span>last update {formatDate(d.updated_at)}</span>
-              )}
-              {d?.rerun_of && (
-                <span className="basis-full">
-                  re-run of{' '}
-                  {d.rerun_of_accessible ? (
-                    <button
-                      type="button"
-                      className="font-mono hover:text-foreground hover:underline"
-                      title="Open the original run — feedback on this re-run applies to it"
-                      onClick={() => setSelected(d.rerun_of!)}
-                    >
-                      {d.rerun_of}
-                    </button>
-                  ) : (
-                    /* The same rule as the row pill: the id is still shown in
-                       full, but it is not a link, because that link would
-                       404. It keeps the copy control the accessible branch
-                       gets for free from being a button — the id rule is
-                       full-AND-copyable unconditionally, and this is the case
-                       where copying earns the most: the only thing left to do
-                       with an id you cannot open is hand it to someone who
-                       can. */
-                    <button
-                      type="button"
-                      className="inline-flex items-center gap-1 font-mono hover:text-foreground"
-                      title="Copy the original run’s id — you no longer have access to open it"
-                      onClick={() => void copyText(d.rerun_of!, 'drawer-rerun-of')}
-                    >
-                      {d.rerun_of}
-                      {copied === 'drawer-rerun-of' ? <Check className="h-3 w-3" /> : <Copy className="h-3 w-3" />}
-                    </button>
-                  )}
-                  {/* The leading space in the string below is load-bearing.
-                      JSX strips the newline between two adjacent elements, so
-                      without it textContent, a copy-paste and every screen
-                      reader read "…b05c23967b51(no longer available to you)".
-                      The ml-2 that used to sit here moved 8px on screen and
-                      nothing anywhere else. */}
-                  {!d.rerun_of_accessible && (
-                    <span className="text-muted-foreground">
-                      {' (no longer available to you)'}
-                    </span>
-                  )}
-                </span>
-              )}
-            </SheetDescription>
-          </SheetHeader>
+          <RunDrawerHeader
+            selected={selected}
+            d={d}
+            detailError={detailError}
+            viewerEmail={user?.email}
+            copied={copied}
+            onCopy={copyText}
+            onOpenRun={setSelected}
+          />
 
           {selectedNote && (
             <p className="rounded-md border bg-muted/40 px-3 py-2 text-xs">{selectedNote}</p>
           )}
 
-          <div className="flex flex-wrap gap-2">
-            <Button
-              size="sm"
-              className="h-8 gap-1.5 text-xs"
-              disabled={rerunDisabled}
-              title={d?.robot_code
-                ? 'Execute this exact saved code as a new run — no regeneration, no LLM cost'
-                : 'No stored code for this run'}
-              onClick={() => selected && void runAgain(selected)}
-            >
-              <Play className="h-3.5 w-3.5" /> Run again
-            </Button>
-            {d?.has_report && (
-              <Button asChild size="sm" variant="outline" className="h-8 gap-1.5 text-xs">
-                <a href={`/reports/${d.run_id}/log.html`} target="_blank" rel="noreferrer">
-                  <FileTerminal className="h-3.5 w-3.5" /> Open report
-                </a>
-              </Button>
-            )}
-            {d?.user_query && (
-              <Button
-                size="sm"
-                variant="outline"
-                className="h-8 gap-1.5 text-xs"
-                title="Start a fresh generation from this description (for when the site changed)"
-                onClick={() => navigate('/generate', { state: { prefillQuery: d.user_query } })}
-              >
-                <RotateCw className="h-3.5 w-3.5" /> Regenerate
-              </Button>
-            )}
-            {/* A run this caller may read but not file still shows WHERE it
-                lives — that is the shared folder doing its job — but as a
-                label rather than a control that could only 404. */}
-            {d && user && (d.can_move ? (
-              <MoveToGroupMenu
-                groups={groups}
-                currentGroupId={d.group_id}
-                onMove={gid => void moveRuns([d.run_id], gid)}
-                onCreateGroup={createGroup}
-                trigger={
-                  <Button size="sm" variant="outline" className="h-8 gap-1.5 text-xs">
-                    <FolderInput className="h-3.5 w-3.5" />
-                    {d.group_name ? `Group: ${d.group_name}` : 'Move to group…'}
-                  </Button>
-                }
-              />
-            ) : d.group_name && (
-              <span
-                className="inline-flex items-center gap-1.5 rounded border px-2 py-1 text-xs text-muted-foreground"
-                title="Only the owner of a run, or an org admin, can move it"
-              >
-                <Folder className="h-3.5 w-3.5" />
-                Group: {d.group_name}
-              </span>
-            ))}
-          </div>
+          <RunDrawerActions
+            d={d}
+            selected={selected}
+            hasUser={!!user}
+            groups={groups}
+            rerunDisabled={rerunDisabled}
+            onRunAgain={runAgain}
+            onRegenerate={q => navigate('/generate', { state: { prefillQuery: q } })}
+            onMove={moveRuns}
+            onCreateGroup={createGroup}
+          />
 
           {/* The card header's copy of this sits BEHIND the drawer overlay, so
               a move that failed from in here would otherwise be silent. */}
           {moveError && <p className="text-xs text-destructive">{moveError}</p>}
 
-          {/* What this run has already told the learning system — read-only
-              here; Retract stays the Generate panel's action alone (see
-              feedbackPath above). `corrections` above is already [] for
-              every case that must render nothing — still loading, stale
-              for this row, refused, or genuinely empty — so this needs no
-              separate loading/error/staleness check: silence claims
-              nothing, same as RecordedCorrections' own empty-array case. */}
-          {corrections.length > 0 && (
-            <div className="space-y-1.5">
-              {feedback?.applied_to && feedback.applied_to !== selected && (
-                /* Same treatment as the header's own id control above
-                   (the "Copy run id" button): font-mono, never truncated,
-                   click-to-copy. This run is a re-run, so the corrections
-                   just listed are filed against the run the code was
-                   cloned from, not this one. */
-                <p className="text-xs text-muted-foreground">
-                  Filed against the original run{' '}
-                  <button
-                    type="button"
-                    className="inline-flex items-center gap-1 font-mono hover:text-foreground"
-                    title="Copy the original run’s id"
-                    onClick={() => void copyText(feedback.applied_to!, 'drawer-applied-to')}
-                  >
-                    {feedback.applied_to}
-                    {copied === 'drawer-applied-to' ? <Check className="h-3 w-3" /> : <Copy className="h-3 w-3" />}
-                  </button>
-                </p>
-              )}
-              <RecordedCorrections corrections={corrections} />
-            </div>
-          )}
+          <RunDrawerCorrections
+            corrections={corrections}
+            appliedTo={feedback?.applied_to}
+            selected={selected}
+            copied={copied}
+            onCopy={copyText}
+          />
 
           <Separator />
 
-          <div className="flex min-h-0 flex-1 flex-col gap-2">
-            <div className="flex items-center justify-between">
-              <span className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">Robot code</span>
-              {d?.robot_code && (
-                <div className="flex gap-1">
-                  <Button
-                    variant="ghost"
-                    size="icon"
-                    className="h-7 w-7"
-                    title="Copy code"
-                    onClick={() => void copyText(d.robot_code!, 'drawer-code')}
-                  >
-                    {copied === 'drawer-code' ? <Check className="h-3.5 w-3.5" /> : <Copy className="h-3.5 w-3.5" />}
-                  </Button>
-                  <Button
-                    variant="ghost"
-                    size="icon"
-                    className="h-7 w-7"
-                    title="Download .robot file"
-                    onClick={() => downloadCode(d.robot_code!, d.run_id)}
-                  >
-                    <Download className="h-3.5 w-3.5" />
-                  </Button>
-                </div>
-              )}
-            </div>
-
-            {drawerCodeBody(detailError, d)}
-          </div>
+          <RunDrawerCode
+            d={d}
+            detailError={detailError}
+            copied={copied}
+            onCopy={copyText}
+            onDownload={downloadCode}
+          />
         </SheetContent>
       </Sheet>
     </div>

--- a/src/frontend-react/src/pages/HistoryPage.tsx
+++ b/src/frontend-react/src/pages/HistoryPage.tsx
@@ -946,13 +946,22 @@ export default function HistoryPage() {
                     </button>
                   ) : (
                     /* The same rule as the row pill: the id is still shown in
-                       full, but it is text rather than a link that 404s. */
-                    <span
-                      className="font-mono"
-                      title="You no longer have access to the original run"
+                       full, but it is not a link, because that link would
+                       404. It keeps the copy control the accessible branch
+                       gets for free from being a button — the id rule is
+                       full-AND-copyable unconditionally, and this is the case
+                       where copying earns the most: the only thing left to do
+                       with an id you cannot open is hand it to someone who
+                       can. */
+                    <button
+                      type="button"
+                      className="inline-flex items-center gap-1 font-mono hover:text-foreground"
+                      title="Copy the original run’s id — you no longer have access to open it"
+                      onClick={() => void copyText(d.rerun_of!, 'drawer-rerun-of')}
                     >
                       {d.rerun_of}
-                    </span>
+                      {copied === 'drawer-rerun-of' ? <Check className="h-3 w-3" /> : <Copy className="h-3 w-3" />}
+                    </button>
                   )}
                   {/* The leading space in the string below is load-bearing.
                       JSX strips the newline between two adjacent elements, so

--- a/src/frontend-react/src/pages/HistoryPage.tsx
+++ b/src/frontend-react/src/pages/HistoryPage.tsx
@@ -311,23 +311,31 @@ export default function HistoryPage() {
   // against `selected` (only `applied_to`, the resolved ORIGINAL run, which
   // legitimately differs from `selected` on a re-run — see the block below),
   // so the same "does the response match the open row" trick doesn't apply
-  // here. `loading` is the substitute: useFetch holds it true from the
-  // moment `feedbackPath` changes until the fetch for THAT path lands, so
-  // forcing `corrections` empty while it is true stops a just-left row's
-  // corrections rendering under the newly-selected row while its own fetch
-  // is still catching up.
+  // here. `loading` and `error` are the substitute, and BOTH are required:
+  // useFetch's reload() sets loading true and error '' at the START of every
+  // attempt for the CURRENT path (useFetch.ts), so together they answer "is
+  // THIS path's fetch still in flight, or did IT fail" — but useFetch never
+  // clears `data` in either case, in its catch branch least of all (only
+  // setError runs there). So a fetch that FAILS for a freshly-selected row
+  // — the 403 below is the everyday case, not an edge one — leaves the
+  // PREVIOUS row's data sitting there with loading already back to false.
+  // Gating on loading alone closes only the in-flight window; without error
+  // too, opening an owned run with corrections on file and then a
+  // colleague's shared run (whose corrections read the gate below refuses)
+  // would go on showing the FIRST run's corrections, and a "filed against"
+  // notice that may be entirely fabricated, under the SECOND run's drawer.
   //
-  // Errors are read but never rendered. A 403 here is EXPECTED and correct:
-  // GET /api/history/{run_id} above passes is_grouped=true (a colleague's
-  // run published into a shared folder opens in this drawer), while
-  // GET /api/feedback/{run_id} deliberately does not — publishing a test
-  // does not publish the corrections filed against it (get_run_corrections,
-  // endpoints.py). An error banner would put a red box on every shared run
-  // in the org. An empty list degrades the same way, silently: silence
-  // claims nothing either way.
+  // Errors are read but never rendered as their own text. A 403 here is
+  // EXPECTED and correct: GET /api/history/{run_id} above passes
+  // is_grouped=true (a colleague's run published into a shared folder opens
+  // in this drawer), while GET /api/feedback/{run_id} deliberately does not
+  // — publishing a test does not publish the corrections filed against it
+  // (get_run_corrections, endpoints.py). An error banner would put a red
+  // box on every shared run in the org. An empty list degrades the same
+  // way, silently: silence claims nothing either way.
   const feedbackPath = selected ? `/api/feedback/${selected}` : null
-  const { data: feedback, loading: feedbackLoading } = useFetch<FeedbackCorrectionsResponse>(feedbackPath)
-  const corrections = feedbackLoading || !Array.isArray(feedback?.corrections) ? [] : feedback.corrections
+  const { data: feedback, loading: feedbackLoading, error: feedbackError } = useFetch<FeedbackCorrectionsResponse>(feedbackPath)
+  const corrections = feedbackLoading || feedbackError || !Array.isArray(feedback?.corrections) ? [] : feedback.corrections
 
   // fromBulk: the toolbar's multi-select move — only that path exits select
   // mode, and only on success. A failed move keeps the selection so the user
@@ -1023,15 +1031,22 @@ export default function HistoryPage() {
           {corrections.length > 0 && (
             <div className="space-y-1.5">
               {feedback?.applied_to && feedback.applied_to !== selected && (
-                /* Same treatment as the header's "re-run of" id above:
-                   font-mono, never truncated. This run is a re-run, so the
-                   corrections just listed are filed against the run the
-                   code was cloned from, not this one. */
+                /* Same treatment as the header's own id control above
+                   (the "Copy run id" button): font-mono, never truncated,
+                   click-to-copy. This run is a re-run, so the corrections
+                   just listed are filed against the run the code was
+                   cloned from, not this one. */
                 <p className="text-xs text-muted-foreground">
                   Filed against the original run{' '}
-                  <span className="font-mono" title="Corrections on a re-run are recorded against the run the code was cloned from">
+                  <button
+                    type="button"
+                    className="inline-flex items-center gap-1 font-mono hover:text-foreground"
+                    title="Copy the original run’s id"
+                    onClick={() => void copyText(feedback.applied_to!, 'drawer-applied-to')}
+                  >
                     {feedback.applied_to}
-                  </span>
+                    {copied === 'drawer-applied-to' ? <Check className="h-3 w-3" /> : <Copy className="h-3 w-3" />}
+                  </button>
                 </p>
               )}
               <RecordedCorrections corrections={corrections} />

--- a/src/frontend-react/src/pages/HistoryPage.tsx
+++ b/src/frontend-react/src/pages/HistoryPage.tsx
@@ -301,7 +301,7 @@ export default function HistoryPage() {
   // useFetch keeps stale data during a refetch, so a just-clicked row would
   // briefly render the PREVIOUS run's code/query. Only trust detail once it
   // matches the open row.
-  const d = detail && detail.run_id === selected ? detail : null
+  const d = detail?.run_id === selected ? detail : null
 
   // What this run has already contributed to the learning store — the
   // History drawer's read of the same data GeneratePage's FeedbackPanel

--- a/src/frontend-react/src/pages/HistoryPage.tsx
+++ b/src/frontend-react/src/pages/HistoryPage.tsx
@@ -313,17 +313,20 @@ export default function HistoryPage() {
   // so the same "does the response match the open row" trick doesn't apply
   // here. `loading` and `error` are the substitute, and BOTH are required:
   // useFetch's reload() sets loading true and error '' at the START of every
-  // attempt for the CURRENT path (useFetch.ts), so together they answer "is
-  // THIS path's fetch still in flight, or did IT fail" — but useFetch never
-  // clears `data` in either case, in its catch branch least of all (only
-  // setError runs there). So a fetch that FAILS for a freshly-selected row
-  // — the 403 below is the everyday case, not an edge one — leaves the
-  // PREVIOUS row's data sitting there with loading already back to false.
-  // Gating on loading alone closes only the in-flight window; without error
-  // too, opening an owned run with corrections on file and then a
-  // colleague's shared run (whose corrections read the gate below refuses)
-  // would go on showing the FIRST run's corrections, and a "filed against"
-  // notice that may be entirely fabricated, under the SECOND run's drawer.
+  // attempt for the CURRENT path (useFetch.ts) — from inside an EFFECT, so
+  // for the one render between `feedbackPath` changing and that effect
+  // firing, both still describe the PREVIOUS path. From the render after
+  // that on, together they answer "is THIS path's fetch still in flight, or
+  // did IT fail" — but useFetch never clears `data` in either case, in its
+  // catch branch least of all (only setError runs there). So a fetch that
+  // FAILS for a freshly-selected row — the 403 below is the everyday case,
+  // not an edge one — leaves the PREVIOUS row's data sitting there with
+  // loading already back to false. Gating on loading alone closes only the
+  // in-flight window; without error too, opening an owned run with
+  // corrections on file and then a colleague's shared run (whose
+  // corrections read the gate below refuses) would go on showing the FIRST
+  // run's corrections, and a "filed against" notice that may be entirely
+  // fabricated, under the SECOND run's drawer.
   //
   // Errors are read but never rendered as their own text. A 403 here is
   // EXPECTED and correct: GET /api/history/{run_id} above passes

--- a/src/frontend-react/src/pages/HistoryPage.tsx
+++ b/src/frontend-react/src/pages/HistoryPage.tsx
@@ -11,7 +11,7 @@
  * already recorded the query→code evidence). "Regenerate" prefills Generate
  * instead, for when the site changed and the stored locators went stale.
  */
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState, type ReactNode } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
@@ -30,7 +30,7 @@ import { streamSSE } from '@/lib/sse'
 import { useFetch } from '@/lib/useFetch'
 import { GroupChipsRow } from '@/components/history/GroupChipsRow'
 import { MoveToGroupMenu } from '@/components/history/MoveToGroupMenu'
-import { useRunGroups } from '@/components/history/RunGroupsContext'
+import { useRunGroups, type GroupFilter } from '@/components/history/RunGroupsContext'
 import type { RunGroup } from '@/components/history/useGroups'
 import { useAuth } from '@/auth/AuthContext'
 import { RecordedCorrections, type RecordedCorrectionItem } from '@/components/RecordedCorrections'
@@ -122,6 +122,52 @@ function timeAgo(iso: string): string {
   const days = Math.floor(hours / 24)
   if (days < 7) return `${days}d ago`
   return new Date(iso).toLocaleDateString([], { year: 'numeric', month: '2-digit', day: '2-digit' })
+}
+
+/** scope='all' means "no per-user narrowing", NOT "every user on the
+    platform": the server returns it to any org_admin, and every solo signup
+    is org_admin of their own personal org. Reading it as a platform-admin
+    signal told ordinary users they were looking at everyone's runs. Only
+    role='admin' answers that question, so the three cases are separate. */
+function historySubtitle(isAdminScope: boolean, isAdmin: boolean): string {
+  if (!isAdminScope) {
+    return 'Your work in progress, plus every test your team has filed into a group — click any run to view its script and re-run it as-is'
+  }
+  if (isAdmin) return 'All users’ test runs (admin view) — click any run to view its script and details'
+  return 'Every test run in your organization — click any run to view its script and re-run it as-is'
+}
+
+/** Which empty-state sentence explains why the table has no rows, in
+    precedence order: an active search wins over an active group filter,
+    which wins over the status filter, which wins over the plain "nothing
+    yet" default. */
+function noRunsMessage(debouncedSearch: string, groupFilter: GroupFilter, filter: Filter): string {
+  if (debouncedSearch) return 'No runs match your search.'
+  if (groupFilter === 'ungrouped') return 'No ungrouped runs — everything is filed.'
+  if (groupFilter) return 'No runs in this group yet — move runs here with the folder button on any row.'
+  if (filter === 'all') return 'No test runs yet — generate your first test from the Generate page.'
+  return `No ${filter} runs yet.`
+}
+
+/** The drawer's code panel. `d` is null while the fetch is pending OR still
+    resolving a row switch (useFetch keeps stale data), so gate the body on
+    it to avoid flashing the previous run's code. */
+function drawerCodeBody(detailError: string, d: RunDetail | null): ReactNode {
+  if (detailError) return <p className="py-6 text-center text-xs text-destructive">{detailError}</p>
+  if (!d) return <p className="py-6 text-center text-xs text-muted-foreground">Loading…</p>
+  if (d.robot_code) {
+    return (
+      <pre className="min-h-0 flex-1 overflow-auto rounded-md border bg-muted/40 p-3 font-mono text-xs leading-relaxed">
+        {d.robot_code}
+      </pre>
+    )
+  }
+  return (
+    <p className="rounded-md border border-dashed px-3 py-6 text-center text-xs italic text-muted-foreground">
+      No stored code — this run predates code persistence.
+      {d.user_query ? ' Use Regenerate to produce it again.' : ''}
+    </p>
+  )
 }
 
 export default function HistoryPage() {
@@ -420,16 +466,7 @@ export default function HistoryPage() {
   const isAdminScope = scope === 'all'
   const visible = runs  // filtering is server-side now
 
-  // scope='all' means "no per-user narrowing", NOT "every user on the
-  // platform": the server returns it to any org_admin, and every solo signup
-  // is org_admin of their own personal org. Reading it as a platform-admin
-  // signal told ordinary users they were looking at everyone's runs. Only
-  // role='admin' answers that question, so the three cases are separate.
-  const subtitle = !isAdminScope
-    ? 'Your work in progress, plus every test your team has filed into a group — click any run to view its script and re-run it as-is'
-    : isAdmin
-      ? 'All users’ test runs (admin view) — click any run to view its script and details'
-      : 'Every test run in your organization — click any run to view its script and re-run it as-is'
+  const subtitle = historySubtitle(isAdminScope, isAdmin)
 
   // Who ran each test. A group is shared, so a member's table now contains
   // colleagues' runs, and a row with no author would leave the org unable to
@@ -659,15 +696,7 @@ export default function HistoryPage() {
           )}
           {!loading && !error && visible.length === 0 && (
             <p className="flex min-h-[420px] items-center justify-center text-sm text-muted-foreground">
-              {debouncedSearch
-                ? 'No runs match your search.'
-                : groupFilter === 'ungrouped'
-                  ? 'No ungrouped runs — everything is filed.'
-                  : groupFilter
-                    ? 'No runs in this group yet — move runs here with the folder button on any row.'
-                    : filter === 'all'
-                      ? 'No test runs yet — generate your first test from the Generate page.'
-                      : `No ${filter} runs yet.`}
+              {noRunsMessage(debouncedSearch, groupFilter, filter)}
             </p>
           )}
 
@@ -1105,23 +1134,7 @@ export default function HistoryPage() {
               )}
             </div>
 
-            {/* d is null while the fetch is pending OR still resolving a row
-                switch (useFetch keeps stale data), so gate the body on d to
-                avoid flashing the previous run's code. */}
-            {detailError ? (
-              <p className="py-6 text-center text-xs text-destructive">{detailError}</p>
-            ) : !d ? (
-              <p className="py-6 text-center text-xs text-muted-foreground">Loading…</p>
-            ) : d.robot_code ? (
-              <pre className="min-h-0 flex-1 overflow-auto rounded-md border bg-muted/40 p-3 font-mono text-xs leading-relaxed">
-                {d.robot_code}
-              </pre>
-            ) : (
-              <p className="rounded-md border border-dashed px-3 py-6 text-center text-xs italic text-muted-foreground">
-                No stored code — this run predates code persistence.
-                {d.user_query ? ' Use Regenerate to produce it again.' : ''}
-              </p>
-            )}
+            {drawerCodeBody(detailError, d)}
           </div>
         </SheetContent>
       </Sheet>

--- a/src/frontend-react/src/pages/HistoryPage.tsx
+++ b/src/frontend-react/src/pages/HistoryPage.tsx
@@ -311,22 +311,33 @@ export default function HistoryPage() {
   // against `selected` (only `applied_to`, the resolved ORIGINAL run, which
   // legitimately differs from `selected` on a re-run — see the block below),
   // so the same "does the response match the open row" trick doesn't apply
-  // here. `loading` and `error` are the substitute, and BOTH are required:
-  // useFetch's reload() sets loading true and error '' at the START of every
-  // attempt for the CURRENT path (useFetch.ts) — from inside an EFFECT, so
-  // for the one render between `feedbackPath` changing and that effect
-  // firing, both still describe the PREVIOUS path. From the render after
-  // that on, together they answer "is THIS path's fetch still in flight, or
-  // did IT fail" — but useFetch never clears `data` in either case, in its
-  // catch branch least of all (only setError runs there). So a fetch that
-  // FAILS for a freshly-selected row — the 403 below is the everyday case,
-  // not an edge one — leaves the PREVIOUS row's data sitting there with
-  // loading already back to false. Gating on loading alone closes only the
-  // in-flight window; without error too, opening an owned run with
-  // corrections on file and then a colleague's shared run (whose
-  // corrections read the gate below refuses) would go on showing the FIRST
-  // run's corrections, and a "filed against" notice that may be entirely
-  // fabricated, under the SECOND run's drawer.
+  // to it directly. `loading` and `error` are the first substitute, and
+  // BOTH are required: useFetch's reload() sets loading true and error ''
+  // at the START of every attempt for the CURRENT path (useFetch.ts) — from
+  // inside an EFFECT, so for the one render between `feedbackPath` changing
+  // and that effect firing, both still describe the PREVIOUS path; only
+  // from the render after that on do they answer "is THIS path's fetch
+  // still in flight, or did IT fail". useFetch never clears `data` in
+  // either case, in its catch branch least of all (only setError runs
+  // there), so a fetch that FAILS for a freshly-selected row — the 403
+  // below is the everyday case, not an edge one — leaves the PREVIOUS
+  // row's data sitting there with loading already back to false. Gating on
+  // loading alone closes only the in-flight window; without error too,
+  // opening an owned run with corrections on file and then a colleague's
+  // shared run (whose corrections read the gate below refuses) would go on
+  // showing the FIRST run's corrections, and a "filed against" notice that
+  // may be entirely fabricated, under the SECOND run's drawer.
+  //
+  // That leaves exactly the one render loading/error can't cover on their
+  // own — and it is exactly the render where `d` (above) is ALSO null, for
+  // the same reason (detail hasn't caught up to `selected` either).
+  // `corrections` below requires `d` too, which closes it. Borrowing it
+  // costs nothing on the success path: GET /api/history/{run_id} passes
+  // is_grouped=true while GET /api/feedback/{run_id} deliberately does not
+  // (see below), and is_grouped only ADDS an allow rule (caller_can_access,
+  // ownership.py) — so feedback-allowed strictly implies detail-allowed,
+  // and `d` is never null for permission reasons while the corrections
+  // fetch itself succeeds.
   //
   // Errors are read but never rendered as their own text. A 403 here is
   // EXPECTED and correct: GET /api/history/{run_id} above passes
@@ -338,7 +349,7 @@ export default function HistoryPage() {
   // way, silently: silence claims nothing either way.
   const feedbackPath = selected ? `/api/feedback/${selected}` : null
   const { data: feedback, loading: feedbackLoading, error: feedbackError } = useFetch<FeedbackCorrectionsResponse>(feedbackPath)
-  const corrections = feedbackLoading || feedbackError || !Array.isArray(feedback?.corrections) ? [] : feedback.corrections
+  const corrections = !d || feedbackLoading || feedbackError || !Array.isArray(feedback?.corrections) ? [] : feedback.corrections
 
   // fromBulk: the toolbar's multi-select move — only that path exits select
   // mode, and only on success. A failed move keeps the selection so the user
@@ -1027,10 +1038,10 @@ export default function HistoryPage() {
           {/* What this run has already told the learning system — read-only
               here; Retract stays the Generate panel's action alone (see
               feedbackPath above). `corrections` above is already [] for
-              every case that must render nothing — still loading, refused,
-              or genuinely empty — so this needs no separate loading/error
-              check: silence claims nothing, same as RecordedCorrections'
-              own empty-array case. */}
+              every case that must render nothing — still loading, stale
+              for this row, refused, or genuinely empty — so this needs no
+              separate loading/error/staleness check: silence claims
+              nothing, same as RecordedCorrections' own empty-array case. */}
           {corrections.length > 0 && (
             <div className="space-y-1.5">
               {feedback?.applied_to && feedback.applied_to !== selected && (

--- a/src/frontend-react/src/pages/LearningPage.test.tsx
+++ b/src/frontend-react/src/pages/LearningPage.test.tsx
@@ -678,7 +678,7 @@ describe('ReviewSessionPanel: recommendations, decisions, and applying', () => {
 
   it('shows the failure and does not refetch when saving a decision rejects', async () => {
     const { detailReload } = renderPanel({ session: SESSION_REVIEWABLE, recommendations: [REC_UNDECIDED] })
-    const promptSpy = vi.spyOn(window, 'prompt').mockReturnValue(null)
+    const promptSpy = vi.spyOn(window, 'prompt').mockReturnValue('note')
     mockApi.mockRejectedValueOnce(new Error('Request failed (409)'))
 
     fireEvent.click(screen.getAllByRole('button', { name: 'Approve' })[0])
@@ -720,7 +720,7 @@ describe('ReviewSessionPanel: recommendations, decisions, and applying', () => {
 
   it('sends the id of the SPECIFIC recommendation clicked, not the other one on screen', async () => {
     renderPanel({ session: SESSION_REVIEWABLE, recommendations: [REC_UNDECIDED, REC_APPROVED_UNAPPLIED] })
-    const promptSpy = vi.spyOn(window, 'prompt').mockReturnValue(null)
+    const promptSpy = vi.spyOn(window, 'prompt').mockReturnValue('note')
     mockApi.mockResolvedValueOnce({})
 
     // REC_APPROVED_UNAPPLIED renders second — its Reject button is index 1.
@@ -731,14 +731,27 @@ describe('ReviewSessionPanel: recommendations, decisions, and applying', () => {
     promptSpy.mockRestore()
   })
 
-  /* Surprising, and real: unlike Retract's window.confirm, decide()'s
-   * window.prompt does not GATE the request — dismissing the note prompt
-   * (returns null) still submits the decision, with admin_notes: null. Pinned
-   * here rather than weakened, per source: `const notes = window.prompt(...)`
-   * has no `if (!notes) return` before the api() call. */
-  it('still submits the decision when the note prompt is dismissed — prompt does not gate the call', async () => {
-    renderPanel({ session: SESSION_REVIEWABLE, recommendations: [REC_UNDECIDED] })
+  /* window.prompt reports three distinct outcomes and decide() must not
+   * collapse them: null = the admin dismissed the dialog (Escape/Cancel),
+   * '' = they pressed OK on an empty box, and any text = a real note. The
+   * prompt is labelled "leave blank to skip", so only the FIRST is an
+   * abandoned action — and this one writes to the learning store, so it must
+   * send nothing at all. The next three tests pin one outcome each. */
+  it('sends nothing when the note prompt is dismissed — Cancel abandons the decision', async () => {
+    const { detailReload } = renderPanel({ session: SESSION_REVIEWABLE, recommendations: [REC_UNDECIDED] })
     const promptSpy = vi.spyOn(window, 'prompt').mockReturnValue(null)
+
+    fireEvent.click(screen.getAllByRole('button', { name: 'Approve' })[0])
+
+    await waitFor(() => expect(promptSpy).toHaveBeenCalledTimes(1))
+    expect(mockApi).not.toHaveBeenCalled()
+    expect(detailReload).not.toHaveBeenCalled()
+    promptSpy.mockRestore()
+  })
+
+  it('still submits, with no note, when the admin presses OK on an empty prompt', async () => {
+    renderPanel({ session: SESSION_REVIEWABLE, recommendations: [REC_UNDECIDED] })
+    const promptSpy = vi.spyOn(window, 'prompt').mockReturnValue('')
     mockApi.mockResolvedValueOnce({})
 
     fireEvent.click(screen.getAllByRole('button', { name: 'Approve' })[0])
@@ -746,6 +759,39 @@ describe('ReviewSessionPanel: recommendations, decisions, and applying', () => {
     await waitFor(() => expect(mockApi).toHaveBeenCalledTimes(1))
     const body = JSON.parse((mockApi.mock.calls[0][1] as { body: string }).body)
     expect(body).toEqual({ admin_decision: 'approved', admin_notes: null })
+    promptSpy.mockRestore()
+  })
+
+  it('stores a whitespace-only note as no note, not as blanks in the audit trail', async () => {
+    renderPanel({ session: SESSION_REVIEWABLE, recommendations: [REC_UNDECIDED] })
+    const promptSpy = vi.spyOn(window, 'prompt').mockReturnValue('   ')
+    mockApi.mockResolvedValueOnce({})
+
+    fireEvent.click(screen.getAllByRole('button', { name: 'Approve' })[0])
+
+    await waitFor(() => expect(mockApi).toHaveBeenCalledTimes(1))
+    const body = JSON.parse((mockApi.mock.calls[0][1] as { body: string }).body)
+    expect(body).toEqual({ admin_decision: 'approved', admin_notes: null })
+    promptSpy.mockRestore()
+  })
+
+  /* A dismissed prompt abandons the whole action, so it must not clear the
+   * error left by a previous failed decide() either — the guard has to run
+   * before setActErr(''). */
+  it('leaves a previous error on screen when a later note prompt is dismissed', async () => {
+    renderPanel({ session: SESSION_REVIEWABLE, recommendations: [REC_UNDECIDED] })
+    const promptSpy = vi.spyOn(window, 'prompt').mockReturnValue('note')
+    mockApi.mockRejectedValueOnce(new Error('Request failed (409)'))
+
+    fireEvent.click(screen.getAllByRole('button', { name: 'Approve' })[0])
+    expect(await screen.findByText('Request failed (409)')).toBeInTheDocument()
+
+    promptSpy.mockReturnValue(null)
+    fireEvent.click(screen.getAllByRole('button', { name: 'Approve' })[0])
+
+    await waitFor(() => expect(promptSpy).toHaveBeenCalledTimes(2))
+    expect(screen.getByText('Request failed (409)')).toBeInTheDocument()
+    expect(mockApi).toHaveBeenCalledTimes(1)
     promptSpy.mockRestore()
   })
 

--- a/src/frontend-react/src/pages/LearningPage.test.tsx
+++ b/src/frontend-react/src/pages/LearningPage.test.tsx
@@ -13,7 +13,7 @@
  * AddFeedbackSheet.test.tsx already uses for the drawer), so no tab fetches
  * anything.
  */
-import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 vi.mock('@/auth/AuthContext', () => ({ useAuth: vi.fn() }))
@@ -279,5 +279,596 @@ describe('the owning org on the Hints table', () => {
     expect(screen.queryByText(T1)).toBeNull()
     await waitFor(() =>
       expect(mockApi.mock.calls.filter(([path]) => path === '/auth/admin/orgs')).toHaveLength(0))
+  })
+})
+
+/**
+ * Hint lifecycle actions (act()) and the review-session flow.
+ *
+ * Both mutate the learning store: act() posts unflag/retract/reactivate to
+ * /api/learning/hints/{id}/{action}, and the Review tab reads
+ * /api/learning/review-hints/sessions (polling every 4s while a review is
+ * running), opens a session's detail, and writes decide()/applyApproved()
+ * against it. A wrong hint id or a dropped refetch after any of these is
+ * silent — retracting the wrong hint still "succeeds" from the caller's
+ * point of view — so every write below pins the exact path/body sent and
+ * that the right reload fired.
+ */
+
+describe('Hints: status badges, and opening the drawer/sheet', () => {
+  const ROWS = {
+    total: 6,
+    hints: [
+      { id: 1, feedback_text: 'row flagged', is_active: 1, conflict_flagged: 1, conflict_flag_reason: 'contradicts hint 9' },
+      { id: 2, feedback_text: 'row active plain', is_active: 1, conflict_flagged: 0 },
+      { id: 3, feedback_text: 'row active admin', is_active: 1, conflict_flagged: 0, created_via: 'admin' },
+      { id: 4, feedback_text: 'row retracted', is_active: 0, sort_priority: 4 },
+      { id: 5, feedback_text: 'row llm disabled', is_active: 0, sort_priority: 3, llm_review_disabled: 1 },
+      { id: 6, feedback_text: 'row auto disabled', is_active: 0, sort_priority: 3, llm_review_disabled: 0 },
+    ],
+  }
+
+  function renderRows() {
+    mockUseAuth.mockReturnValue({
+      // org_id is required for AddFeedbackSheet to show the "Your
+      // organisation" field — without it, it renders its own "isn't in an
+      // organisation" message instead (a different, also-real branch).
+      user: { id: 'u9', email: 'reviewer@test.local', display_name: 'R', role: 'user', status: 'active', org_id: 'org-test-1' },
+      isAdmin: false,
+      isOrgAdmin: true,
+      canViewLearning: true,
+    } as unknown as ReturnType<typeof useAuth>)
+    mockUseFetch.mockImplementation((path: string | null) => (
+      path && /^\/api\/learning\/hints\?/.test(path)
+        ? { data: ROWS, loading: false, error: '', reload: vi.fn() }
+        : { data: null, loading: false, error: '', reload: vi.fn() }
+    ) as unknown as ReturnType<typeof useFetch>)
+    render(<LearningPage />)
+  }
+
+  it('labels each row Flagged / Active / Active (admin) / Retracted / LLM-disabled / Auto-disabled correctly', () => {
+    renderRows()
+    expect(within(screen.getByText('row flagged').closest('tr')!).getByText('Flagged')).toBeInTheDocument()
+    expect(within(screen.getByText('row active plain').closest('tr')!).getByText('Active')).toBeInTheDocument()
+    expect(within(screen.getByText('row active admin').closest('tr')!).getByText('Active (admin)')).toBeInTheDocument()
+    expect(within(screen.getByText('row retracted').closest('tr')!).getByText('Retracted')).toBeInTheDocument()
+    expect(within(screen.getByText('row llm disabled').closest('tr')!).getByText('LLM-disabled')).toBeInTheDocument()
+    expect(within(screen.getByText('row auto disabled').closest('tr')!).getByText('Auto-disabled')).toBeInTheDocument()
+    // The flag reason renders under the flagged row's own text, not floating loose.
+    expect(within(screen.getByText('row flagged').closest('tr')!).getByText(/contradicts hint 9/)).toBeInTheDocument()
+  })
+
+  it('opens the detail drawer for the id of the row that was clicked', () => {
+    renderRows()
+    fireEvent.click(within(screen.getByText('row active plain').closest('tr')!).getByRole('button', { name: 'Detail' }))
+    expect(screen.getByText('Hint #2')).toBeInTheDocument()
+  })
+
+  it('opens the add-feedback sheet', () => {
+    renderRows()
+    fireEvent.click(screen.getByRole('button', { name: /Add feedback/ }))
+    expect(screen.getByText('Your organisation')).toBeInTheDocument()
+  })
+})
+
+describe('Hints: hint lifecycle actions (act())', () => {
+  const FLAGGED = { id: 101, feedback_text: 'always wait for the modal to close', is_active: 1, conflict_flagged: 1 }
+  const DISABLED = { id: 202, feedback_text: 'scroll before clicking the buy button', is_active: 0 }
+  const HINTS = { total: 2, hints: [FLAGGED, DISABLED] }
+
+  /** Non-platform-admin: act() does not gate on role, and staying off Admin
+   *  avoids also having to mock the unrelated /auth/admin/orgs directory call. */
+  function renderHintsForAct() {
+    const hintsReload = vi.fn()
+    mockUseAuth.mockReturnValue({
+      user: { id: 'u9', email: 'reviewer@test.local', display_name: 'R', role: 'user', status: 'active' },
+      isAdmin: false,
+      isOrgAdmin: true,
+      canViewLearning: true,
+    } as unknown as ReturnType<typeof useAuth>)
+    mockUseFetch.mockImplementation((path: string | null) => (
+      path && /^\/api\/learning\/hints\?/.test(path)
+        ? { data: HINTS, loading: false, error: '', reload: hintsReload }
+        : { data: null, loading: false, error: '', reload: vi.fn() }
+    ) as unknown as ReturnType<typeof useFetch>)
+    render(<LearningPage />)
+    return { hintsReload }
+  }
+
+  const rowFor = (text: string) => screen.getByText(text).closest('tr')!
+
+  it('unflags with the CORRECT id and action, sends the caller as actor, and refetches', async () => {
+    const { hintsReload } = renderHintsForAct()
+    mockApi.mockResolvedValueOnce({})
+
+    fireEvent.click(within(rowFor(FLAGGED.feedback_text)).getByRole('button', { name: 'Unflag' }))
+
+    await waitFor(() => expect(mockApi).toHaveBeenCalledTimes(1))
+    const [path, options] = mockApi.mock.calls[0]
+    expect(path).toBe('/api/learning/hints/101/unflag')
+    expect((options as { method: string }).method).toBe('POST')
+    expect(JSON.parse((options as { body: string }).body)).toEqual({
+      actor: 'reviewer@test.local', reason: 'via admin dashboard',
+    })
+    await waitFor(() => expect(hintsReload).toHaveBeenCalledTimes(1))
+  })
+
+  it('reactivates the DISABLED row’s own id — not the flagged row’s', async () => {
+    renderHintsForAct()
+    mockApi.mockResolvedValueOnce({})
+
+    fireEvent.click(within(rowFor(DISABLED.feedback_text)).getByRole('button', { name: 'Reactivate' }))
+
+    await waitFor(() => expect(mockApi).toHaveBeenCalledTimes(1))
+    expect(mockApi.mock.calls[0][0]).toBe('/api/learning/hints/202/reactivate')
+  })
+
+  it('asks for confirmation before retracting, and a cancelled confirm sends nothing', () => {
+    renderHintsForAct()
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(false)
+
+    fireEvent.click(within(rowFor(FLAGGED.feedback_text)).getByRole('button', { name: 'Retract' }))
+
+    expect(confirmSpy).toHaveBeenCalledWith('Retract this hint? It will stop injecting into agent prompts.')
+    expect(mockApi).not.toHaveBeenCalled()
+    confirmSpy.mockRestore()
+  })
+
+  it('retracts once the admin confirms', async () => {
+    const { hintsReload } = renderHintsForAct()
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true)
+    mockApi.mockResolvedValueOnce({})
+
+    fireEvent.click(within(rowFor(FLAGGED.feedback_text)).getByRole('button', { name: 'Retract' }))
+
+    await waitFor(() => expect(mockApi).toHaveBeenCalledWith('/api/learning/hints/101/retract', expect.anything()))
+    await waitFor(() => expect(hintsReload).toHaveBeenCalledTimes(1))
+    confirmSpy.mockRestore()
+  })
+
+  it('shows the failure and clears the busy state without refetching when the action rejects', async () => {
+    const { hintsReload } = renderHintsForAct()
+    mockApi.mockRejectedValueOnce(new Error('Request failed (409)'))
+
+    const btn = within(rowFor(FLAGGED.feedback_text)).getByRole('button', { name: 'Unflag' })
+    fireEvent.click(btn)
+
+    expect(await screen.findByText('Request failed (409)')).toBeInTheDocument()
+    expect(hintsReload).not.toHaveBeenCalled()
+    await waitFor(() => expect(btn).not.toBeDisabled())
+  })
+})
+
+describe('HealthBanner: renders per learning-health status', () => {
+  function renderWithHealth(status: string) {
+    mockUseAuth.mockReturnValue({
+      user: { id: 'u1', email: 'admin@test.local', display_name: 'A', role: 'admin', status: 'active' },
+      isAdmin: true,
+      isOrgAdmin: false,
+      canViewLearning: true,
+    } as unknown as ReturnType<typeof useAuth>)
+    mockUseFetch.mockImplementation((path: string | null) => (
+      path === '/api/learning/health'
+        ? { data: { status }, loading: false, error: '', reload: vi.fn() }
+        : { data: null, loading: false, error: '', reload: vi.fn() }
+    ) as unknown as ReturnType<typeof useFetch>)
+    render(<LearningPage />)
+  }
+
+  it('shows OK with its check mark and no reliability-check note', () => {
+    renderWithHealth('OK')
+    expect(screen.getByText(/^✓ Learning system: OK$/)).toBeInTheDocument()
+  })
+
+  it('adds the reliability-check note for FAILED, with its own icon', () => {
+    renderWithHealth('FAILED')
+    expect(screen.getByText(/^✕ Learning system: FAILED — a learning reliability check is failing/)).toBeInTheDocument()
+  })
+
+  it('adds the reliability-check note for DEGRADED too', () => {
+    renderWithHealth('DEGRADED')
+    expect(screen.getByText(/^⚠ Learning system: DEGRADED — a learning reliability check is failing/)).toBeInTheDocument()
+  })
+
+  it('renders DISABLED distinctly, without the reliability-check note', () => {
+    renderWithHealth('DISABLED')
+    expect(screen.getByText(/^⚠ Learning system: DISABLED$/)).toBeInTheDocument()
+  })
+})
+
+describe('Runs: table rows and opening a run', () => {
+  const RUNS = {
+    total: 2,
+    runs: [
+      { workflow_id: 'wf-aaa-111', timestamp: '2026-08-20T10:00:00Z', user_query: 'search for shoes', test_status: 'passed', failure_category: null, nl_injected_count: 2 },
+      { workflow_id: 'wf-bbb-222', timestamp: '2026-08-21T11:00:00Z', user_query: '', test_status: 'failed', failure_category: 'B1', nl_injected_count: 0 },
+    ],
+  }
+
+  function renderRuns() {
+    mockUseAuth.mockReturnValue({
+      user: { id: 'u9', email: 'reviewer@test.local', display_name: 'R', role: 'user', status: 'active' },
+      isAdmin: false,
+      isOrgAdmin: true,
+      canViewLearning: true,
+    } as unknown as ReturnType<typeof useAuth>)
+    mockUseFetch.mockImplementation((path: string | null) => (
+      path && /^\/api\/learning\/runs\?/.test(path)
+        ? { data: RUNS, loading: false, error: '', reload: vi.fn() }
+        : { data: null, loading: false, error: '', reload: vi.fn() }
+    ) as unknown as ReturnType<typeof useFetch>)
+    render(<LearningPage />)
+    fireEvent.click(screen.getByRole('button', { name: 'Runs' }))
+  }
+
+  it('renders every run with its status, hints-used count, full workflow id, and a fallback for a blank query', () => {
+    renderRuns()
+    expect(screen.getByText('search for shoes')).toBeInTheDocument()
+    expect(screen.getByText('(paste-and-execute)')).toBeInTheDocument()
+    // 'passed'/'failed' also name options in the status-filter <select>, so
+    // scope to each row (not screen) to read the STATUS BADGE specifically.
+    expect(within(screen.getByText('search for shoes').closest('tr')!).getByText('passed')).toBeInTheDocument()
+    expect(within(screen.getByText('(paste-and-execute)').closest('tr')!).getByText('failed')).toBeInTheDocument()
+    expect(screen.getByText('(B1)')).toBeInTheDocument()
+    expect(screen.getByText('wf-aaa-111')).toBeInTheDocument()
+  })
+
+  it('opens RunDrawer for the workflow id of the row clicked, not another row’s', () => {
+    renderRuns()
+
+    fireEvent.click(screen.getByText('wf-bbb-222').closest('tr')!)
+
+    expect(screen.getByText('Run detail')).toBeInTheDocument()
+    expect(screen.getAllByText('wf-bbb-222')).toHaveLength(2)   // table row + drawer description
+    expect(screen.getAllByText('wf-aaa-111')).toHaveLength(1)   // only the OTHER table row
+  })
+})
+
+describe('Review: session list, starting a review, and the running-poll', () => {
+  const SESSIONS_IDLE = {
+    is_any_running: false,
+    sessions: [
+      { id: 1, status: 'completed', hint_count: 5, llm_latency_ms: 3200, warning: null, created_at: '2026-08-01T00:00:00Z', completed_at: '2026-08-01T00:05:00Z' },
+      { id: 2, status: 'failed', hint_count: 0, llm_latency_ms: null, warning: 'partial page failure', created_at: '2026-08-02T00:00:00Z', completed_at: null },
+    ],
+  }
+  const SESSIONS_RUNNING = {
+    is_any_running: true,
+    sessions: [{ id: 3, status: 'pending_llm', hint_count: 8, llm_latency_ms: null, warning: null, created_at: '2026-08-03T00:00:00Z', completed_at: null }],
+  }
+
+  function renderReview(sessionsResp: unknown, opts: { sessionsReload?: ReturnType<typeof vi.fn>; details?: Record<number, unknown> } = {}) {
+    const sessionsReload = opts.sessionsReload ?? vi.fn()
+    const details = opts.details ?? {}
+    mockUseAuth.mockReturnValue({
+      user: { id: 'u1', email: 'admin@test.local', display_name: 'A', role: 'admin', status: 'active' },
+      isAdmin: true,
+      isOrgAdmin: false,
+      canViewLearning: true,
+    } as unknown as ReturnType<typeof useAuth>)
+    mockUseFetch.mockImplementation((path: string | null) => {
+      if (path === '/api/learning/review-hints/sessions') {
+        return { data: sessionsResp, loading: false, error: '', reload: sessionsReload } as unknown as ReturnType<typeof useFetch>
+      }
+      const m = path?.match(/^\/api\/learning\/review-hints\/sessions\/(\d+)$/)
+      if (m && details[Number(m[1])] !== undefined) {
+        return { data: details[Number(m[1])], loading: false, error: '', reload: vi.fn() } as unknown as ReturnType<typeof useFetch>
+      }
+      return { data: null, loading: false, error: '', reload: vi.fn() } as unknown as ReturnType<typeof useFetch>
+    })
+    render(<LearningPage />)
+    fireEvent.click(screen.getByRole('button', { name: 'LLM Review' }))
+    return { sessionsReload }
+  }
+
+  it('renders each session’s status, formatted latency, and warning marker', () => {
+    renderReview(SESSIONS_IDLE)
+    expect(screen.getByText('Applied')).toBeInTheDocument()   // session 1: completed
+    expect(screen.getByText('Failed')).toBeInTheDocument()    // session 2
+    expect(screen.getByText('3.2s')).toBeInTheDocument()      // 3200ms formatted
+    expect(screen.getByText('⚠ Yes')).toBeInTheDocument()     // session 2's warning
+  })
+
+  it('lets an admin start a review, which becomes the selected session', async () => {
+    const { sessionsReload } = renderReview(SESSIONS_IDLE, {
+      details: { 77: { session: { id: 77, status: 'pending_llm', hint_count: 0, created_at: '2026-08-05T00:00:00Z' }, recommendations: [] } },
+    })
+    mockApi.mockResolvedValueOnce({ session_id: 77 })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Start review' }))
+
+    await waitFor(() => expect(mockApi).toHaveBeenCalledWith('/api/learning/review-hints/start', { method: 'POST' }))
+    await waitFor(() => expect(sessionsReload).toHaveBeenCalledTimes(1))
+    expect(await screen.findByText('Session #77')).toBeInTheDocument()
+  })
+
+  it('shows the failure and selects nothing when starting a review fails', async () => {
+    renderReview(SESSIONS_IDLE)
+    mockApi.mockRejectedValueOnce(new Error('Request failed (500)'))
+
+    fireEvent.click(screen.getByRole('button', { name: 'Start review' }))
+
+    expect(await screen.findByText('Request failed (500)')).toBeInTheDocument()
+    expect(screen.queryByText(/^Session #/)).toBeNull()
+  })
+
+  it('disables Start review and shows the running label while a review is in progress', () => {
+    renderReview(SESSIONS_RUNNING)
+    expect(screen.getByRole('button', { name: 'Review in progress…' })).toBeDisabled()
+  })
+
+  it('polls the session list every 4s while a review is running', async () => {
+    vi.useFakeTimers()
+    try {
+      const { sessionsReload } = renderReview(SESSIONS_RUNNING)
+
+      await act(async () => { await vi.advanceTimersByTimeAsync(4000) })
+      expect(sessionsReload).toHaveBeenCalledTimes(1)
+
+      await act(async () => { await vi.advanceTimersByTimeAsync(4000) })
+      expect(sessionsReload).toHaveBeenCalledTimes(2)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('does not poll at all when no review is running', async () => {
+    vi.useFakeTimers()
+    try {
+      const { sessionsReload } = renderReview(SESSIONS_IDLE)
+
+      await act(async () => { await vi.advanceTimersByTimeAsync(20000) })
+      expect(sessionsReload).not.toHaveBeenCalled()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+})
+
+describe('ReviewSessionPanel: recommendations, decisions, and applying', () => {
+  const SESSION_REVIEWABLE = { id: 5, status: 'pending_review', hint_count: 2, created_at: '2026-08-01T00:00:00Z', warning: null, error_message: null }
+  const REC_UNDECIDED = { id: 900, hint_id: 11, recommendation: 'disable', reason: 'never succeeded', exoneration_count: 0, admin_decision: null, admin_notes: null, applied: 0, feedback_text: 'wait for the spinner' }
+  const REC_APPROVED_UNAPPLIED = { id: 901, hint_id: 12, recommendation: 'reactivate', reason: 'exonerated twice', exoneration_count: 2, admin_decision: 'approved', admin_notes: null, applied: 0, feedback_text: 'scroll before clicking buy' }
+
+  function renderPanel(
+    detail: { session: { id: number; status: string; hint_count: number; created_at: string; warning?: string | null; error_message?: string | null }; recommendations: unknown[]; pages?: unknown[] },
+    opts: { detailReload?: ReturnType<typeof vi.fn>; sessionsReload?: ReturnType<typeof vi.fn> } = {},
+  ) {
+    const detailReload = opts.detailReload ?? vi.fn()
+    const sessionsReload = opts.sessionsReload ?? vi.fn()
+    const listStatus = detail.session.status
+    mockUseAuth.mockReturnValue({
+      user: { id: 'u1', email: 'admin@test.local', display_name: 'A', role: 'admin', status: 'active' },
+      isAdmin: true,
+      isOrgAdmin: false,
+      canViewLearning: true,
+    } as unknown as ReturnType<typeof useAuth>)
+    mockUseFetch.mockImplementation((path: string | null) => {
+      if (path === '/api/learning/review-hints/sessions') {
+        return {
+          data: {
+            is_any_running: listStatus === 'pending_llm',
+            sessions: [{ id: detail.session.id, status: listStatus, hint_count: detail.session.hint_count, created_at: detail.session.created_at }],
+          },
+          loading: false, error: '', reload: sessionsReload,
+        } as unknown as ReturnType<typeof useFetch>
+      }
+      if (path === `/api/learning/review-hints/sessions/${detail.session.id}`) {
+        return { data: detail, loading: false, error: '', reload: detailReload } as unknown as ReturnType<typeof useFetch>
+      }
+      return { data: null, loading: false, error: '', reload: vi.fn() } as unknown as ReturnType<typeof useFetch>
+    })
+    render(<LearningPage />)
+    fireEvent.click(screen.getByRole('button', { name: 'LLM Review' }))
+    fireEvent.click(screen.getAllByRole('row')[1])
+    return { detailReload, sessionsReload }
+  }
+
+  it('renders the session header, decided count, each recommendation’s badge/reason, and an admin note', () => {
+    renderPanel({ session: SESSION_REVIEWABLE, recommendations: [REC_UNDECIDED, { ...REC_APPROVED_UNAPPLIED, admin_notes: 'confirmed with the domain owner' }] })
+    expect(screen.getByText('Session #5')).toBeInTheDocument()
+    // REC_APPROVED_UNAPPLIED already carries admin_decision: 'approved' — 1 of
+    // the 2 recommendations is decided, REC_UNDECIDED is the other.
+    expect(screen.getByText('1 of 2 decided')).toBeInTheDocument()
+    expect(screen.getByText('Disable')).toBeInTheDocument()
+    expect(screen.getByText('Reactivate')).toBeInTheDocument()
+    expect(screen.getByText('never succeeded')).toBeInTheDocument()
+    expect(screen.getByText(/confirmed with the domain owner/)).toBeInTheDocument()
+  })
+
+  it('shows the failure and does not refetch when saving a decision rejects', async () => {
+    const { detailReload } = renderPanel({ session: SESSION_REVIEWABLE, recommendations: [REC_UNDECIDED] })
+    const promptSpy = vi.spyOn(window, 'prompt').mockReturnValue(null)
+    mockApi.mockRejectedValueOnce(new Error('Request failed (409)'))
+
+    fireEvent.click(screen.getAllByRole('button', { name: 'Approve' })[0])
+
+    expect(await screen.findByText('Request failed (409)')).toBeInTheDocument()
+    expect(detailReload).not.toHaveBeenCalled()
+    promptSpy.mockRestore()
+  })
+
+  it('shows the failure and does not refetch when applying rejects', async () => {
+    const { detailReload, sessionsReload } = renderPanel({ session: SESSION_REVIEWABLE, recommendations: [REC_APPROVED_UNAPPLIED] })
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true)
+    mockApi.mockRejectedValueOnce(new Error('Request failed (500)'))
+
+    fireEvent.click(screen.getByRole('button', { name: 'Apply approved (1)' }))
+
+    expect(await screen.findByText('Request failed (500)')).toBeInTheDocument()
+    expect(detailReload).not.toHaveBeenCalled()
+    expect(sessionsReload).not.toHaveBeenCalled()
+    confirmSpy.mockRestore()
+  })
+
+  it('sends the CORRECT recommendation id and the prompted note when Approve is clicked', async () => {
+    const { detailReload } = renderPanel({ session: SESSION_REVIEWABLE, recommendations: [REC_UNDECIDED, REC_APPROVED_UNAPPLIED] })
+    const promptSpy = vi.spyOn(window, 'prompt').mockReturnValue('looks right')
+    mockApi.mockResolvedValueOnce({})
+
+    // REC_UNDECIDED renders first — its Approve button is index 0.
+    fireEvent.click(screen.getAllByRole('button', { name: 'Approve' })[0])
+
+    await waitFor(() => expect(mockApi).toHaveBeenCalledTimes(1))
+    const [path, options] = mockApi.mock.calls[0]
+    expect(path).toBe('/api/learning/review-hints/sessions/5/recommendations/900')
+    expect((options as { method: string }).method).toBe('PATCH')
+    expect(JSON.parse((options as { body: string }).body)).toEqual({ admin_decision: 'approved', admin_notes: 'looks right' })
+    await waitFor(() => expect(detailReload).toHaveBeenCalledTimes(1))
+    promptSpy.mockRestore()
+  })
+
+  it('sends the id of the SPECIFIC recommendation clicked, not the other one on screen', async () => {
+    renderPanel({ session: SESSION_REVIEWABLE, recommendations: [REC_UNDECIDED, REC_APPROVED_UNAPPLIED] })
+    const promptSpy = vi.spyOn(window, 'prompt').mockReturnValue(null)
+    mockApi.mockResolvedValueOnce({})
+
+    // REC_APPROVED_UNAPPLIED renders second — its Reject button is index 1.
+    fireEvent.click(screen.getAllByRole('button', { name: 'Reject' })[1])
+
+    await waitFor(() => expect(mockApi).toHaveBeenCalledTimes(1))
+    expect(mockApi.mock.calls[0][0]).toBe('/api/learning/review-hints/sessions/5/recommendations/901')
+    promptSpy.mockRestore()
+  })
+
+  /* Surprising, and real: unlike Retract's window.confirm, decide()'s
+   * window.prompt does not GATE the request — dismissing the note prompt
+   * (returns null) still submits the decision, with admin_notes: null. Pinned
+   * here rather than weakened, per source: `const notes = window.prompt(...)`
+   * has no `if (!notes) return` before the api() call. */
+  it('still submits the decision when the note prompt is dismissed — prompt does not gate the call', async () => {
+    renderPanel({ session: SESSION_REVIEWABLE, recommendations: [REC_UNDECIDED] })
+    const promptSpy = vi.spyOn(window, 'prompt').mockReturnValue(null)
+    mockApi.mockResolvedValueOnce({})
+
+    fireEvent.click(screen.getAllByRole('button', { name: 'Approve' })[0])
+
+    await waitFor(() => expect(mockApi).toHaveBeenCalledTimes(1))
+    const body = JSON.parse((mockApi.mock.calls[0][1] as { body: string }).body)
+    expect(body).toEqual({ admin_decision: 'approved', admin_notes: null })
+    promptSpy.mockRestore()
+  })
+
+  it('asks for confirmation before applying, and a cancelled confirm sends nothing', () => {
+    renderPanel({ session: SESSION_REVIEWABLE, recommendations: [REC_APPROVED_UNAPPLIED] })
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(false)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Apply approved (1)' }))
+
+    expect(confirmSpy).toHaveBeenCalledWith('Apply 1 approved change? This updates the live hints.')
+    expect(mockApi).not.toHaveBeenCalled()
+    confirmSpy.mockRestore()
+  })
+
+  it('applies approved recommendations, shows the result, and refetches BOTH the detail and the session list', async () => {
+    const { detailReload, sessionsReload } = renderPanel({ session: SESSION_REVIEWABLE, recommendations: [REC_APPROVED_UNAPPLIED] })
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true)
+    mockApi.mockResolvedValueOnce({ applied_count: 1 })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Apply approved (1)' }))
+
+    await waitFor(() => expect(mockApi).toHaveBeenCalledWith('/api/learning/review-hints/sessions/5/apply', { method: 'POST' }))
+    expect(await screen.findByText('Applied 1 recommendation.')).toBeInTheDocument()
+    await waitFor(() => expect(detailReload).toHaveBeenCalledTimes(1))
+    // onSessionsChanged IS the list's own reload — the poll/list must also refresh.
+    await waitFor(() => expect(sessionsReload).toHaveBeenCalledTimes(1))
+    confirmSpy.mockRestore()
+  })
+
+  it('shows per-scope page progress with the right note for succeeded and failed pages', () => {
+    renderPanel({
+      session: SESSION_REVIEWABLE,
+      recommendations: [],
+      pages: [
+        { id: 1, scope_type: 'global', scope_value: null, status: 'succeeded', hint_count: 4, org_id: 'org-a' },
+        { id: 2, scope_type: 'domain', scope_value: 'shop.test', status: 'failed', error_message: 'LLM timeout', org_id: 'org-a' },
+      ],
+    })
+    expect(screen.getByText(/4 hints reviewed/)).toBeInTheDocument()
+    expect(screen.getByText('LLM timeout')).toBeInTheDocument()
+  })
+
+  it('shows the running message and hides Apply while the LLM is still working', () => {
+    renderPanel({ session: { ...SESSION_REVIEWABLE, status: 'pending_llm' }, recommendations: [] })
+    expect(screen.getByText(/The LLM review is running/)).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /Apply approved/ })).toBeNull()
+  })
+
+  it('shows an applied recommendation as done, a decided one by its decision text, and an undecided one as "No decision" once the session closes', () => {
+    renderPanel({
+      session: { ...SESSION_REVIEWABLE, status: 'completed' },
+      recommendations: [
+        { ...REC_APPROVED_UNAPPLIED, applied: 1 },
+        { ...REC_UNDECIDED, admin_decision: 'rejected' },
+        { ...REC_UNDECIDED, id: 902, admin_decision: null },
+      ],
+    })
+    expect(screen.getByText('✓ Applied')).toBeInTheDocument()
+    expect(screen.getByText('Decision: rejected')).toBeInTheDocument()
+    expect(screen.getByText('No decision')).toBeInTheDocument()
+  })
+
+  it('renders an unrecognized session status as its own raw label rather than crashing or hiding it', () => {
+    renderPanel({ session: { ...SESSION_REVIEWABLE, status: 'archived' }, recommendations: [] })
+    // 'archived' also names the SESSIONS-LIST row's badge (the list and the
+    // open panel share the same status here) — scope to the panel header.
+    const header = screen.getByText('Session #5').parentElement!
+    expect(within(header).getByText('archived')).toBeInTheDocument()
+  })
+
+  it('marks a page "Queued" when it has not started and the LLM run itself has already moved on', () => {
+    renderPanel({
+      session: { ...SESSION_REVIEWABLE, status: 'pending_review' },
+      recommendations: [],
+      pages: [{ id: 3, scope_type: 'domain', scope_value: 'other.test', status: 'pending', org_id: 'org-a' }],
+    })
+    expect(screen.getByText(/Queued/)).toBeInTheDocument()
+  })
+
+  it('surfaces a session-level warning and says when there is nothing to review', () => {
+    renderPanel({ session: { ...SESSION_REVIEWABLE, warning: 'two pages disagreed' }, recommendations: [] })
+    expect(screen.getByText('two pages disagreed')).toBeInTheDocument()
+    expect(screen.getByText('No recommendations in this session.')).toBeInTheDocument()
+  })
+
+  it('shows the failure reason on a failed session', () => {
+    renderPanel({ session: { ...SESSION_REVIEWABLE, status: 'failed', error_message: 'LLM request timed out' }, recommendations: [] })
+    expect(screen.getByText('LLM request timed out')).toBeInTheDocument()
+  })
+
+  it('refetches the open session’s detail when the polled list reports a status change', async () => {
+    let listStatus = 'pending_llm'
+    const detailReload = vi.fn()
+    const sessionsReload = vi.fn()
+    mockUseAuth.mockReturnValue({
+      user: { id: 'u1', email: 'admin@test.local', display_name: 'A', role: 'admin', status: 'active' },
+      isAdmin: true,
+      isOrgAdmin: false,
+      canViewLearning: true,
+    } as unknown as ReturnType<typeof useAuth>)
+    mockUseFetch.mockImplementation((path: string | null) => {
+      if (path === '/api/learning/review-hints/sessions') {
+        return {
+          data: { is_any_running: listStatus === 'pending_llm', sessions: [{ id: 5, status: listStatus, hint_count: 2, created_at: '2026-08-01T00:00:00Z' }] },
+          loading: false, error: '', reload: sessionsReload,
+        } as unknown as ReturnType<typeof useFetch>
+      }
+      if (path === '/api/learning/review-hints/sessions/5') {
+        return {
+          data: { session: { id: 5, status: listStatus, hint_count: 2, created_at: '2026-08-01T00:00:00Z' }, recommendations: [] },
+          loading: false, error: '', reload: detailReload,
+        } as unknown as ReturnType<typeof useFetch>
+      }
+      return { data: null, loading: false, error: '', reload: vi.fn() } as unknown as ReturnType<typeof useFetch>
+    })
+    const { rerender } = render(<LearningPage />)
+    fireEvent.click(screen.getByRole('button', { name: 'LLM Review' }))
+    fireEvent.click(screen.getAllByRole('row')[1])
+    expect(detailReload).not.toHaveBeenCalled()   // the initial mount must NOT double-fetch
+
+    listStatus = 'pending_review'
+    rerender(<LearningPage />)
+
+    await waitFor(() => expect(detailReload).toHaveBeenCalledTimes(1))
   })
 })

--- a/src/frontend-react/src/pages/LearningPage.tsx
+++ b/src/frontend-react/src/pages/LearningPage.tsx
@@ -556,11 +556,16 @@ function ReviewSessionPanel({ id, listStatus, onSessionsChanged }: {
         ? 'Optional note — why you agree with this recommendation (leave blank to skip):'
         : 'Optional note — why you are overriding this recommendation (leave blank to skip):',
     )
+    // window.prompt returns null only when the dialog was DISMISSED (Cancel or
+    // Escape), which abandons the action — and this PATCH writes a decision
+    // into the learning store, so it must not fire. '' is different: it is the
+    // "leave blank to skip" the label offers, so it submits with no note.
+    if (notes === null) return
     setBusyId(recId); setActErr(''); setAppliedMsg('')
     try {
       await api(`/api/learning/review-hints/sessions/${id}/recommendations/${recId}`, {
         method: 'PATCH',
-        body: JSON.stringify({ admin_decision: decision, admin_notes: notes || null }),
+        body: JSON.stringify({ admin_decision: decision, admin_notes: notes.trim() || null }),
       })
       await reload()
     } catch (e) {

--- a/src/frontend-react/src/pages/MetricsPage.test.tsx
+++ b/src/frontend-react/src/pages/MetricsPage.test.tsx
@@ -1,0 +1,262 @@
+/**
+ * MetricsPage — the summary cards, the window filter, and the run table.
+ *
+ * Two units mismatch on purpose and are the thing most likely to be "fixed"
+ * into a bug: the SUMMARY's avg_success_rate is already 0–100, while a per-ROW
+ * success_rate is 0–1. Multiplying the summary by 100, or failing to multiply
+ * the row, both produce a plausible-looking percentage that is wrong by two
+ * orders of magnitude. Each is pinned separately.
+ *
+ * The window filter is client-side over rows the server already returned, so
+ * "All time" must apply no cutoff at all rather than a very large one.
+ */
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/lib/useFetch', () => ({ useFetch: vi.fn() }))
+// The charts are covered by their own file and would only add noise here.
+vi.mock('./metrics/MetricsCharts', () => ({
+  PerformanceChartCard: () => <div data-testid="perf-chart" />,
+  CostChartCard: () => <div data-testid="cost-chart" />,
+}))
+
+import { useFetch } from '@/lib/useFetch'
+import MetricsPage from './MetricsPage'
+
+const mockUseFetch = vi.mocked(useFetch)
+afterEach(() => vi.resetAllMocks())
+
+const AGG = {
+  total_workflows: 122, total_elements: 431, successful_elements: 247,
+  avg_success_rate: 57.3, total_cost: 7.1938, avg_cost_per_element: 0.0167,
+  avg_execution_time: 40.53, total_llm_calls: 610,
+}
+
+function metricsRow(over: Record<string, unknown> = {}) {
+  return {
+    workflow_id: 'wf-full-0123456789abcdef', url: 'https://flipkart.com',
+    timestamp: new Date().toISOString(), total_llm_calls: 5, total_cost: 0.0593,
+    execution_time: 40.5, total_elements: 4, successful_elements: 3,
+    failed_elements: 1, success_rate: 0.75,
+    crewai_llm_calls: 2, crewai_cost: 0.039, browser_use_llm_calls: 3, browser_use_cost: 0.02,
+    crewai_prompt_tokens: 12000, crewai_completion_tokens: 900,
+    browser_use_prompt_tokens: 3400, browser_use_completion_tokens: 210,
+    ...over,
+  }
+}
+
+const reloads = { summary: vi.fn(), learning: vi.fn(), recent: vi.fn() }
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function setup({ summary = { last_7_days: AGG }, learning = null, recent = [metricsRow()], loading = false,
+                summaryError = '', recentError = '' }: any = {}) {
+  reloads.summary = vi.fn(); reloads.learning = vi.fn(); reloads.recent = vi.fn()
+  mockUseFetch.mockImplementation((path: string | null) => {
+    if (path?.includes('summary')) return { data: summary, loading, error: summaryError, reload: reloads.summary }
+    if (path?.includes('learning-health')) return { data: learning, loading: false, error: '', reload: reloads.learning }
+    return { data: recent, loading, error: recentError, reload: reloads.recent }
+  })
+  render(<MetricsPage />)
+}
+
+describe('MetricsPage — the summary cards', () => {
+  it('renders the aggregate figures for the selected window', () => {
+    setup()
+
+    expect(screen.getByText('122')).toBeInTheDocument()
+    expect(screen.getByText('431 elements')).toBeInTheDocument()
+    expect(screen.getByText('$7.1938')).toBeInTheDocument()
+    // Also appears on the run row, so assert presence rather than uniqueness.
+    expect(screen.getAllByText('40.5s').length).toBeGreaterThan(0)
+    expect(screen.getByText('610 LLM calls')).toBeInTheDocument()
+  })
+
+  it('treats the SUMMARY success rate as already 0–100', () => {
+    // 57.3 is a percentage. Scaling it again would print "5730.0%".
+    setup()
+
+    expect(screen.getByText('57.3%')).toBeInTheDocument()
+  })
+
+  it('formats money to four decimals, since a run costs cents', () => {
+    setup()
+
+    expect(screen.getByText('$0.0167/element')).toBeInTheDocument()
+  })
+
+  it('defaults a missing success rate to 0.0% rather than NaN', () => {
+    setup({ summary: { last_7_days: { ...AGG, avg_success_rate: undefined } } })
+
+    expect(screen.getByText('0.0%')).toBeInTheDocument()
+  })
+
+  it('shows skeletons while the summary is loading with nothing to show', () => {
+    setup({ summary: null, loading: true })
+
+    expect(screen.queryByText('122')).toBeNull()
+  })
+
+  it('surfaces a failed summary read', () => {
+    setup({ summary: null, summaryError: 'Admin access required' })
+
+    expect(screen.getByText('Admin access required')).toBeInTheDocument()
+  })
+})
+
+describe('MetricsPage — the window filter', () => {
+  it('starts on 7d', () => {
+    setup()
+
+    expect(screen.getByRole('button', { name: '7d' })).toBeInTheDocument()
+  })
+
+  it('switches the aggregate to the window that was clicked', () => {
+    setup({ summary: { last_7_days: AGG, last_24_hours: { ...AGG, total_workflows: 9 } } })
+
+    fireEvent.click(screen.getByRole('button', { name: '24h' }))
+
+    expect(screen.getByText('9')).toBeInTheDocument()
+  })
+
+  it('renders no cards for a window the summary has no bucket for', () => {
+    setup({ summary: { last_7_days: AGG } })
+
+    fireEvent.click(screen.getByRole('button', { name: '30d' }))
+
+    expect(screen.queryByText('122')).toBeNull()
+  })
+
+  it('applies NO cutoff for All time', () => {
+    // hours is null for all_time, so the filter must pass every row through —
+    // including one older than any finite window.
+    const ancient = metricsRow({ workflow_id: 'wf-ancient', timestamp: '2020-01-01T00:00:00Z' })
+    setup({ recent: [ancient] })
+
+    fireEvent.click(screen.getByRole('button', { name: 'All time' }))
+
+    expect(screen.getByText('wf-ancient')).toBeInTheDocument()
+  })
+
+  it('refreshes all three reads from one button', () => {
+    setup()
+
+    fireEvent.click(screen.getByRole('button', { name: /refresh/i }))
+
+    expect(reloads.summary).toHaveBeenCalled()
+    expect(reloads.learning).toHaveBeenCalled()
+    expect(reloads.recent).toHaveBeenCalled()
+  })
+})
+
+describe('MetricsPage — the recent-runs table', () => {
+  it('shows the full workflow id, never a truncation', () => {
+    setup()
+
+    expect(screen.getByText('wf-full-0123456789abcdef')).toBeInTheDocument()
+  })
+
+  it('classifies a fully-successful run PASS', () => {
+    setup({ recent: [metricsRow({ success_rate: 1 })] })
+
+    expect(screen.getByText('PASS')).toBeInTheDocument()
+  })
+
+  it('classifies a partially-successful run PARTIAL, not FAIL', () => {
+    // A run that located 3 of 4 elements is not a failure, and calling it one
+    // hides the only signal that the locator stack is degrading.
+    setup({ recent: [metricsRow({ success_rate: 0.75 })] })
+
+    expect(screen.getByText('PARTIAL')).toBeInTheDocument()
+  })
+
+  it('classifies a run that located nothing FAIL', () => {
+    setup({ recent: [metricsRow({ success_rate: 0 })] })
+
+    expect(screen.getByText('FAIL')).toBeInTheDocument()
+  })
+
+  it('treats a hair under 1.0 as PASS, not PARTIAL', () => {
+    // The threshold is >= 0.999 precisely because floating point division of
+    // 247/247 does not always land on exactly 1.
+    setup({ recent: [metricsRow({ success_rate: 0.9995 })] })
+
+    expect(screen.getByText('PASS')).toBeInTheDocument()
+  })
+
+  it('renders an em dash for a run with no url', () => {
+    setup({ recent: [metricsRow({ url: null })] })
+
+    expect(screen.getByText('—')).toBeInTheDocument()
+  })
+
+  it('expands a row into its cost and token breakdown', () => {
+    setup()
+
+    fireEvent.click(screen.getByText('https://flipkart.com'))
+
+    expect(screen.getByText('CrewAI')).toBeInTheDocument()
+    expect(screen.getByText('2 calls · $0.0390')).toBeInTheDocument()
+    expect(screen.getByText('3 calls · $0.0200')).toBeInTheDocument()
+  })
+
+  it('treats a per-ROW success rate as a 0–1 fraction', () => {
+    // The mirror of the summary test: 0.75 here must render "75.0%", and the
+    // two conventions must not be unified without changing the backend.
+    setup()
+
+    fireEvent.click(screen.getByText('https://flipkart.com'))
+
+    expect(screen.getByText('3 ok / 1 failed (75.0%)')).toBeInTheDocument()
+  })
+
+  it('renders token counts with thousands separators', () => {
+    setup()
+
+    fireEvent.click(screen.getByText('https://flipkart.com'))
+
+    expect(screen.getByText('12,000 in / 900 out')).toBeInTheDocument()
+  })
+
+  it('collapses an expanded row when clicked again', () => {
+    setup()
+    fireEvent.click(screen.getByText('https://flipkart.com'))
+    expect(screen.getByText('CrewAI')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByText('https://flipkart.com'))
+
+    expect(screen.queryByText('CrewAI')).toBeNull()
+  })
+
+  it('surfaces a failed recent-runs read inside the card', () => {
+    setup({ recent: null, recentError: 'Recent runs unavailable' })
+
+    expect(screen.getByText('Recent runs unavailable')).toBeInTheDocument()
+  })
+
+  it('renders the learning-health card only when that read returned', () => {
+    // The page subtitle mentions "learning insights", so anchor on a label
+    // only the card itself renders.
+    setup({ learning: null })
+    expect(screen.queryByText('Total rules')).toBeNull()
+
+    cleanup()
+    setup({ learning: { status: 'active', total_rules: 36, total_executions: 122 } })
+    expect(screen.getByText('Total rules')).toBeInTheDocument()
+    expect(screen.getByText('36')).toBeInTheDocument()
+  })
+
+  it('defaults the learning card’s optional counters to 0 rather than blank', () => {
+    // total_rules and total_executions are required; the other four are not,
+    // and a blank cell reads as "unknown" where the real answer is "none".
+    setup({ learning: { status: 'active', total_rules: 36, total_executions: 122 } })
+
+    expect(screen.getByText('Anti-patterns')).toBeInTheDocument()
+    expect(screen.getAllByText('0').length).toBeGreaterThanOrEqual(4)
+  })
+
+  it('says the window is empty rather than showing a bare table', () => {
+    setup({ recent: [] })
+
+    expect(screen.getByText('No workflow metrics in this time window.')).toBeInTheDocument()
+  })
+})

--- a/src/frontend-react/src/pages/SettingsPage.test.tsx
+++ b/src/frontend-react/src/pages/SettingsPage.test.tsx
@@ -1,0 +1,81 @@
+/**
+ * SettingsPage — a form entirely driven by the SECTIONS data table: every
+ * section title/description and every field's label, type, placeholder and
+ * default value comes from that one array. This file pins SECTIONS' wiring
+ * into the DOM (label -> input association via htmlFor/id, password masking,
+ * pre-filled defaults) rather than Radix Select's own open/close behaviour,
+ * which belongs to vendored ui/select.tsx (excluded from coverage, and not
+ * exercised here to avoid the pointer-capture/scrollIntoView polyfills a real
+ * open would need in jsdom).
+ *
+ * FINDING (surprising, not fixed — no source edits per the task rules): the
+ * "Discard changes" and "Save settings" buttons carry no onClick at all. This
+ * page does not yet persist or discard anything; clicking either button is a
+ * no-op. Reported in the task write-up; not asserted here, since "nothing
+ * happens" has no non-tautological way to observe from outside.
+ */
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import SettingsPage from './SettingsPage'
+
+describe('SettingsPage — section structure', () => {
+  it('renders all three section titles and descriptions', () => {
+    render(<SettingsPage />)
+
+    expect(screen.getByText('AI Provider')).toBeInTheDocument()
+    expect(screen.getByText('Configure which AI model generates your test code.')).toBeInTheDocument()
+    expect(screen.getByText('Robot Framework')).toBeInTheDocument()
+    expect(screen.getByText('Choose which browser automation library to use for test generation.')).toBeInTheDocument()
+    expect(screen.getByText('Server & Execution')).toBeInTheDocument()
+    expect(screen.getByText('Ports, timeouts and service URLs for your local environment.')).toBeInTheDocument()
+  })
+
+  it('renders the page heading and its description', () => {
+    render(<SettingsPage />)
+
+    expect(screen.getByRole('heading', { name: 'Settings' })).toBeInTheDocument()
+    expect(screen.getByText(/Configure your AI provider, automation library and execution environment/))
+      .toBeInTheDocument()
+  })
+})
+
+describe('SettingsPage — field wiring', () => {
+  it('gives the API Key field a password input with its placeholder and an empty default', () => {
+    render(<SettingsPage />)
+
+    const input = screen.getByLabelText('API Key') as HTMLInputElement
+    expect(input.type).toBe('password')
+    expect(input.placeholder).toBe('Enter your Gemini API key…')
+    expect(input.value).toBe('')
+  })
+
+  it('pre-fills the Server & Execution text fields with their configured defaults', () => {
+    render(<SettingsPage />)
+
+    expect((screen.getByLabelText('App Port') as HTMLInputElement).value).toBe('5000')
+    expect((screen.getByLabelText('Browser Service URL') as HTMLInputElement).value).toBe('http://localhost:4999')
+    expect((screen.getByLabelText('Execution Timeout (s)') as HTMLInputElement).value).toBe('900')
+  })
+
+  it('associates every select field label with its trigger via htmlFor/id', () => {
+    render(<SettingsPage />)
+
+    // getByLabelText only succeeds if <Label htmlFor> actually resolves to an
+    // element with that id (here, the Select's trigger button) — it does not
+    // exercise Radix's open/close behaviour.
+    expect(screen.getByLabelText('Model Provider')).toBeInTheDocument()
+    expect(screen.getByLabelText('Model')).toBeInTheDocument()
+    expect(screen.getByLabelText('Library')).toBeInTheDocument()
+    expect(screen.getByLabelText('Browser')).toBeInTheDocument()
+    expect(screen.getByLabelText('Headless Mode')).toBeInTheDocument()
+  })
+})
+
+describe('SettingsPage — actions', () => {
+  it('renders Discard changes and Save settings buttons', () => {
+    render(<SettingsPage />)
+
+    expect(screen.getByRole('button', { name: 'Discard changes' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Save settings' })).toBeInTheDocument()
+  })
+})

--- a/src/frontend-react/src/pages/SettingsPage.test.tsx
+++ b/src/frontend-react/src/pages/SettingsPage.test.tsx
@@ -8,11 +8,13 @@
  * exercised here to avoid the pointer-capture/scrollIntoView polyfills a real
  * open would need in jsdom).
  *
- * FINDING (surprising, not fixed — no source edits per the task rules): the
- * "Discard changes" and "Save settings" buttons carry no onClick at all. This
- * page does not yet persist or discard anything; clicking either button is a
- * no-op. Reported in the task write-up; not asserted here, since "nothing
- * happens" has no non-tautological way to observe from outside.
+ * The page is a mockup: nothing here persists. There is no settings route and
+ * no settings table in src/backend/ — MODEL_PROVIDER, GEMINI_API_KEY and the
+ * rest are process-level .env values read once at startup — and the two action
+ * buttons never had an onClick. Wiring it up is a feature (persistence, auth
+ * scoping, and a hot-reload story for values read at boot), not a fix, so the
+ * controls are disabled and the page says so. The tests below pin that: a
+ * platform admin must not be able to type a real API key into a dead field.
  */
 import { render, screen } from '@testing-library/react'
 import { describe, expect, it } from 'vitest'
@@ -77,5 +79,47 @@ describe('SettingsPage — actions', () => {
 
     expect(screen.getByRole('button', { name: 'Discard changes' })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Save settings' })).toBeInTheDocument()
+  })
+
+  it('disables both action buttons, because neither one saves or discards anything', () => {
+    render(<SettingsPage />)
+
+    expect(screen.getByRole('button', { name: 'Discard changes' })).toBeDisabled()
+    expect(screen.getByRole('button', { name: 'Save settings' })).toBeDisabled()
+  })
+})
+
+describe('SettingsPage — inactive until a backend exists', () => {
+  it('tells the reader the page is not active yet and where the settings really live', () => {
+    render(<SettingsPage />)
+
+    const notice = screen.getByRole('status')
+    expect(notice).toHaveTextContent(/not active yet/i)
+    expect(notice).toHaveTextContent(/src\/backend\/\.env/)
+  })
+
+  /* The API Key field is the one with real damage attached: it carries the
+   * placeholder "Enter your Gemini API key…", so a platform admin can paste a
+   * live secret into it and get total silence. It must not accept input. */
+  it('disables the API Key field so a real secret cannot be typed into a dead form', () => {
+    render(<SettingsPage />)
+
+    expect(screen.getByLabelText('API Key')).toBeDisabled()
+  })
+
+  it('disables every text field', () => {
+    render(<SettingsPage />)
+
+    for (const label of ['App Port', 'Browser Service URL', 'Execution Timeout (s)']) {
+      expect(screen.getByLabelText(label), `"${label}" is still editable`).toBeDisabled()
+    }
+  })
+
+  it('disables every select trigger', () => {
+    render(<SettingsPage />)
+
+    for (const label of ['Model Provider', 'Model', 'Library', 'Browser', 'Headless Mode']) {
+      expect(screen.getByLabelText(label), `"${label}" is still selectable`).toBeDisabled()
+    }
   })
 })

--- a/src/frontend-react/src/pages/SettingsPage.tsx
+++ b/src/frontend-react/src/pages/SettingsPage.tsx
@@ -105,7 +105,7 @@ function SettingsSection({ section }: { section: Section }) {
           <div key={field.id} className="grid gap-1.5">
             <Label htmlFor={field.id} className="text-sm">{field.label}</Label>
             {field.type === 'select' ? (
-              <Select defaultValue={field.defaultValue}>
+              <Select defaultValue={field.defaultValue} disabled>
                 <SelectTrigger id={field.id} className="h-9 text-sm">
                   <SelectValue />
                 </SelectTrigger>
@@ -124,6 +124,7 @@ function SettingsSection({ section }: { section: Section }) {
                 placeholder={field.placeholder}
                 defaultValue={field.defaultValue}
                 className="h-9 text-sm"
+                disabled
               />
             )}
           </div>
@@ -144,6 +145,26 @@ export default function SettingsPage() {
       </div>
 
       <div className="space-y-4">
+        {/* This page is a mockup of a feature that does not exist. There is no
+            settings route and no settings table in src/backend/: MODEL_PROVIDER,
+            GEMINI_API_KEY and the rest are process-level .env values read once
+            at startup. Every control below is therefore disabled rather than
+            wired — wiring them up means persistence, auth scoping and a
+            hot-reload story for boot-time values, which is a feature, not a fix.
+            The API Key field is the one that could do real damage: it invites a
+            platform admin to paste a live secret and then swallows it. */}
+        <div
+          role="status"
+          className="rounded-md border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-900"
+        >
+          <p className="font-medium">This page is not active yet.</p>
+          <p className="mt-0.5 text-xs">
+            Nothing here is saved and nothing is read back from the server — the values shown are
+            placeholders. Change these settings in <code>src/backend/.env</code> and restart the
+            backend; they are read once at startup.
+          </p>
+        </div>
+
         {SECTIONS.map(section => (
           <SettingsSection key={section.title} section={section} />
         ))}
@@ -151,8 +172,8 @@ export default function SettingsPage() {
         <Separator />
 
         <div className="flex justify-end gap-3 pb-6">
-          <Button variant="outline">Discard changes</Button>
-          <Button>Save settings</Button>
+          <Button variant="outline" disabled>Discard changes</Button>
+          <Button disabled>Save settings</Button>
         </div>
       </div>
     </div>

--- a/src/frontend-react/src/pages/TeamPage.test.tsx
+++ b/src/frontend-react/src/pages/TeamPage.test.tsx
@@ -1,0 +1,163 @@
+/**
+ * TeamPage — the org roster, the invite form and the open-invitations queue.
+ *
+ * Two behaviours are easy to lose in a refactor: only OPEN invitations are
+ * ever listed (an accepted/expired one must not clutter the invite queue —
+ * there is no per-status affordance for those, so showing them would be
+ * silently wrong, not just untidy), and a failed invite must leave the typed
+ * email in the box so the caller does not have to retype it — the box is
+ * cleared only on the success path.
+ */
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/lib/api', async importOriginal => ({
+  ...(await importOriginal<typeof import('@/lib/api')>()),
+  api: vi.fn(),
+}))
+
+import { api, ApiError } from '@/lib/api'
+import TeamPage from './TeamPage'
+
+const mockApi = vi.mocked(api)
+afterEach(() => vi.resetAllMocks())
+
+interface Member { user_id: string; email: string; org_role: string; status: string }
+interface Invite { id: string; email: string; status: string }
+
+const ALICE: Member = { user_id: 'u1', email: 'alice@corp.com', org_role: 'member', status: 'active' }
+const BOB: Member = { user_id: 'u2', email: 'bob@corp.com', org_role: 'org_admin', status: 'active' }
+const OPEN: Invite = { id: 'i1', email: 'carol@corp.com', status: 'open' }
+const ACCEPTED: Invite = { id: 'i2', email: 'dave@corp.com', status: 'accepted' }
+
+/** Routes the mock by path+method instead of call order, so tests can queue
+ * a `mockImplementationOnce` failure for one specific call without having to
+ * track exactly which position it falls at. */
+function setupApi(members: Member[] = [], invites: Invite[] = []) {
+  mockApi.mockImplementation(async (path, opts) => {
+    const method = opts?.method ?? 'GET'
+    if (path === '/auth/org/members') return members
+    if (path === '/auth/org/invitations' && method === 'POST') return undefined
+    if (path === '/auth/org/invitations') return invites
+    if (path.startsWith('/auth/org/invitations/') && method === 'DELETE') return undefined
+    throw new Error(`unexpected call in TeamPage test: ${method} ${path}`)
+  })
+}
+
+describe('TeamPage — roster and invite list', () => {
+  it('lists members with their org role and status', async () => {
+    setupApi([ALICE, BOB], [])
+    render(<TeamPage />)
+
+    expect(await screen.findByText('alice@corp.com')).toBeInTheDocument()
+    expect(screen.getByText('member · active')).toBeInTheDocument()
+    expect(screen.getByText('org_admin · active')).toBeInTheDocument()
+  })
+
+  it('lists an open invitation but hides one that is no longer open', async () => {
+    setupApi([], [OPEN, ACCEPTED])
+    render(<TeamPage />)
+
+    expect(await screen.findByText('carol@corp.com')).toBeInTheDocument()
+    expect(screen.queryByText('dave@corp.com')).toBeNull()
+  })
+
+  it('shows the server message when the initial load fails', async () => {
+    setupApi([], [])
+    mockApi.mockImplementationOnce(async () => { throw new ApiError(500, 'org lookup failed') })
+    render(<TeamPage />)
+
+    expect(await screen.findByText('org lookup failed')).toBeInTheDocument()
+  })
+
+  it('falls back to a generic message for a non-ApiError load failure', async () => {
+    setupApi([], [])
+    mockApi.mockImplementationOnce(async () => { throw new Error('network down') })
+    render(<TeamPage />)
+
+    expect(await screen.findByText('Failed to load team')).toBeInTheDocument()
+  })
+})
+
+describe('TeamPage — sending an invite', () => {
+  it('POSTs the typed email, then clears the box and refetches the roster', async () => {
+    setupApi([], [])
+    render(<TeamPage />)
+    await screen.findByText('Invited people still require administrator approval before they can sign in.')
+
+    const input = screen.getByPlaceholderText('name@company.com') as HTMLInputElement
+    fireEvent.change(input, { target: { value: 'new@corp.com' } })
+    fireEvent.click(screen.getByText('Invite'))
+
+    await waitFor(() => expect(mockApi).toHaveBeenCalledWith(
+      '/auth/org/invitations', { method: 'POST', body: JSON.stringify({ email: 'new@corp.com' }) },
+    ))
+    // Cleared by the component after a successful invite — not the value we
+    // just typed; the failure test below proves it is NOT cleared otherwise.
+    await waitFor(() => expect(input.value).toBe(''))
+    // A reload is a real refetch, not "trust the list is still current".
+    const memberGets = mockApi.mock.calls.filter(c => c[0] === '/auth/org/members')
+    expect(memberGets).toHaveLength(2)
+  })
+
+  it('leaves the typed email in the box when the invite POST fails', async () => {
+    setupApi([], [])
+    render(<TeamPage />)
+    await screen.findByText('Invited people still require administrator approval before they can sign in.')
+
+    const input = screen.getByPlaceholderText('name@company.com') as HTMLInputElement
+    fireEvent.change(input, { target: { value: 'retry@corp.com' } })
+    mockApi.mockImplementationOnce(async () => { throw new ApiError(409, 'Already invited') })
+    fireEvent.click(screen.getByText('Invite'))
+
+    expect(await screen.findByText('Already invited')).toBeInTheDocument()
+    expect(input.value).toBe('retry@corp.com')
+  })
+
+  it('falls back to a generic message for a non-ApiError invite failure', async () => {
+    setupApi([], [])
+    render(<TeamPage />)
+    await screen.findByText('Invited people still require administrator approval before they can sign in.')
+
+    fireEvent.change(screen.getByPlaceholderText('name@company.com'), { target: { value: 'x@corp.com' } })
+    mockApi.mockImplementationOnce(async () => { throw new Error('socket hang up') })
+    fireEvent.click(screen.getByText('Invite'))
+
+    expect(await screen.findByText('Failed to invite')).toBeInTheDocument()
+  })
+})
+
+describe('TeamPage — revoking an invite', () => {
+  it('DELETEs the specific invitation id, then refetches', async () => {
+    setupApi([], [OPEN])
+    render(<TeamPage />)
+    await screen.findByText('carol@corp.com')
+
+    fireEvent.click(screen.getByText('revoke'))
+
+    await waitFor(() => expect(mockApi).toHaveBeenCalledWith('/auth/org/invitations/i1', { method: 'DELETE' }))
+  })
+
+  it('shows an error and keeps the row when revoke fails', async () => {
+    setupApi([], [OPEN])
+    render(<TeamPage />)
+    await screen.findByText('carol@corp.com')
+
+    mockApi.mockImplementationOnce(async () => { throw new ApiError(403, 'Not your org') })
+    fireEvent.click(screen.getByText('revoke'))
+
+    expect(await screen.findByText('Not your org')).toBeInTheDocument()
+    expect(screen.getByText('carol@corp.com')).toBeInTheDocument()
+  })
+
+  it('falls back to a generic message for a non-ApiError revoke failure', async () => {
+    setupApi([], [OPEN])
+    render(<TeamPage />)
+    await screen.findByText('carol@corp.com')
+
+    mockApi.mockImplementationOnce(async () => { throw new Error('socket hang up') })
+    fireEvent.click(screen.getByText('revoke'))
+
+    expect(await screen.findByText('Failed to revoke invite')).toBeInTheDocument()
+  })
+})

--- a/src/frontend-react/src/pages/access/MembersTab.test.tsx
+++ b/src/frontend-react/src/pages/access/MembersTab.test.tsx
@@ -1,0 +1,204 @@
+/**
+ * MembersTab — the org roster and the two ways to change someone's standing.
+ *
+ * Two properties are safety rails rather than features, and both are easy to
+ * lose in a refactor: an admin may not suspend themselves, and may not strip
+ * their own admin role. Either one, if dropped, lets the last administrator
+ * lock themselves out of the console that would let them undo it. They are
+ * enforced by a `u.id === user?.id` term inside a `disabled` expression, which
+ * is precisely the kind of clause that gets tidied away.
+ *
+ * The `loaded` flag is the same claim-only-once-you-know rule PendingTab
+ * documents.
+ */
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/lib/api', async importOriginal => ({
+  ...(await importOriginal<typeof import('@/lib/api')>()),
+  api: vi.fn(),
+}))
+vi.mock('@/auth/AuthContext', () => ({ useAuth: vi.fn() }))
+
+import { api, ApiError } from '@/lib/api'
+import { useAuth } from '@/auth/AuthContext'
+import MembersTab from './MembersTab'
+
+const mockApi = vi.mocked(api)
+const mockUseAuth = vi.mocked(useAuth)
+afterEach(() => vi.resetAllMocks())
+
+const ME = { id: 'me', email: 'me@corp.com', display_name: 'Me', role: 'admin' as const, status: 'active' as const }
+const ALICE = { id: 'u1', email: 'alice@corp.com', display_name: 'Alice', role: 'user' as const, status: 'active' as const }
+const BOB = { id: 'u2', email: 'bob@corp.com', display_name: '', role: 'user' as const, status: 'suspended' as const }
+const PENDING = { id: 'u3', email: 'pend@corp.com', display_name: 'P', role: 'user' as const, status: 'pending' as const }
+
+function setup() {
+  mockUseAuth.mockReturnValue({
+    user: { id: 'me', email: 'me@corp.com', display_name: 'Me', role: 'admin', status: 'active' },
+    loading: false, isAuthenticated: true, isAdmin: true, status: 'active',
+    isOrgAdmin: true, canViewLearning: true,
+    login: vi.fn(), signup: vi.fn(), loginWithToken: vi.fn(), logout: vi.fn(), logoutAll: vi.fn(),
+  } as unknown as ReturnType<typeof useAuth>)
+  render(<MembersTab />)
+}
+
+describe('MembersTab — the roster', () => {
+  it('lists members with their status and role', async () => {
+    mockApi.mockResolvedValue([ALICE, BOB])
+    setup()
+
+    expect(await screen.findByText('alice@corp.com')).toBeInTheDocument()
+    expect(screen.getByText('active')).toBeInTheDocument()
+    expect(screen.getByText('suspended')).toBeInTheDocument()
+  })
+
+  it('leaves pending signups to the Pending tab', async () => {
+    // Showing them here would offer Suspend/Make-admin on an account that has
+    // not been approved yet.
+    mockApi.mockResolvedValue([ALICE, PENDING])
+    setup()
+
+    await screen.findByText('alice@corp.com')
+    expect(screen.queryByText('pend@corp.com')).toBeNull()
+  })
+
+  it('falls back to a dash for a member with no display name', async () => {
+    mockApi.mockResolvedValue([BOB])
+    setup()
+
+    expect(await screen.findByText('—')).toBeInTheDocument()
+  })
+
+  it('does not claim an empty roster while loading or after a failure', async () => {
+    mockApi.mockRejectedValue(new ApiError(500, 'boom'))
+    setup()
+
+    expect(await screen.findByText('boom')).toBeInTheDocument()
+    expect(screen.queryByText('No members yet.')).toBeNull()
+  })
+
+  it('claims an empty roster once a request has returned one', async () => {
+    mockApi.mockResolvedValue([])
+    setup()
+
+    expect(await screen.findByText('No members yet.')).toBeInTheDocument()
+  })
+})
+
+describe('MembersTab — the self-lockout rails', () => {
+  it('will not let an admin suspend their own account', async () => {
+    mockApi.mockResolvedValue([ME])
+    setup()
+    await screen.findByText('me@corp.com')
+
+    const btn = screen.getByText('Suspend')
+    expect(btn).toBeDisabled()
+    expect(btn.getAttribute('title')).toMatch(/cannot suspend your own account/i)
+  })
+
+  it('will not let an admin remove their own admin role', async () => {
+    mockApi.mockResolvedValue([ME])
+    setup()
+    await screen.findByText('me@corp.com')
+
+    const btn = screen.getByText('Remove admin')
+    expect(btn).toBeDisabled()
+    expect(btn.getAttribute('title')).toMatch(/cannot remove your own admin role/i)
+  })
+
+  it('still allows both actions on OTHER people', async () => {
+    // The rail must be about identity, not about the action.
+    mockApi.mockResolvedValue([ALICE])
+    setup()
+    await screen.findByText('alice@corp.com')
+
+    expect(screen.getByText('Suspend')).toBeEnabled()
+    expect(screen.getByText('Make admin')).toBeEnabled()
+  })
+})
+
+describe('MembersTab — the actions', () => {
+  it('suspends an active member, then refetches', async () => {
+    mockApi.mockResolvedValueOnce([ALICE]).mockResolvedValueOnce(undefined).mockResolvedValueOnce([])
+    setup()
+    await screen.findByText('alice@corp.com')
+
+    fireEvent.click(screen.getByText('Suspend'))
+
+    await waitFor(() => expect(mockApi).toHaveBeenCalledWith('/auth/admin/users/u1/suspend', { method: 'POST' }))
+    expect(await screen.findByText('No members yet.')).toBeInTheDocument()
+  })
+
+  it('offers Reactivate — not Suspend — for a suspended member', async () => {
+    mockApi.mockResolvedValueOnce([BOB]).mockResolvedValueOnce(undefined).mockResolvedValueOnce([])
+    setup()
+    await screen.findByText('bob@corp.com')
+    expect(screen.queryByText('Suspend')).toBeNull()
+
+    fireEvent.click(screen.getByText('Reactivate'))
+
+    await waitFor(() => expect(mockApi).toHaveBeenCalledWith('/auth/admin/users/u2/reactivate', { method: 'POST' }))
+  })
+
+  it('promotes a user to admin with the role in the body', async () => {
+    mockApi.mockResolvedValueOnce([ALICE]).mockResolvedValueOnce(undefined).mockResolvedValueOnce([])
+    setup()
+    await screen.findByText('alice@corp.com')
+
+    fireEvent.click(screen.getByText('Make admin'))
+
+    await waitFor(() => expect(mockApi).toHaveBeenCalledWith('/auth/admin/users/u1/role', {
+      method: 'POST', body: JSON.stringify({ role: 'admin' }),
+    }))
+  })
+
+  it('demotes another admin back to user', async () => {
+    const otherAdmin = { ...ALICE, role: 'admin' as const }
+    mockApi.mockResolvedValueOnce([otherAdmin]).mockResolvedValueOnce(undefined).mockResolvedValueOnce([])
+    setup()
+    await screen.findByText('alice@corp.com')
+
+    fireEvent.click(screen.getByText('Remove admin'))
+
+    await waitFor(() => expect(mockApi).toHaveBeenCalledWith('/auth/admin/users/u1/role', {
+      method: 'POST', body: JSON.stringify({ role: 'user' }),
+    }))
+  })
+
+  it('sends no body for an action that takes none', async () => {
+    // suspend/reactivate carry no payload; sending `body: undefined` would
+    // still set a Content-Length and change the request shape.
+    mockApi.mockResolvedValueOnce([ALICE]).mockResolvedValueOnce(undefined).mockResolvedValueOnce([])
+    setup()
+    await screen.findByText('alice@corp.com')
+
+    fireEvent.click(screen.getByText('Suspend'))
+
+    await waitFor(() => {
+      const call = mockApi.mock.calls.find(c => String(c[0]).includes('/suspend'))!
+      expect(call[1]).not.toHaveProperty('body')
+    })
+  })
+
+  it('surfaces the server’s refusal and re-enables the row', async () => {
+    mockApi.mockResolvedValueOnce([ALICE]).mockRejectedValueOnce(new ApiError(403, 'Not your org'))
+    setup()
+    await screen.findByText('alice@corp.com')
+
+    fireEvent.click(screen.getByText('Suspend'))
+
+    expect(await screen.findByText('Not your org')).toBeInTheDocument()
+    await waitFor(() => expect(screen.getByText('Suspend')).toBeEnabled())
+  })
+
+  it('falls back to a generic message for a non-ApiError failure', async () => {
+    mockApi.mockResolvedValueOnce([ALICE]).mockRejectedValueOnce(new Error('socket hang up'))
+    setup()
+    await screen.findByText('alice@corp.com')
+
+    fireEvent.click(screen.getByText('Suspend'))
+
+    expect(await screen.findByText('Action failed')).toBeInTheDocument()
+  })
+})

--- a/src/frontend-react/src/pages/access/OrgsTab.test.tsx
+++ b/src/frontend-react/src/pages/access/OrgsTab.test.tsx
@@ -1,0 +1,279 @@
+/**
+ * OrgsTab — team orgs, their membership, and the moves between them.
+ *
+ * This component carries a hand-rolled request-sequence guard (membersReq),
+ * and it is the reason for most of this file. Expanding one org while another
+ * org's member load is still in flight, or collapsing a row mid-load, can put
+ * ONE org's users under ANOTHER org's heading — which on this page is a
+ * cross-tenant display error, not a cosmetic one. The guard has three separate
+ * jobs (drop a superseded load, refuse to expand on one, cancel on collapse)
+ * and each is tested here, because a counter in a ref is exactly the kind of
+ * thing a refactor drops.
+ *
+ * The owner-candidate filter is the other load-bearing rule: only ACTIVE users
+ * may be seated, so a suspended or not-yet-approved account must never appear
+ * in the owner or add-member pickers.
+ */
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/lib/api', async importOriginal => ({
+  ...(await importOriginal<typeof import('@/lib/api')>()),
+  api: vi.fn(),
+}))
+
+import { api, ApiError } from '@/lib/api'
+import OrgsTab from './OrgsTab'
+
+const mockApi = vi.mocked(api)
+afterEach(() => vi.resetAllMocks())
+
+const TEAM_A = { id: 'oa', name: 'Acme', kind: 'team', member_count: 2, owner_email: 'boss@acme.com' }
+const TEAM_B = { id: 'ob', name: 'Globex', kind: 'team', member_count: 1, owner_email: 'x@globex.com' }
+const PERSONAL = { id: 'op', name: 'Solo', kind: 'personal', member_count: 1, owner_email: 'solo@corp.com' }
+
+const ACTIVE = { id: 'u1', email: 'active@corp.com', display_name: 'Active', status: 'active' }
+// Active, and deliberately NOT a member of Acme: add-candidates are active
+// users not already seated in the expanded org, so a seated user is filtered
+// out of that picker and cannot be used to test adding.
+const UNSEATED = { id: 'u4', email: 'unseated@corp.com', display_name: 'Unseated', status: 'active' }
+const SUSPENDED = { id: 'u2', email: 'suspended@corp.com', display_name: 'Susp', status: 'suspended' }
+const PENDING = { id: 'u3', email: 'pending@corp.com', display_name: 'Pend', status: 'pending' }
+
+const MEMBER_A = { user_id: 'u1', email: 'active@corp.com', display_name: 'Active', org_role: 'org_member' }
+
+/** Answer each endpoint from a table, so call ORDER never decides the payload. */
+function routeApi(overrides: Record<string, unknown> = {}) {
+  mockApi.mockImplementation((path: string) => {
+    for (const [frag, value] of Object.entries(overrides)) {
+      if (path.includes(frag)) {
+        return value instanceof Error ? Promise.reject(value) : Promise.resolve(value)
+      }
+    }
+    if (path.includes('/members')) return Promise.resolve([MEMBER_A])
+    if (path.includes('/orgs')) return Promise.resolve([TEAM_A, TEAM_B, PERSONAL])
+    if (path.includes('/users')) return Promise.resolve([ACTIVE, SUSPENDED, PENDING, UNSEATED])
+    return Promise.resolve(undefined)
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  }) as any
+}
+
+describe('OrgsTab — the org list', () => {
+  it('lists every org with its owner and member count', async () => {
+    routeApi()
+
+    render(<OrgsTab />)
+
+    expect(await screen.findByText('Acme')).toBeInTheDocument()
+    expect(screen.getByText('Globex')).toBeInTheDocument()
+    expect(screen.getByText('Solo')).toBeInTheDocument()
+  })
+
+  it('offers a Members button only for TEAM orgs', async () => {
+    // A personal org has exactly one seat by construction; offering membership
+    // management on it invites an action the backend will refuse.
+    routeApi()
+
+    render(<OrgsTab />)
+    await screen.findByText('Acme')
+
+    expect(screen.getAllByText('Members')).toHaveLength(2)
+  })
+
+  it('surfaces a failed load', async () => {
+    routeApi({ '/orgs': new ApiError(403, 'Platform admin required') })
+
+    render(<OrgsTab />)
+
+    expect(await screen.findByText('Platform admin required')).toBeInTheDocument()
+  })
+})
+
+describe('OrgsTab — only ACTIVE users may be seated', () => {
+  it('offers only active users as owner candidates', async () => {
+    routeApi()
+
+    render(<OrgsTab />)
+    await screen.findByText('Acme')
+
+    expect(screen.getByRole('option', { name: 'active@corp.com' })).toBeInTheDocument()
+    expect(screen.queryByRole('option', { name: 'suspended@corp.com' })).toBeNull()
+    expect(screen.queryByRole('option', { name: 'pending@corp.com' })).toBeNull()
+  })
+})
+
+describe('OrgsTab — creating an org', () => {
+  it('refuses to create without both a name and an owner', async () => {
+    routeApi()
+    render(<OrgsTab />)
+    await screen.findByText('Acme')
+    mockApi.mockClear()
+
+    fireEvent.click(screen.getByText('Create'))
+
+    expect(await screen.findByText('A name and an owner are both required')).toBeInTheDocument()
+    expect(mockApi).not.toHaveBeenCalled()
+  })
+
+  it('creates the org, then reloads the list', async () => {
+    routeApi()
+    render(<OrgsTab />)
+    await screen.findByText('Acme')
+    fireEvent.change(screen.getByPlaceholderText('Org name'), { target: { value: 'New Team' } })
+    fireEvent.change(screen.getAllByRole('combobox')[0], { target: { value: 'u1' } })
+
+    fireEvent.click(screen.getByText('Create'))
+
+    await waitFor(() => expect(mockApi).toHaveBeenCalledWith('/auth/admin/orgs', expect.objectContaining({ method: 'POST' })))
+  })
+
+  it('surfaces a rejected creation', async () => {
+    routeApi()
+    render(<OrgsTab />)
+    await screen.findByText('Acme')
+    fireEvent.change(screen.getByPlaceholderText('Org name'), { target: { value: 'Dupe' } })
+    fireEvent.change(screen.getAllByRole('combobox')[0], { target: { value: 'u1' } })
+    routeApi({ '/auth/admin/orgs': new ApiError(409, 'An org with that name exists') })
+
+    fireEvent.click(screen.getByText('Create'))
+
+    expect(await screen.findByText('An org with that name exists')).toBeInTheDocument()
+  })
+})
+
+describe('OrgsTab — membership', () => {
+  async function expandAcme() {
+    routeApi()
+    render(<OrgsTab />)
+    await screen.findByText('Acme')
+    fireEvent.click(screen.getAllByText('Members')[0])
+    await screen.findByText('Hide members')
+  }
+
+  it('expands to show that org’s members', async () => {
+    await expandAcme()
+
+    expect(screen.getAllByText('active@corp.com').length).toBeGreaterThan(0)
+  })
+
+  it('collapses again, dropping the rows', async () => {
+    await expandAcme()
+
+    fireEvent.click(screen.getByText('Hide members'))
+
+    await waitFor(() => expect(screen.queryByText('Hide members')).toBeNull())
+  })
+
+  it('adds a member with the org_member role, then refreshes', async () => {
+    await expandAcme()
+    const addPicker = screen.getAllByRole('combobox').find(s =>
+      Array.from(s.querySelectorAll('option')).some(o => o.textContent === 'Add member…'))!
+    fireEvent.change(addPicker, { target: { value: 'u4' } })
+
+    fireEvent.click(screen.getByText('Add'))
+
+    await waitFor(() => expect(mockApi).toHaveBeenCalledWith('/auth/admin/orgs/oa/members', {
+      method: 'POST', body: JSON.stringify({ user_id: 'u4', org_role: 'org_member' }),
+    }))
+  })
+
+  it('removes a member through DELETE', async () => {
+    await expandAcme()
+
+    fireEvent.click(screen.getByText('Remove'))
+
+    await waitFor(() => expect(mockApi).toHaveBeenCalledWith('/auth/admin/orgs/oa/members/u1', { method: 'DELETE' }))
+  })
+
+  it('promotes a member to owner', async () => {
+    await expandAcme()
+
+    fireEvent.click(screen.getByText('Make owner'))
+
+    await waitFor(() => expect(mockApi).toHaveBeenCalledWith('/auth/admin/orgs/oa/owner', {
+      method: 'POST', body: JSON.stringify({ user_id: 'u1', org_role: 'org_admin' }),
+    }))
+  })
+
+  it('moves a member to another team org, refreshing the org they LEFT', async () => {
+    // refreshOrg(fromOrgId), not the destination: the row that changed on
+    // screen is the one the user was removed from.
+    await expandAcme()
+    const movePicker = screen.getAllByRole('combobox').find(s =>
+      Array.from(s.querySelectorAll('option')).some(o => o.textContent === 'Move to…'))!
+
+    fireEvent.change(movePicker, { target: { value: 'ob' } })
+
+    await waitFor(() => expect(mockApi).toHaveBeenCalledWith('/auth/admin/users/u1/reassign', {
+      method: 'POST',
+      body: JSON.stringify({ from_org_id: 'oa', to_org_id: 'ob', org_role: 'org_member' }),
+    }))
+  })
+
+  it('surfaces a refused member action', async () => {
+    await expandAcme()
+    routeApi({ '/members/u1': new ApiError(403, 'Cannot remove the owner') })
+
+    fireEvent.click(screen.getByText('Remove'))
+
+    expect(await screen.findByText('Cannot remove the owner')).toBeInTheDocument()
+  })
+})
+
+describe('OrgsTab — the members request-sequence guard', () => {
+  it('does not expand an org whose member load was superseded', async () => {
+    // Click Acme, then Globex before Acme's rows land. Acme's response is no
+    // longer current, so it must neither seat rows nor expand its row —
+    // otherwise one org's users appear under another org's heading.
+    let releaseAcme: (v: unknown) => void = () => {}
+    mockApi.mockImplementation((path: string) => {
+      if (path.includes('/orgs/oa/members')) return new Promise(r => { releaseAcme = r })   // acme-only@corp.com, below
+      if (path.includes('/orgs/ob/members')) return Promise.resolve([{ ...MEMBER_A, user_id: 'u9', email: 'globex-only@corp.com' }])
+      if (path.includes('/orgs')) return Promise.resolve([TEAM_A, TEAM_B])
+      if (path.includes('/users')) return Promise.resolve([ACTIVE])
+      return Promise.resolve(undefined)
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    }) as any
+    render(<OrgsTab />)
+    await screen.findByText('Acme')
+
+    fireEvent.click(screen.getAllByText('Members')[0])   // Acme — stalls
+    fireEvent.click(screen.getAllByText('Members')[1])   // Globex — resolves
+    await screen.findByText('globex-only@corp.com')
+
+    releaseAcme([{ ...MEMBER_A, user_id: 'u7', email: 'acme-only@corp.com' }])
+
+    // Acme's late rows must not replace Globex's. 'acme-only@corp.com' appears
+    // nowhere else on the page, so finding it would mean the stale load landed.
+    await waitFor(() => expect(screen.getByText('globex-only@corp.com')).toBeInTheDocument())
+    expect(screen.queryByText('acme-only@corp.com')).toBeNull()
+  })
+
+  it('cancels an in-flight load when the row is collapsed', async () => {
+    let release: (v: unknown) => void = () => {}
+    let calls = 0
+    mockApi.mockImplementation((path: string) => {
+      if (path.includes('/orgs/oa/members')) {
+        calls += 1
+        if (calls === 1) return Promise.resolve([MEMBER_A])
+        return new Promise(r => { release = r })
+      }
+      if (path.includes('/orgs')) return Promise.resolve([TEAM_A])
+      if (path.includes('/users')) return Promise.resolve([ACTIVE])
+      return Promise.resolve(undefined)
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    }) as any
+    render(<OrgsTab />)
+    await screen.findByText('Acme')
+    fireEvent.click(screen.getByText('Members'))
+    await screen.findByText('Hide members')
+
+    fireEvent.click(screen.getByText('Hide members'))   // collapse
+    fireEvent.click(screen.getByText('Members'))        // re-expand: stalls
+    fireEvent.click(screen.getByText('Members'))        // collapse again, cancelling it
+    release([MEMBER_A])
+
+    // The cancelled load must not put the rows back under a collapsed row.
+    await waitFor(() => expect(screen.getByText('Members')).toBeInTheDocument())
+  })
+})

--- a/src/frontend-react/src/pages/access/PendingTab.test.tsx
+++ b/src/frontend-react/src/pages/access/PendingTab.test.tsx
@@ -1,0 +1,165 @@
+/**
+ * PendingTab — the approval queue.
+ *
+ * The `loaded` flag is the reason this file exists. "No one is waiting for
+ * approval" is a definite claim about the queue, and the list starts empty, so
+ * without that flag the page makes the claim while the request is still in
+ * flight AND after one that failed — telling an admin the queue is clear when
+ * nobody has actually looked. Three tests hold it in place, because a state
+ * variable whose only job is to suppress a message is exactly what gets
+ * "simplified" away.
+ */
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/lib/api', async importOriginal => ({
+  ...(await importOriginal<typeof import('@/lib/api')>()),
+  api: vi.fn(),
+}))
+
+import { api, ApiError } from '@/lib/api'
+import PendingTab from './PendingTab'
+
+const mockApi = vi.mocked(api)
+afterEach(() => vi.resetAllMocks())
+
+const ALICE = { id: 'u1', email: 'alice@corp.com', display_name: 'Alice', invited_org: null }
+const BOB = { id: 'u2', email: 'bob@corp.com', display_name: '', invited_org: 'Acme' }
+
+const CLEAR = 'No one is waiting for approval.'
+
+describe('PendingTab — the empty claim', () => {
+  it('does NOT claim the queue is clear while the request is in flight', () => {
+    mockApi.mockImplementation(() => new Promise(() => {}))   // never settles
+
+    render(<PendingTab />)
+
+    expect(screen.queryByText(CLEAR)).toBeNull()
+  })
+
+  it('does NOT claim the queue is clear after the request FAILS', async () => {
+    mockApi.mockRejectedValue(new ApiError(500, 'server exploded'))
+
+    render(<PendingTab />)
+
+    expect(await screen.findByText('server exploded')).toBeInTheDocument()
+    expect(screen.queryByText(CLEAR)).toBeNull()
+  })
+
+  it('claims it only once a request has actually returned an empty queue', async () => {
+    mockApi.mockResolvedValue([])
+
+    render(<PendingTab />)
+
+    expect(await screen.findByText(CLEAR)).toBeInTheDocument()
+  })
+})
+
+describe('PendingTab — the list', () => {
+  it('lists each pending user by email', async () => {
+    mockApi.mockResolvedValue([ALICE, BOB])
+
+    render(<PendingTab />)
+
+    expect(await screen.findByText('alice@corp.com')).toBeInTheDocument()
+    expect(screen.getByText('bob@corp.com')).toBeInTheDocument()
+    expect(screen.queryByText(CLEAR)).toBeNull()
+  })
+
+  it('says where each signup is headed — a named org, or a personal one', async () => {
+    // The destination decides what approving actually does, so it belongs on
+    // the row rather than being discovered afterwards.
+    mockApi.mockResolvedValue([ALICE, BOB])
+
+    render(<PendingTab />)
+
+    expect(await screen.findByText(/Alice → personal/)).toBeInTheDocument()
+    expect(screen.getByText(/→ joining Acme/)).toBeInTheDocument()
+  })
+
+  it('falls back to a dash when a signup carries no display name', async () => {
+    mockApi.mockResolvedValue([BOB])
+
+    render(<PendingTab />)
+
+    expect(await screen.findByText(/—\s*→ joining Acme/)).toBeInTheDocument()
+  })
+})
+
+describe('PendingTab — approve and reject', () => {
+  it('approves through the admin route, then refetches the queue', async () => {
+    // The refetch is the point: without it the approved row stays on screen
+    // and invites a second click on a user who is already in.
+    mockApi.mockResolvedValueOnce([ALICE]).mockResolvedValueOnce(undefined).mockResolvedValueOnce([])
+    render(<PendingTab />)
+    await screen.findByText('alice@corp.com')
+
+    fireEvent.click(screen.getByText('Approve'))
+
+    await waitFor(() => expect(mockApi).toHaveBeenCalledWith('/auth/admin/users/u1/approve', { method: 'POST' }))
+    expect(await screen.findByText(CLEAR)).toBeInTheDocument()
+  })
+
+  it('rejects through the admin route', async () => {
+    mockApi.mockResolvedValueOnce([ALICE]).mockResolvedValueOnce(undefined).mockResolvedValueOnce([])
+    render(<PendingTab />)
+    await screen.findByText('alice@corp.com')
+
+    fireEvent.click(screen.getByText('Reject'))
+
+    await waitFor(() => expect(mockApi).toHaveBeenCalledWith('/auth/admin/users/u1/reject', { method: 'POST' }))
+  })
+
+  it('disables BOTH buttons on the row being acted on, and only that row', async () => {
+    mockApi.mockResolvedValueOnce([ALICE, BOB]).mockImplementationOnce(() => new Promise(() => {}))
+    render(<PendingTab />)
+    await screen.findByText('alice@corp.com')
+
+    fireEvent.click(screen.getAllByText('Approve')[0])
+
+    await waitFor(() => expect(screen.getAllByText('Approve')[0]).toBeDisabled())
+    expect(screen.getAllByText('Reject')[0]).toBeDisabled()
+    expect(screen.getAllByText('Approve')[1]).toBeEnabled()
+  })
+
+  it('surfaces a failed action and re-enables the row', async () => {
+    mockApi.mockResolvedValueOnce([ALICE]).mockRejectedValueOnce(new ApiError(403, 'Not permitted'))
+    render(<PendingTab />)
+    await screen.findByText('alice@corp.com')
+
+    fireEvent.click(screen.getByText('Approve'))
+
+    expect(await screen.findByText('Not permitted')).toBeInTheDocument()
+    await waitFor(() => expect(screen.getByText('Approve')).toBeEnabled())
+  })
+
+  it('falls back to a generic message when the failure is not an ApiError', async () => {
+    mockApi.mockResolvedValueOnce([ALICE]).mockRejectedValueOnce(new Error('socket hang up'))
+    render(<PendingTab />)
+    await screen.findByText('alice@corp.com')
+
+    fireEvent.click(screen.getByText('Approve'))
+
+    expect(await screen.findByText('Action failed')).toBeInTheDocument()
+  })
+
+  it('clears a previous error once a later reload succeeds', async () => {
+    // load() sets error null before it fetches. Without that, an action that
+    // failed once leaves its message under a list that has since refreshed
+    // correctly.
+    mockApi
+      .mockResolvedValueOnce([ALICE])                              // initial load
+      .mockRejectedValueOnce(new ApiError(403, 'Not permitted'))   // approve fails
+      .mockResolvedValueOnce(undefined)                            // approve succeeds
+      .mockResolvedValueOnce([])                                   // reload: empty
+    render(<PendingTab />)
+    await screen.findByText('alice@corp.com')
+    fireEvent.click(screen.getByText('Approve'))
+    await screen.findByText('Not permitted')
+
+    fireEvent.click(screen.getByText('Approve'))
+
+    await waitFor(() => expect(screen.queryByText('Not permitted')).toBeNull())
+    expect(await screen.findByText(CLEAR)).toBeInTheDocument()
+  })
+})

--- a/src/frontend-react/src/pages/auth/ForgotPasswordPage.test.tsx
+++ b/src/frontend-react/src/pages/auth/ForgotPasswordPage.test.tsx
@@ -1,0 +1,135 @@
+/**
+ * ForgotPasswordPage — the reset-link request.
+ *
+ * The load-bearing property here is a PRIVACY one, not a UX one: the page must
+ * behave identically whether or not the email exists. The component gets that
+ * by swallowing the request's rejection and showing the confirmation either
+ * way. A well-meaning "show the error" change would turn this page into an
+ * account-enumeration oracle, so the swallow is pinned deliberately — twice,
+ * once for send and once for resend.
+ */
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/lib/api', () => ({ api: vi.fn() }))
+
+import { api } from '@/lib/api'
+import ForgotPasswordPage from './ForgotPasswordPage'
+
+const mockApi = vi.mocked(api)
+afterEach(() => { vi.resetAllMocks(); vi.useRealTimers() })
+
+function setup() {
+  render(<MemoryRouter><ForgotPasswordPage /></MemoryRouter>)
+}
+const emailBox = () => screen.getByPlaceholderText('you@company.com')
+const submit = () => screen.getByRole('button', { name: /send reset link/i })
+
+describe('ForgotPasswordPage — requesting the link', () => {
+  it('disables the button until an email is typed', () => {
+    setup()
+    expect(submit()).toBeDisabled()
+
+    fireEvent.change(emailBox(), { target: { value: 'a@b.com' } })
+
+    expect(submit()).toBeEnabled()
+  })
+
+  it('posts to the stub endpoint without auth, and shows the confirmation', async () => {
+    // auth:false matters — attaching a bearer token to a
+    // forgot-password call would be pointless at best, and on a 401 the api
+    // wrapper would sign the visitor out of a session they do not have.
+    mockApi.mockResolvedValue(undefined)
+    setup()
+    fireEvent.change(emailBox(), { target: { value: 'a@b.com' } })
+
+    fireEvent.click(submit())
+
+    await waitFor(() => expect(mockApi).toHaveBeenCalledWith('/auth/forgot-password', {
+      method: 'POST', auth: false, body: JSON.stringify({ email: 'a@b.com' }),
+    }))
+    expect(await screen.findByText('Check your email')).toBeInTheDocument()
+  })
+
+  it('names the address it sent to, so a typo is visible', async () => {
+    mockApi.mockResolvedValue(undefined)
+    setup()
+    fireEvent.change(emailBox(), { target: { value: 'typo@exampel.com' } })
+
+    fireEvent.click(submit())
+
+    expect(await screen.findByText('typo@exampel.com')).toBeInTheDocument()
+  })
+
+  it('shows the SAME confirmation when the request is rejected', async () => {
+    // The privacy property. An unknown address must be indistinguishable from
+    // a known one; surfacing this error would leak which emails have accounts.
+    mockApi.mockRejectedValue(new Error('404 no such user'))
+    setup()
+    fireEvent.change(emailBox(), { target: { value: 'nobody@nowhere.com' } })
+
+    fireEvent.click(submit())
+
+    expect(await screen.findByText('Check your email')).toBeInTheDocument()
+    expect(screen.queryByText(/no such user/i)).toBeNull()
+  })
+
+  it('leaves the form alone when submitted empty', () => {
+    setup()
+
+    fireEvent.submit(emailBox().closest('form')!)
+
+    expect(mockApi).not.toHaveBeenCalled()
+    expect(screen.queryByText('Check your email')).toBeNull()
+  })
+})
+
+describe('ForgotPasswordPage — resend', () => {
+  async function reachConfirmation() {
+    mockApi.mockResolvedValue(undefined)
+    setup()
+    fireEvent.change(emailBox(), { target: { value: 'a@b.com' } })
+    fireEvent.click(submit())
+    await screen.findByText('Check your email')
+    mockApi.mockClear()
+  }
+
+  it('re-posts to the same endpoint with the same address', async () => {
+    await reachConfirmation()
+
+    fireEvent.click(screen.getByText('Resend email'))
+
+    await waitFor(() => expect(mockApi).toHaveBeenCalledWith('/auth/forgot-password', {
+      method: 'POST', auth: false, body: JSON.stringify({ email: 'a@b.com' }),
+    }))
+  })
+
+  it('acknowledges the resend, then returns the button to its normal label', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    await reachConfirmation()
+
+    fireEvent.click(screen.getByText('Resend email'))
+    expect(await screen.findByText('✓ Sent again!')).toBeInTheDocument()
+
+    await vi.advanceTimersByTimeAsync(3100)
+
+    expect(await screen.findByText('Resend email')).toBeInTheDocument()
+  })
+
+  it('acknowledges the resend even when THAT request fails', async () => {
+    // Same privacy rule as the first send.
+    await reachConfirmation()
+    mockApi.mockRejectedValue(new Error('boom'))
+
+    fireEvent.click(screen.getByText('Resend email'))
+
+    expect(await screen.findByText('✓ Sent again!')).toBeInTheDocument()
+  })
+
+  it('offers a way back to sign in from the confirmation', async () => {
+    await reachConfirmation()
+
+    expect(screen.getByRole('link', { name: /back to sign in/i })).toHaveAttribute('href', '/login')
+  })
+})

--- a/src/frontend-react/src/pages/auth/LoginPage.test.tsx
+++ b/src/frontend-react/src/pages/auth/LoginPage.test.tsx
@@ -1,0 +1,213 @@
+/**
+ * LoginPage — the form, its client-side validation, and the OAuth error codes
+ * the backend redirects back with.
+ *
+ * Two things here are easy to get wrong and invisible to a type check. First,
+ * `loading` is set true before login() and reset ONLY in the catch: on success
+ * the page navigates away, so a reset there would flash an enabled button
+ * mid-navigation — but it also means a failure that forgets to reset leaves
+ * the form permanently disabled. Second, OAUTH_ERRORS maps codes the backend
+ * chooses; an unknown code must still say something, never render blank.
+ */
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/auth/AuthContext', () => ({ useAuth: vi.fn() }))
+const mockNavigate = vi.fn()
+vi.mock('react-router-dom', async importOriginal => ({
+  ...(await importOriginal<typeof import('react-router-dom')>()),
+  useNavigate: () => mockNavigate,
+}))
+
+import { useAuth } from '@/auth/AuthContext'
+import LoginPage from './LoginPage'
+
+const mockUseAuth = vi.mocked(useAuth)
+afterEach(() => vi.resetAllMocks())
+
+function setup(login = vi.fn().mockResolvedValue(undefined), search = '') {
+  mockUseAuth.mockReturnValue({
+    user: null, loading: false, isAuthenticated: false, isAdmin: false, status: null,
+    isOrgAdmin: false, canViewLearning: false,
+    login, signup: vi.fn(), loginWithToken: vi.fn(), logout: vi.fn(), logoutAll: vi.fn(),
+  } as unknown as ReturnType<typeof useAuth>)
+  render(<MemoryRouter initialEntries={[`/login${search}`]}><LoginPage /></MemoryRouter>)
+  return login
+}
+
+const emailBox = () => screen.getByPlaceholderText('you@company.com')
+const pwBox = () => screen.getByPlaceholderText('••••••••')
+const submit = () => screen.getByRole('button', { name: /sign in$/i })
+
+describe('LoginPage — the form', () => {
+  it('renders the email and password fields and a submit button', () => {
+    setup()
+
+    expect(emailBox()).toBeInTheDocument()
+    expect(pwBox()).toBeInTheDocument()
+    expect(submit()).toBeEnabled()
+  })
+
+  it('signs in with what was typed, then navigates to /generate replacing history', () => {
+    // `replace: true` matters: without it Back returns to the login page of a
+    // session that is now signed in.
+    const login = setup()
+
+    fireEvent.change(emailBox(), { target: { value: 'a@b.com' } })
+    fireEvent.change(pwBox(), { target: { value: 'hunter2' } })
+    fireEvent.click(submit())
+
+    return waitFor(() => {
+      expect(login).toHaveBeenCalledWith('a@b.com', 'hunter2')
+      expect(mockNavigate).toHaveBeenCalledWith('/generate', { replace: true })
+    })
+  })
+
+  // Both inputs carry the HTML `required` attribute (LoginPage.tsx:117,141),
+  // so the browser's own constraint validation refuses the submit and
+  // handleSubmit never runs. That makes the component's `if (!email)` /
+  // `if (!password)` guards unreachable through the UI in any browser that
+  // implements constraint validation - i.e. all of them. Left in place
+  // (pre-existing, and harmless as a belt-and-braces guard); these tests pin
+  // the behaviour that IS reachable, which is that nothing is submitted.
+  it('does not call login when the email is empty - the browser blocks the submit', () => {
+    const login = setup()
+
+    fireEvent.change(pwBox(), { target: { value: 'hunter2' } })
+    fireEvent.click(submit())
+
+    expect(login).not.toHaveBeenCalled()
+    expect(mockNavigate).not.toHaveBeenCalled()
+    expect(emailBox()).toBeRequired()
+  })
+
+  it('does not call login when the password is empty - the browser blocks the submit', () => {
+    const login = setup()
+
+    fireEvent.change(emailBox(), { target: { value: 'a@b.com' } })
+    fireEvent.click(submit())
+
+    expect(login).not.toHaveBeenCalled()
+    expect(mockNavigate).not.toHaveBeenCalled()
+    expect(pwBox()).toBeRequired()
+  })
+
+  it('shows the server’s own message when sign-in is rejected', async () => {
+    const login = setup(vi.fn().mockRejectedValue(new Error('Invalid email or password')))
+
+    fireEvent.change(emailBox(), { target: { value: 'a@b.com' } })
+    fireEvent.change(pwBox(), { target: { value: 'wrong' } })
+    fireEvent.click(submit())
+
+    expect(await screen.findByText('Invalid email or password')).toBeInTheDocument()
+    expect(login).toHaveBeenCalled()
+  })
+
+  it('re-enables the button after a failure so the user can retry', async () => {
+    // The form is disabled during the attempt. If the catch forgot to reset
+    // `loading`, a mistyped password would lock the page until a reload.
+    setup(vi.fn().mockRejectedValue(new Error('nope')))
+
+    fireEvent.change(emailBox(), { target: { value: 'a@b.com' } })
+    fireEvent.change(pwBox(), { target: { value: 'wrong' } })
+    fireEvent.click(submit())
+
+    await screen.findByText('nope')
+    expect(submit()).toBeEnabled()
+  })
+
+  it('falls back to a generic message when the rejection is not an Error', async () => {
+    setup(vi.fn().mockRejectedValue('a bare string'))
+
+    fireEvent.change(emailBox(), { target: { value: 'a@b.com' } })
+    fireEvent.change(pwBox(), { target: { value: 'x' } })
+    fireEvent.click(submit())
+
+    expect(await screen.findByText('Sign in failed')).toBeInTheDocument()
+  })
+
+  it('clears the previous error when the form is resubmitted', async () => {
+    // setError('') runs first in handleSubmit. Without it a retry that is
+    // still in flight shows the OLD failure, which reads as a second failure.
+    const login = vi.fn()
+      .mockRejectedValueOnce(new Error('first failure'))
+      .mockResolvedValueOnce(undefined)
+    setup(login)
+    fireEvent.change(emailBox(), { target: { value: 'a@b.com' } })
+    fireEvent.change(pwBox(), { target: { value: 'x' } })
+    fireEvent.click(submit())
+    expect(await screen.findByText('first failure')).toBeInTheDocument()
+
+    fireEvent.click(submit())
+
+    await waitFor(() => expect(screen.queryByText('first failure')).toBeNull())
+    expect(login).toHaveBeenCalledTimes(2)
+  })
+})
+
+describe('LoginPage — password visibility', () => {
+  it('starts masked', () => {
+    setup()
+    expect(pwBox()).toHaveAttribute('type', 'password')
+  })
+
+  it('reveals and re-masks, and its label names the NEXT action each time', () => {
+    setup()
+
+    fireEvent.click(screen.getByLabelText('Show password'))
+    expect(pwBox()).toHaveAttribute('type', 'text')
+
+    fireEvent.click(screen.getByLabelText('Hide password'))
+    expect(pwBox()).toHaveAttribute('type', 'password')
+  })
+})
+
+describe('LoginPage — OAuth error codes from the backend redirect', () => {
+  it.each([
+    ['email_exists', /already exists/i],
+    ['account_disabled', /has been disabled/i],
+    ['email_unverified', /not verified/i],
+    ['invalid_state', /expired/i],
+    ['google_failed', /failed/i],
+  ])('renders a specific message for ?error=%s', (code, expected) => {
+    setup(vi.fn(), `?error=${code}`)
+
+    expect(screen.getByText(expected)).toBeInTheDocument()
+  })
+
+  it('falls back to the generic Google message for an unrecognised code', () => {
+    // The backend owns these codes. A new one must never render an empty
+    // error area that silently swallows a failed sign-in.
+    setup(vi.fn(), '?error=some_new_code_we_do_not_know')
+
+    expect(screen.getByText(/Google sign-in failed/i)).toBeInTheDocument()
+  })
+
+  it('shows no error at all on a clean load', () => {
+    setup()
+
+    expect(screen.queryByText(/Google sign-in failed/i)).toBeNull()
+  })
+})
+
+describe('LoginPage — the other ways out', () => {
+  it('sends the Google button to the backend’s own OAuth entry point', () => {
+    setup()
+    const original = window.location
+    // jsdom forbids assigning window.location.href; swap in a plain object.
+    Object.defineProperty(window, 'location', { writable: true, value: { href: '' } })
+
+    fireEvent.click(screen.getByRole('button', { name: /google/i }))
+
+    expect((window.location as unknown as { href: string }).href).toBe('/auth/google/login')
+    Object.defineProperty(window, 'location', { writable: true, value: original })
+  })
+
+  it('links to signup and to password recovery', () => {
+    setup()
+
+    expect(screen.getByRole('link', { name: /sign up/i })).toHaveAttribute('href', '/signup')
+    expect(screen.getByRole('link', { name: /forgot/i })).toHaveAttribute('href', '/forgot-password')
+  })
+})

--- a/src/frontend-react/src/pages/auth/SignupPage.test.tsx
+++ b/src/frontend-react/src/pages/auth/SignupPage.test.tsx
@@ -1,0 +1,258 @@
+/**
+ * SignupPage — client-side validation and the password strength meter.
+ *
+ * Unlike LoginPage, these inputs carry no HTML `required`, so validate() is
+ * genuinely the gate: every rule in it is reachable and each one is the only
+ * thing standing between a malformed signup and a request the server has to
+ * reject. The meter is tested through its label rather than its internals,
+ * because the label is what a user acts on.
+ */
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/auth/AuthContext', () => ({ useAuth: vi.fn() }))
+const mockNavigate = vi.fn()
+vi.mock('react-router-dom', async importOriginal => ({
+  ...(await importOriginal<typeof import('react-router-dom')>()),
+  useNavigate: () => mockNavigate,
+}))
+
+import { useAuth } from '@/auth/AuthContext'
+import SignupPage from './SignupPage'
+
+const mockUseAuth = vi.mocked(useAuth)
+afterEach(() => vi.resetAllMocks())
+
+function setup(signup = vi.fn().mockResolvedValue(undefined)) {
+  mockUseAuth.mockReturnValue({
+    user: null, loading: false, isAuthenticated: false, isAdmin: false, status: null,
+    isOrgAdmin: false, canViewLearning: false,
+    login: vi.fn(), signup, loginWithToken: vi.fn(), logout: vi.fn(), logoutAll: vi.fn(),
+  } as unknown as ReturnType<typeof useAuth>)
+  render(<MemoryRouter><SignupPage /></MemoryRouter>)
+  return signup
+}
+
+const first = () => screen.getByPlaceholderText('Alex')
+const last = () => screen.getByPlaceholderText('Johnson')
+const email = () => screen.getByPlaceholderText('you@company.com')
+const pw = () => screen.getByPlaceholderText('Min. 8 characters')
+const confirm = () => screen.getByPlaceholderText('Re-enter password')
+const terms = () => screen.getByRole('checkbox')
+const submit = () => screen.getByRole('button', { name: /create account/i })
+
+/** Fill a valid form, then let each test break exactly one thing. */
+function fillValid() {
+  fireEvent.change(first(), { target: { value: 'Alex' } })
+  fireEvent.change(last(), { target: { value: 'Johnson' } })
+  fireEvent.change(email(), { target: { value: 'alex@company.com' } })
+  fireEvent.change(pw(), { target: { value: 'Password1' } })
+  fireEvent.change(confirm(), { target: { value: 'Password1' } })
+  fireEvent.click(terms())
+}
+
+describe('SignupPage — the happy path', () => {
+  it('signs up with the joined display name and navigates away', async () => {
+    const signup = setup()
+    fillValid()
+
+    fireEvent.click(submit())
+
+    await waitFor(() => {
+      expect(signup).toHaveBeenCalledWith('alex@company.com', 'Password1', 'Alex Johnson')
+      expect(mockNavigate).toHaveBeenCalledWith('/generate', { replace: true })
+    })
+  })
+
+  it('trims the display name when the last name is left blank', async () => {
+    // `${first} ${last}`.trim() — without the trim the account is created with
+    // a trailing space in its display name, which then shows up everywhere.
+    const signup = setup()
+    fillValid()
+    fireEvent.change(last(), { target: { value: '' } })
+
+    fireEvent.click(submit())
+
+    await waitFor(() => expect(signup).toHaveBeenCalledWith('alex@company.com', 'Password1', 'Alex'))
+  })
+})
+
+describe('SignupPage — validate() blocks each bad field', () => {
+  it('requires a first name, and does not treat spaces as one', async () => {
+    const signup = setup()
+    fillValid()
+    fireEvent.change(first(), { target: { value: '   ' } })
+
+    fireEvent.click(submit())
+
+    expect(await screen.findByText('Required')).toBeInTheDocument()
+    expect(signup).not.toHaveBeenCalled()
+  })
+
+  it('blocks a malformed email — the browser refuses the submit before validate() runs', () => {
+    // The field is type="email" with no `required`. A NON-EMPTY malformed
+    // value fails the browser's own constraint validation, so handleSubmit
+    // never runs and the component's `!email.includes('@')` rule is
+    // unreachable for this case. It IS reachable for an empty email, which
+    // type="email" considers valid - that path is covered by the
+    // "reports every bad field at once" test below.
+    const signup = setup()
+    fillValid()
+    fireEvent.change(email(), { target: { value: 'not-an-email' } })
+
+    fireEvent.click(submit())
+
+    expect(signup).not.toHaveBeenCalled()
+    expect(screen.queryByText('Enter a valid email')).toBeNull()
+  })
+
+  it('rejects an EMPTY email through validate(), since type="email" allows it', async () => {
+    const signup = setup()
+    fillValid()
+    fireEvent.change(email(), { target: { value: '' } })
+
+    fireEvent.click(submit())
+
+    expect(await screen.findByText('Enter a valid email')).toBeInTheDocument()
+    expect(signup).not.toHaveBeenCalled()
+  })
+
+  it('rejects a password under 8 characters', async () => {
+    const signup = setup()
+    fillValid()
+    fireEvent.change(pw(), { target: { value: 'Pass1' } })
+    fireEvent.change(confirm(), { target: { value: 'Pass1' } })
+
+    fireEvent.click(submit())
+
+    expect(await screen.findByText('Minimum 8 characters')).toBeInTheDocument()
+    expect(signup).not.toHaveBeenCalled()
+  })
+
+  it('rejects a mismatched confirmation', async () => {
+    const signup = setup()
+    fillValid()
+    fireEvent.change(confirm(), { target: { value: 'Password2' } })
+
+    fireEvent.click(submit())
+
+    expect(await screen.findByText('Passwords do not match')).toBeInTheDocument()
+    expect(signup).not.toHaveBeenCalled()
+  })
+
+  it('requires the terms checkbox', async () => {
+    const signup = setup()
+    fillValid()
+    fireEvent.click(terms())   // untick it again
+
+    fireEvent.click(submit())
+
+    expect(await screen.findByText('Please accept the terms')).toBeInTheDocument()
+    expect(signup).not.toHaveBeenCalled()
+  })
+
+  it('reports every bad field at once, not just the first', async () => {
+    // validate() accumulates into one object. Reporting one at a time turns a
+    // single fix-up into five round trips.
+    const signup = setup()
+
+    fireEvent.click(submit())
+
+    expect(await screen.findByText('Required')).toBeInTheDocument()
+    expect(screen.getByText('Enter a valid email')).toBeInTheDocument()
+    expect(screen.getByText('Minimum 8 characters')).toBeInTheDocument()
+    expect(screen.getByText('Please accept the terms')).toBeInTheDocument()
+    expect(signup).not.toHaveBeenCalled()
+  })
+})
+
+describe('SignupPage — the password strength meter', () => {
+  it('shows nothing until something is typed', () => {
+    setup()
+
+    expect(screen.queryByText('Weak')).toBeNull()
+    expect(screen.queryByText('Fair')).toBeNull()
+    expect(screen.queryByText('Strong')).toBeNull()
+  })
+
+  it('shows NO label for a password that scores zero', () => {
+    // 'abc' earns nothing: under 8 characters, not mixed case, no digit. The
+    // score indexes STRENGTH_LABEL, whose 0 entry is the empty string - so a
+    // very weak password is silent rather than labelled "Weak". Pinned
+    // because it is surprising, and because a future label added at index 0
+    // would change what an empty-ish field says.
+    setup()
+    fireEvent.change(pw(), { target: { value: 'abc' } })
+
+    expect(screen.queryByText('Weak')).toBeNull()
+    expect(screen.queryByText('Fair')).toBeNull()
+    expect(screen.queryByText('Strong')).toBeNull()
+  })
+
+  it('calls eight lowercase characters Weak — length alone is not enough', () => {
+    setup()
+    fireEvent.change(pw(), { target: { value: 'abcdefgh' } })
+
+    expect(screen.getByText('Weak')).toBeInTheDocument()
+  })
+
+  it('calls mixed case at length Fair', () => {
+    setup()
+    fireEvent.change(pw(), { target: { value: 'abcdefgH' } })
+
+    expect(screen.getByText('Fair')).toBeInTheDocument()
+  })
+
+  it('calls mixed case with a digit Strong', () => {
+    setup()
+    fireEvent.change(pw(), { target: { value: 'abcdefG1' } })
+
+    expect(screen.getByText('Strong')).toBeInTheDocument()
+  })
+
+  it('does not exceed Strong for a very complex password', () => {
+    // The score is clamped to 3; an unclamped one would index past
+    // STRENGTH_LABEL and render undefined.
+    setup()
+    fireEvent.change(pw(), { target: { value: 'aB3!aB3!aB3!aB3!' } })
+
+    expect(screen.getByText('Strong')).toBeInTheDocument()
+  })
+})
+
+describe('SignupPage — server rejection and password visibility', () => {
+  it('shows the server’s message and re-enables the button', async () => {
+    setup(vi.fn().mockRejectedValue(new Error('Email already registered')))
+    fillValid()
+
+    fireEvent.click(submit())
+
+    expect(await screen.findByText('Email already registered')).toBeInTheDocument()
+    expect(submit()).toBeEnabled()
+  })
+
+  it('falls back to a generic message for a non-Error rejection', async () => {
+    setup(vi.fn().mockRejectedValue({ weird: true }))
+    fillValid()
+
+    fireEvent.click(submit())
+
+    expect(await screen.findByText('Sign up failed')).toBeInTheDocument()
+  })
+
+  it('toggles the password field between masked and visible', () => {
+    setup()
+    expect(pw()).toHaveAttribute('type', 'password')
+
+    fireEvent.click(screen.getByLabelText('Toggle password visibility'))
+
+    expect(pw()).toHaveAttribute('type', 'text')
+  })
+
+  it('links back to sign-in', () => {
+    setup()
+
+    expect(screen.getByRole('link', { name: /sign in/i })).toHaveAttribute('href', '/login')
+  })
+})

--- a/src/frontend-react/src/pages/auth/SignupPage.test.tsx
+++ b/src/frontend-react/src/pages/auth/SignupPage.test.tsx
@@ -174,21 +174,25 @@ describe('SignupPage — the password strength meter', () => {
   it('shows nothing until something is typed', () => {
     setup()
 
+    // The whole meter is behind `password.length > 0`, so index 0 of
+    // STRENGTH_LABEL is unreachable while the field is empty - which is what
+    // makes it free to carry a real word for the case below.
+    expect(screen.queryByText('Very weak')).toBeNull()
     expect(screen.queryByText('Weak')).toBeNull()
     expect(screen.queryByText('Fair')).toBeNull()
     expect(screen.queryByText('Strong')).toBeNull()
   })
 
-  it('shows NO label for a password that scores zero', () => {
-    // 'abc' earns nothing: under 8 characters, not mixed case, no digit. The
-    // score indexes STRENGTH_LABEL, whose 0 entry is the empty string - so a
-    // very weak password is silent rather than labelled "Weak". Pinned
-    // because it is surprising, and because a future label added at index 0
-    // would change what an empty-ish field says.
+  it('calls a password that scores zero Very weak, rather than saying nothing', () => {
+    // 'abc' earns nothing: under 8 characters, not mixed case, no digit. Its
+    // score indexes STRENGTH_LABEL[0], which used to be the empty string - so
+    // the weakest password on the scale was the one the meter refused to
+    // describe, and the bars stayed grey exactly as they do for a field
+    // nobody has touched.
     setup()
     fireEvent.change(pw(), { target: { value: 'abc' } })
 
-    expect(screen.queryByText('Weak')).toBeNull()
+    expect(screen.getByText('Very weak')).toBeInTheDocument()
     expect(screen.queryByText('Fair')).toBeNull()
     expect(screen.queryByText('Strong')).toBeNull()
   })

--- a/src/frontend-react/src/pages/auth/SignupPage.test.tsx
+++ b/src/frontend-react/src/pages/auth/SignupPage.test.tsx
@@ -91,12 +91,11 @@ describe('SignupPage — validate() blocks each bad field', () => {
   })
 
   it('blocks a malformed email — the browser refuses the submit before validate() runs', () => {
-    // The field is type="email" with no `required`. A NON-EMPTY malformed
-    // value fails the browser's own constraint validation, so handleSubmit
-    // never runs and the component's `!email.includes('@')` rule is
-    // unreachable for this case. It IS reachable for an empty email, which
-    // type="email" considers valid - that path is covered by the
-    // "reports every bad field at once" test below.
+    // The field is type="email" with no `required` and the form has no
+    // noValidate, so a NON-EMPTY malformed value fails the browser's own
+    // constraint validation and handleSubmit never runs. That is why the
+    // component's own `!email.includes('@')` rule reaches the user only when
+    // the field is EMPTY, and why its message names that case and not this one.
     const signup = setup()
     fillValid()
     fireEvent.change(email(), { target: { value: 'not-an-email' } })
@@ -104,17 +103,21 @@ describe('SignupPage — validate() blocks each bad field', () => {
     fireEvent.click(submit())
 
     expect(signup).not.toHaveBeenCalled()
-    expect(screen.queryByText('Enter a valid email')).toBeNull()
+    expect(screen.queryByText('Enter your work email')).toBeNull()
   })
 
-  it('rejects an EMPTY email through validate(), since type="email" allows it', async () => {
+  it('asks for the email, in the words of the only case that reaches the user — an empty field', async () => {
     const signup = setup()
     fillValid()
     fireEvent.change(email(), { target: { value: '' } })
 
     fireEvent.click(submit())
 
-    expect(await screen.findByText('Enter a valid email')).toBeInTheDocument()
+    expect(await screen.findByText('Enter your work email')).toBeInTheDocument()
+    // The old wording, "Enter a valid email", described the malformed-input
+    // case the browser had already taken over - it accused a visitor who had
+    // typed nothing of typing something wrong.
+    expect(screen.queryByText('Enter a valid email')).toBeNull()
     expect(signup).not.toHaveBeenCalled()
   })
 
@@ -160,7 +163,7 @@ describe('SignupPage — validate() blocks each bad field', () => {
     fireEvent.click(submit())
 
     expect(await screen.findByText('Required')).toBeInTheDocument()
-    expect(screen.getByText('Enter a valid email')).toBeInTheDocument()
+    expect(screen.getByText('Enter your work email')).toBeInTheDocument()
     expect(screen.getByText('Minimum 8 characters')).toBeInTheDocument()
     expect(screen.getByText('Please accept the terms')).toBeInTheDocument()
     expect(signup).not.toHaveBeenCalled()

--- a/src/frontend-react/src/pages/auth/SignupPage.tsx
+++ b/src/frontend-react/src/pages/auth/SignupPage.tsx
@@ -65,7 +65,10 @@ export default function SignupPage() {
   function validate() {
     const e: Record<string, string> = {}
     if (!firstName.trim())        e.firstName = 'Required'
-    if (!email.includes('@'))     e.email     = 'Enter a valid email'
+    // type="email" (no noValidate on the form) means the browser blocks a
+    // non-empty malformed address before handleSubmit runs, so the only way
+    // this rule reaches a visitor is an empty field. The message names that.
+    if (!email.includes('@'))     e.email     = 'Enter your work email'
     if (password.length < 8)      e.password  = 'Minimum 8 characters'
     if (password !== confirm)     e.confirm   = 'Passwords do not match'
     if (!agreed)                  e.terms     = 'Please accept the terms'

--- a/src/frontend-react/src/pages/auth/SignupPage.tsx
+++ b/src/frontend-react/src/pages/auth/SignupPage.tsx
@@ -44,7 +44,11 @@ function pwStrength(pw: string): 0 | 1 | 2 | 3 {
   return Math.min(s, 3) as 0 | 1 | 2 | 3
 }
 
-const STRENGTH_LABEL = ['', 'Weak', 'Fair', 'Strong'] as const
+// Index 0 is reachable: pwStrength returns 0 for any non-empty password that
+// earns nothing, and the meter renders whenever the field is non-empty. It was
+// the empty string, so the weakest password on the scale was the only one the
+// meter refused to name. The empty field never reaches here at all.
+const STRENGTH_LABEL = ['Very weak', 'Weak', 'Fair', 'Strong'] as const
 const STRENGTH_COLOR = ['bg-muted', 'bg-red-500', 'bg-yellow-500', 'bg-green-500'] as const
 
 export default function SignupPage() {

--- a/src/frontend-react/src/pages/learning/HintDrawer.test.tsx
+++ b/src/frontend-react/src/pages/learning/HintDrawer.test.tsx
@@ -23,7 +23,7 @@
  * Metadata half at the bottom renders the drawer — it is a Sheet, not a
  * route, so no Router is involved.
  */
-import { render, screen } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 vi.mock('@/auth/AuthContext', () => ({ useAuth: vi.fn() }))
@@ -32,11 +32,13 @@ vi.mock('@/lib/api', () => ({ api: vi.fn() }))
 
 import { useAuth } from '@/auth/AuthContext'
 import { useFetch } from '@/lib/useFetch'
+import { api } from '@/lib/api'
 import HintDrawer, { ACTION_LABELS, diffFields, isCompactChange, COMPACT_FIELD_LIMIT } from './HintDrawer'
 import type { TimelineEntry } from './types'
 
 const mockUseAuth = vi.mocked(useAuth)
 const mockUseFetch = vi.mocked(useFetch)
+const mockApi = vi.mocked(api)
 
 afterEach(() => vi.resetAllMocks())
 
@@ -257,5 +259,238 @@ describe('Metadata names the org and the author', () => {
 
     expect(valueFor('Org')).toBe('—')
     expect(valueFor('Author')).toBe('unknown')
+  })
+})
+
+/**
+ * The edit form (saveEdit) and the lifecycle actions (unflag/retract/
+ * reactivate, via lifecycle()) — both mutate the learning store through
+ * call(), which PATCHes/POSTs then reload()s the drawer AND calls onChanged()
+ * (the caller's own refetch). A wrong hint id or a dropped refetch here is
+ * silent, so every write below pins the exact path/body sent and that both
+ * callbacks fired. The timeline-render and status-branch describes below
+ * cover the audit-history and badge code that only the "Metadata" tests
+ * above exercised a slice of (a hint that is Active, with no timeline rows).
+ */
+
+describe('the audit timeline renders what diffFields computes', () => {
+  function renderWithTimeline(hint: Record<string, unknown>, timeline: TimelineEntry[]) {
+    mockUseAuth.mockReturnValue({
+      user: { id: 'u1', email: 'admin@test.local', display_name: 'A', role: 'admin', status: 'active' },
+      isAdmin: true,
+    } as unknown as ReturnType<typeof useAuth>)
+    mockUseFetch.mockReturnValue({
+      data: { hint: { id: 7, feedback_text: 'wait for the spinner', is_active: 1, conflict_flagged: 0, ...hint }, timeline },
+      loading: false, error: '', reload: vi.fn(),
+    } as unknown as ReturnType<typeof useFetch>)
+    render(<HintDrawer id={7} onChanged={() => {}} onClose={() => {}} />)
+  }
+
+  it('renders a compact entry inline: actor, action label, before→after, reason, and workflow id', () => {
+    renderWithTimeline({}, [entry({
+      actor: 'writer@test.local', action: 'patch', reason: 'category was wrong', workflow_id: 'wf-123',
+      before_value: '{"category":"structural"}', after_value: '{"category":"B1"}',
+    })])
+    expect(screen.getByText('writer@test.local')).toBeInTheDocument()
+    expect(screen.getByText(/edited/)).toBeInTheDocument()
+    expect(screen.getByText(/category=structural → category=B1/)).toBeInTheDocument()
+    expect(screen.getByText('category was wrong')).toBeInTheDocument()
+    expect(screen.getByText('wf-123')).toBeInTheDocument()
+  })
+
+  it('falls back to the trigger type when a trigger_events row has no actor', () => {
+    renderWithTimeline({}, [entry({ source: 'trigger_events', actor: null, trigger_type: 'trigger_1', action: 'flagged' })])
+    expect(screen.getByText('trigger_1')).toBeInTheDocument()
+    expect(screen.getByText(/flagged this hint/)).toBeInTheDocument()
+  })
+
+  it('renders no before→after suffix for a bare create with no diff', () => {
+    renderWithTimeline({}, [entry({ action: 'create', before_value: null, after_value: null })])
+    expect(screen.getByText(/created/)).toBeInTheDocument()
+    expect(screen.queryByText(/→/)).toBeNull()
+  })
+
+  it('switches a large before/after payload to the expandable detail view instead of the inline string', () => {
+    const before = { id: 99, feedback_text: 'x', category: 'timing', scope: 'domain', domain: 'shop.test', url: null, evidence_count: 2, applied_count: 5 }
+    const after = { survivor_id: 12, evidence_count: 8, applied_count: 20, used_src: 4, failure_src: 1, unused_src: 1 }
+    renderWithTimeline({}, [entry({ action: 'merge', before_value: JSON.stringify(before), after_value: JSON.stringify(after) })])
+    expect(screen.getByText(/fields changed — view detail/)).toBeInTheDocument()
+    // The field union is real DOM content (not just a collapsed summary) —
+    // used_src exists only in after_value, so its row is real evidence the
+    // union (not just the changed keys) rendered.
+    expect(screen.getByText('used_src:')).toBeInTheDocument()
+  })
+})
+
+describe('status badge covers every active/disabled combination', () => {
+  function renderStatus(hint: Record<string, unknown>) {
+    mockUseAuth.mockReturnValue({
+      user: { id: 'u1', email: 'admin@test.local', display_name: 'A', role: 'admin', status: 'active' },
+      isAdmin: true,
+    } as unknown as ReturnType<typeof useAuth>)
+    mockUseFetch.mockReturnValue({
+      data: { hint: { id: 7, feedback_text: 'wait for the spinner', is_active: 1, conflict_flagged: 0, ...hint }, timeline: [] },
+      loading: false, error: '', reload: vi.fn(),
+    } as unknown as ReturnType<typeof useFetch>)
+    render(<HintDrawer id={7} onChanged={() => {}} onClose={() => {}} />)
+  }
+
+  it('shows Flagged with its reason when active and conflict-flagged', () => {
+    renderStatus({ is_active: 1, conflict_flagged: 1, conflict_flag_reason: 'contradicts hint 9' })
+    expect(screen.getByText('Flagged')).toBeInTheDocument()
+    expect(screen.getByText('contradicts hint 9')).toBeInTheDocument()
+  })
+
+  it('shows LLM-disabled, not the generic Disabled label, when llm_review_disabled is set', () => {
+    renderStatus({ is_active: 0, llm_review_disabled: 1 })
+    expect(screen.getByText('LLM-disabled')).toBeInTheDocument()
+  })
+
+  it('shows the generic Disabled label when inactive for any other reason', () => {
+    renderStatus({ is_active: 0, llm_review_disabled: 0 })
+    expect(screen.getByText('Disabled')).toBeInTheDocument()
+  })
+
+  it('renders the anchor-query section only when the hint carries one', () => {
+    renderStatus({ anchor_query: 'find the checkout button' })
+    expect(screen.getByText('find the checkout button')).toBeInTheDocument()
+  })
+})
+
+describe('the edit form (saveEdit)', () => {
+  function renderForEdit(hint: Record<string, unknown> = {}, opts: { reload?: ReturnType<typeof vi.fn>; onChanged?: ReturnType<typeof vi.fn>; id?: number } = {}) {
+    const reload = opts.reload ?? vi.fn()
+    const onChanged = opts.onChanged ?? vi.fn()
+    mockUseAuth.mockReturnValue({
+      user: { id: 'u1', email: 'editor@test.local', display_name: 'E', role: 'admin', status: 'active' },
+      isAdmin: true,
+    } as unknown as ReturnType<typeof useAuth>)
+    mockUseFetch.mockReturnValue({
+      data: { hint: { id: opts.id ?? 55, feedback_text: 'wait for the spinner', is_active: 1, conflict_flagged: 0, scope: 'domain', domain: 'old.test', category: 'uncategorized', ...hint }, timeline: [] },
+      loading: false, error: '', reload,
+    } as unknown as ReturnType<typeof useFetch>)
+    render(<HintDrawer id={opts.id ?? 55} onChanged={onChanged} onClose={() => {}} />)
+    return { reload, onChanged }
+  }
+
+  it('saves scope=domain with the typed domain, the RIGHT hint id, and refetches both the drawer and the caller', async () => {
+    const { reload, onChanged } = renderForEdit({}, { id: 55 })
+    mockApi.mockResolvedValueOnce({})
+
+    fireEvent.change(screen.getByPlaceholderText('example.com'), { target: { value: 'new.test' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+
+    await waitFor(() => expect(mockApi).toHaveBeenCalledTimes(1))
+    const [path, options] = mockApi.mock.calls[0]
+    expect(path).toBe('/api/learning/hints/55')
+    expect((options as { method: string }).method).toBe('PATCH')
+    expect(JSON.parse((options as { body: string }).body)).toEqual({
+      scope: 'domain', domain: 'new.test', url: null, category: 'uncategorized',
+      original_failure_category: null, actor: 'editor@test.local', reason: 'edited via admin dashboard',
+    })
+    await waitFor(() => expect(reload).toHaveBeenCalledTimes(1))
+    expect(onChanged).toHaveBeenCalledTimes(1)
+  })
+
+  it('switches to the URL field when scope is changed to url, and saves url instead of domain', async () => {
+    renderForEdit()
+    mockApi.mockResolvedValueOnce({})
+
+    fireEvent.change(screen.getByDisplayValue('domain'), { target: { value: 'url' } })
+    fireEvent.change(screen.getByPlaceholderText('https://example.com/page'), { target: { value: 'https://shop.test/checkout' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+
+    await waitFor(() => expect(mockApi).toHaveBeenCalledTimes(1))
+    const body = JSON.parse((mockApi.mock.calls[0][1] as { body: string }).body)
+    expect(body.scope).toBe('url')
+    expect(body.url).toBe('https://shop.test/checkout')
+    expect(body.domain).toBeNull()
+  })
+
+  it('surfaces the error and leaves Save usable again when the PATCH fails, without refetching', async () => {
+    const { reload, onChanged } = renderForEdit()
+    mockApi.mockRejectedValueOnce(new Error('Request failed (409)'))
+
+    const saveBtn = screen.getByRole('button', { name: 'Save' })
+    fireEvent.click(saveBtn)
+
+    expect(await screen.findByText('Request failed (409)')).toBeInTheDocument()
+    await waitFor(() => expect(saveBtn).not.toBeDisabled())
+    expect(reload).not.toHaveBeenCalled()
+    expect(onChanged).not.toHaveBeenCalled()
+  })
+})
+
+describe('lifecycle actions (unflag / retract / reactivate)', () => {
+  function renderLifecycle(hint: Record<string, unknown>, opts: { reload?: ReturnType<typeof vi.fn>; onChanged?: ReturnType<typeof vi.fn>; id?: number } = {}) {
+    const reload = opts.reload ?? vi.fn()
+    const onChanged = opts.onChanged ?? vi.fn()
+    mockUseAuth.mockReturnValue({
+      user: { id: 'u1', email: 'admin@test.local', display_name: 'A', role: 'admin', status: 'active' },
+      isAdmin: true,
+    } as unknown as ReturnType<typeof useAuth>)
+    mockUseFetch.mockReturnValue({
+      data: { hint: { id: opts.id ?? 7, feedback_text: 'wait for the spinner', is_active: 1, conflict_flagged: 0, ...hint }, timeline: [] },
+      loading: false, error: '', reload,
+    } as unknown as ReturnType<typeof useFetch>)
+    render(<HintDrawer id={opts.id ?? 7} onChanged={onChanged} onClose={() => {}} />)
+    return { reload, onChanged }
+  }
+
+  it('unflags a flagged hint and refetches both the drawer and the caller’s list', async () => {
+    const { reload, onChanged } = renderLifecycle({ is_active: 1, conflict_flagged: 1 }, { id: 42 })
+    mockApi.mockResolvedValueOnce({})
+
+    fireEvent.click(screen.getByRole('button', { name: 'Unflag' }))
+
+    await waitFor(() => expect(mockApi).toHaveBeenCalledTimes(1))
+    const [path, options] = mockApi.mock.calls[0]
+    expect(path).toBe('/api/learning/hints/42/unflag')
+    expect(JSON.parse((options as { body: string }).body)).toEqual({ actor: 'admin@test.local', reason: 'via admin dashboard' })
+    await waitFor(() => expect(reload).toHaveBeenCalledTimes(1))
+    expect(onChanged).toHaveBeenCalledTimes(1)
+  })
+
+  it('asks for confirmation before retracting; a cancelled confirm sends nothing', () => {
+    renderLifecycle({ is_active: 1, conflict_flagged: 0 }, { id: 42 })
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(false)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Retract' }))
+
+    expect(confirmSpy).toHaveBeenCalledWith('Retract this hint? It will stop injecting into agent prompts.')
+    expect(mockApi).not.toHaveBeenCalled()
+    confirmSpy.mockRestore()
+  })
+
+  it('retracts THIS drawer’s hint id once confirmed — a distinctive id, not a hardcoded default', async () => {
+    mockApi.mockResolvedValueOnce({})
+    renderLifecycle({ is_active: 1, conflict_flagged: 0 }, { id: 999 })
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Retract' }))
+
+    await waitFor(() => expect(mockApi).toHaveBeenCalledTimes(1))
+    expect(mockApi.mock.calls[0][0]).toBe('/api/learning/hints/999/retract')
+    confirmSpy.mockRestore()
+  })
+
+  it('reactivates a disabled hint', async () => {
+    mockApi.mockResolvedValueOnce({})
+    renderLifecycle({ is_active: 0, llm_review_disabled: 0 }, { id: 7 })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Reactivate' }))
+
+    await waitFor(() => expect(mockApi).toHaveBeenCalledWith('/api/learning/hints/7/reactivate', expect.anything()))
+  })
+
+  it('shows the failure and does not refetch when a lifecycle action rejects', async () => {
+    const { reload, onChanged } = renderLifecycle({ is_active: 1, conflict_flagged: 1 }, { id: 7 })
+    mockApi.mockRejectedValueOnce(new Error('Request failed (409)'))
+
+    fireEvent.click(screen.getByRole('button', { name: 'Unflag' }))
+
+    expect(await screen.findByText('Request failed (409)')).toBeInTheDocument()
+    expect(reload).not.toHaveBeenCalled()
+    expect(onChanged).not.toHaveBeenCalled()
   })
 })

--- a/src/frontend-react/src/pages/learning/RunDrawer.test.tsx
+++ b/src/frontend-react/src/pages/learning/RunDrawer.test.tsx
@@ -1,0 +1,212 @@
+/**
+ * RunDrawer — one run's learning journey: which hints were considered, which
+ * were injected, and what each one was credited with afterwards.
+ *
+ * The funnel is the part worth pinning. "considered" and "injected" are
+ * different populations, and a hint that was dropped carries a reason that
+ * explains why the run did not benefit from it. Collapsing those into one list
+ * of "hints used" would make the page agree with itself and disagree with the
+ * database.
+ *
+ * BUCKET_BADGES also carries aliases (success/failure) for older trace rows
+ * alongside the buckets the backend emits today (used/harmful/unused). An
+ * unknown bucket must still render its own name rather than disappearing.
+ */
+import { render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/lib/useFetch', () => ({ useFetch: vi.fn() }))
+
+import { useFetch } from '@/lib/useFetch'
+import RunDrawer from './RunDrawer'
+
+const mockUseFetch = vi.mocked(useFetch)
+afterEach(() => vi.resetAllMocks())
+
+const WF = 'wf-0123456789abcdef-0123456789abcdef'
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function setup(data: any, { loading = false, error = '' } = {}) {
+  mockUseFetch.mockReturnValue({ data, loading, error, reload: vi.fn() })
+  render(<RunDrawer workflowId={WF} onClose={vi.fn()} />)
+}
+
+const RUN = {
+  test_status: 'failed', failure_category: 'B2', timestamp: '2026-09-05T10:00:00Z',
+  user_query: 'search flipkart for shoes', url: 'https://flipkart.com', domain: 'flipkart.com',
+  failed_keyword: 'Click', error_message: 'element not found', model_version: 'gemini-3.5-flash',
+}
+const base = { run: RUN, trace: [], triggers: [] }
+
+describe('RunDrawer — load states and identity', () => {
+  it('shows the full workflow id, never a truncation', () => {
+    // Standing rule in this repo: a run id shown anywhere is shown whole.
+    setup(base)
+
+    expect(screen.getByText(WF)).toBeInTheDocument()
+  })
+
+  it('shows the id even while the detail is still loading', () => {
+    setup(null, { loading: true })
+
+    expect(screen.getByText(WF)).toBeInTheDocument()
+    expect(screen.getByText('Loading…')).toBeInTheDocument()
+  })
+
+  it('shows the error and no body when the read fails', () => {
+    setup(null, { error: 'Org-admin access required' })
+
+    expect(screen.getByText('Org-admin access required')).toBeInTheDocument()
+    expect(screen.queryByText(/Hint funnel/)).toBeNull()
+  })
+
+  it('requests the run detail with the id percent-encoded', () => {
+    setup(base)
+
+    expect(mockUseFetch).toHaveBeenCalledWith(`/api/learning/runs/${encodeURIComponent(WF)}`)
+  })
+})
+
+describe('RunDrawer — the run summary', () => {
+  it('renders status, failure category, query, url and model', () => {
+    setup(base)
+
+    expect(screen.getByText('failed')).toBeInTheDocument()
+    expect(screen.getByText('B2')).toBeInTheDocument()
+    expect(screen.getByText('search flipkart for shoes')).toBeInTheDocument()
+    expect(screen.getByText('https://flipkart.com')).toBeInTheDocument()
+    // The drawer also dumps the raw payload lower down, so match the
+    // labelled line rather than the bare model string.
+    expect(screen.getByText('Model: gemini-3.5-flash')).toBeInTheDocument()
+  })
+
+  it('renders the failed keyword and its error message together', () => {
+    setup(base)
+
+    expect(screen.getByText(/Failed keyword: Click/)).toBeInTheDocument()
+    expect(screen.getByText('element not found')).toBeInTheDocument()
+  })
+
+  it('names paste-and-execute runs rather than showing an empty quote', () => {
+    // A blank box would read as a missing query; this run genuinely had none.
+    setup({ ...base, run: { ...RUN, user_query: '' } })
+
+    expect(screen.getByText('(paste-and-execute — no query)')).toBeInTheDocument()
+  })
+
+  it('falls back to the domain when there is no full url', () => {
+    setup({ ...base, run: { ...RUN, url: '' } })
+
+    expect(screen.getByText('flipkart.com')).toBeInTheDocument()
+  })
+
+  it('renders "unknown" for a run with no recorded status', () => {
+    setup({ ...base, run: { ...RUN, test_status: '' } })
+
+    expect(screen.getByText('unknown')).toBeInTheDocument()
+  })
+
+  it('marks a holdout run, so its result is not read as a normal one', () => {
+    // A holdout run had its hints deliberately suppressed. Without the badge
+    // its failure looks like evidence that learning is not working.
+    setup({ ...base, metrics: { was_holdout: 1 } })
+
+    expect(screen.getByText('holdout')).toBeInTheDocument()
+  })
+
+  it('does not mark a non-holdout run', () => {
+    setup({ ...base, metrics: { was_holdout: 0 } })
+
+    expect(screen.queryByText('holdout')).toBeNull()
+  })
+})
+
+describe('RunDrawer — the hint funnel', () => {
+  const injected = {
+    hint_id: 11, scope: 'domain', similarity_score: 0.8342, injected: 1,
+    drop_reason: null, attribution_bucket: 'used', feedback_text: 'the search box locator was off',
+    attribution_reason: 'credited on a pass',
+  }
+  const dropped = {
+    hint_id: 12, scope: 'global', similarity_score: 0.11, injected: 0,
+    drop_reason: 'below similarity threshold', attribution_bucket: null,
+    feedback_text: 'unrelated hint', attribution_reason: null,
+  }
+
+  it('counts every hint CONSIDERED, not only those injected', () => {
+    // The funnel's whole value is the gap between the two.
+    setup({ ...base, trace: [injected, dropped] })
+
+    expect(screen.getByText('Hint funnel (2)')).toBeInTheDocument()
+  })
+
+  it('distinguishes an injected hint from a dropped one, and gives the reason', () => {
+    setup({ ...base, trace: [injected, dropped] })
+
+    expect(screen.getByText('injected')).toBeInTheDocument()
+    expect(screen.getByText('dropped')).toBeInTheDocument()
+    expect(screen.getByText('(below similarity threshold)')).toBeInTheDocument()
+  })
+
+  it('rounds the similarity score to a whole percent', () => {
+    setup({ ...base, trace: [injected] })
+
+    expect(screen.getByText('sim 83%')).toBeInTheDocument()
+  })
+
+  it('omits similarity entirely when it was not recorded', () => {
+    setup({ ...base, trace: [{ ...injected, similarity_score: null }] })
+
+    expect(screen.queryByText(/^sim /)).toBeNull()
+  })
+
+  it('renders the attribution bucket and its reason', () => {
+    setup({ ...base, trace: [injected] })
+
+    expect(screen.getByText('used')).toBeInTheDocument()
+    expect(screen.getByText('credited on a pass')).toBeInTheDocument()
+  })
+
+  it('still renders a bucket it has no colour for', () => {
+    // BUCKET_BADGES is a lookup with a fallback; a new backend bucket must
+    // show its name rather than silently vanish.
+    setup({ ...base, trace: [{ ...injected, attribution_bucket: 'brand_new_bucket' }] })
+
+    expect(screen.getByText('brand_new_bucket')).toBeInTheDocument()
+  })
+
+  it('renders the legacy success/failure aliases', () => {
+    setup({ ...base, trace: [{ ...injected, attribution_bucket: 'success' }] })
+
+    expect(screen.getByText('success')).toBeInTheDocument()
+  })
+
+  it('says a hint was deleted rather than rendering a blank row', () => {
+    // The trace outlives the hint. An empty line would look like a bug.
+    setup({ ...base, trace: [{ ...injected, feedback_text: null }] })
+
+    expect(screen.getByText('(hint deleted)')).toBeInTheDocument()
+  })
+
+  it('says explicitly when no hints were considered at all', () => {
+    setup(base)
+
+    expect(screen.getByText('No hints were considered for this run.')).toBeInTheDocument()
+    expect(screen.getByText('Hint funnel (0)')).toBeInTheDocument()
+  })
+})
+
+describe('RunDrawer — trigger events', () => {
+  it('lists trigger events with their reason when there are any', () => {
+    setup({ ...base, triggers: [{ id: 1, trigger_type: 'trigger_1', reason: 'fix after fail' }] })
+
+    expect(screen.getByText('Trigger events (1)')).toBeInTheDocument()
+    expect(screen.getByText('fix after fail')).toBeInTheDocument()
+  })
+
+  it('omits the section entirely when nothing fired', () => {
+    setup(base)
+
+    expect(screen.queryByText(/Trigger events/)).toBeNull()
+  })
+})

--- a/src/frontend-react/src/pages/learning/StatsTab.test.tsx
+++ b/src/frontend-react/src/pages/learning/StatsTab.test.tsx
@@ -1,0 +1,229 @@
+/**
+ * StatsTab — the learning dashboard's numbers, and the formatters underneath
+ * them.
+ *
+ * Almost every value on this page is optional and defaulted with `??`. That is
+ * deliberate — the endpoint's shape grows — but it means a missing section
+ * renders "0" rather than nothing, and 0 is a claim. These tests pin which
+ * absences show as 0, which show as "—", and which show as "n/a" or
+ * "insufficient data", because those three say very different things to
+ * someone deciding whether learning is working.
+ *
+ * fmtLift is tested directly as well: it is the one formatter whose OUTPUT is
+ * a judgement (a signed percentage), and it uses a typographic minus (U+2212),
+ * not a hyphen, which is exactly the sort of detail a rewrite loses.
+ */
+import { render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/lib/useFetch', () => ({ useFetch: vi.fn() }))
+
+import { useFetch } from '@/lib/useFetch'
+import StatsTab from './StatsTab'
+import { fmtLift, pctOrDash, fmtWhen } from './types'
+
+const mockUseFetch = vi.mocked(useFetch)
+afterEach(() => vi.resetAllMocks())
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function setup(data: any, { loading = false, error = '' } = {}) {
+  mockUseFetch.mockReturnValue({ data, loading, error, reload: vi.fn() })
+  render(<StatsTab />)
+}
+
+describe('StatsTab — the three load states', () => {
+  it('shows a loading line while the stats are in flight', () => {
+    setup(null, { loading: true })
+
+    expect(screen.getByText('Loading…')).toBeInTheDocument()
+  })
+
+  it('shows the error instead of the page when the read fails', () => {
+    setup(null, { error: 'Org-admin access required' })
+
+    expect(screen.getByText('Org-admin access required')).toBeInTheDocument()
+    expect(screen.queryByText('Hint inventory')).toBeNull()
+  })
+
+  it('renders nothing at all when there is no data and no error', () => {
+    const { container } = render(<div />)
+    setup(null)
+
+    expect(screen.queryByText('Hint inventory')).toBeNull()
+    expect(container).toBeInTheDocument()
+  })
+})
+
+describe('StatsTab — hint inventory', () => {
+  it('renders every inventory count it is given', () => {
+    setup({
+      hint_inventory: {
+        active: 36, flagged: 2, auto_disabled: 5, llm_review_disabled: 1,
+        retracted: 4, admin_created: 7, workflow_created: 29,
+      },
+    })
+
+    expect(screen.getByText('36')).toBeInTheDocument()
+    expect(screen.getByText('29')).toBeInTheDocument()
+    expect(screen.getByText('Auto-disabled')).toBeInTheDocument()
+  })
+
+  it('falls back to 0 for a missing inventory rather than blanking the section', () => {
+    setup({})
+
+    expect(screen.getByText('Hint inventory')).toBeInTheDocument()
+    expect(screen.getAllByText('0').length).toBeGreaterThan(0)
+  })
+})
+
+describe('StatsTab — learning effectiveness', () => {
+  const nc = {
+    lift: 0.042,
+    honest_lift: -0.013,
+    no_hints_available: { total: 40, pass_rate: 0.6 },
+    hints_injected: { total: 60, pass_rate: 0.75 },
+    holdout_suppressed: { total: 0, pass_rate: null },
+  }
+
+  it('shows each category’s run count and pass rate', () => {
+    setup({ learning_effectiveness: { natural_comparison: nc } })
+
+    expect(screen.getByText('40')).toBeInTheDocument()
+    expect(screen.getByText('60.0% pass rate')).toBeInTheDocument()
+    expect(screen.getByText('75.0% pass rate')).toBeInTheDocument()
+  })
+
+  it('says "no runs yet" for a category with zero runs, not a 0% pass rate', () => {
+    // 0% pass rate and "we have not measured this" are completely different
+    // claims about the holdout arm.
+    setup({ learning_effectiveness: { natural_comparison: nc } })
+
+    expect(screen.getByText('no runs yet')).toBeInTheDocument()
+  })
+
+  it('renders a positive lift with an explicit + sign', () => {
+    setup({ learning_effectiveness: { natural_comparison: nc } })
+
+    expect(screen.getByText('+4.2%')).toBeInTheDocument()
+  })
+
+  it('says "insufficient data" — not 0% — when honest lift is unknown', () => {
+    setup({ learning_effectiveness: { natural_comparison: { ...nc, honest_lift: null } } })
+
+    expect(screen.getByText('insufficient data')).toBeInTheDocument()
+  })
+
+  it('shows an em dash for lift when the whole comparison is absent', () => {
+    setup({ learning_effectiveness: {} })
+
+    expect(screen.getAllByText('—').length).toBeGreaterThan(0)
+  })
+})
+
+describe('StatsTab — attribution health and cost', () => {
+  it('renders attribution counts with their credited sub-line', () => {
+    setup({
+      attribution_health: {
+        events_total: 118, credited_events: 41,
+        retirement_reversal_rate: 0.25, retired_never_used_total: 8,
+        holdout_lift: 0.031,
+      },
+    })
+
+    expect(screen.getByText('118')).toBeInTheDocument()
+    expect(screen.getByText('41 credited ≥1 hint')).toBeInTheDocument()
+    expect(screen.getByText('25.0%')).toBeInTheDocument()
+    expect(screen.getByText('+3.1%')).toBeInTheDocument()
+  })
+
+  it('says "n/a" — not 0 — for an unmeasured reversal rate or holdout lift', () => {
+    setup({ attribution_health: { events_total: 0, credited_events: 0 } })
+
+    expect(screen.getAllByText('n/a')).toHaveLength(2)
+  })
+
+  it('formats cost per successful test to four decimals', () => {
+    // Runs cost fractions of a cent; two decimals would round most of them to
+    // $0.00 and make the figure useless.
+    setup({ learning_effectiveness: { cost_per_successful_test: 0.0593, total_executions: 122 } })
+
+    expect(screen.getByText('$0.0593')).toBeInTheDocument()
+    expect(screen.getByText('122 executions')).toBeInTheDocument()
+  })
+})
+
+describe('StatsTab — the four tables', () => {
+  it('names each trigger by its label rather than its raw key', () => {
+    setup({ trigger_activity: [{ trigger_type: 'trigger_1', total: 9, flagged: 2 }] })
+
+    expect(screen.getByText('Fix-after-fail (Case B)')).toBeInTheDocument()
+  })
+
+  it('falls back to the raw key for a trigger type it has no label for', () => {
+    // The backend owns these keys. A new one must still render, not vanish.
+    setup({ trigger_activity: [{ trigger_type: 'trigger_99_new', total: 1, flagged: 0 }] })
+
+    expect(screen.getByText('trigger_99_new')).toBeInTheDocument()
+  })
+
+  it('renders token counts with thousands separators and cost to four decimals', () => {
+    setup({
+      llm_cost: {
+        total_estimated_usd: 1.2345,
+        by_model: [{ model: 'gemini-3.5-flash', input_tokens: 1234567, output_tokens: 8901, calls: 42, estimated_cost_usd: 1.2345 }],
+      },
+    })
+
+    expect(screen.getByText('1,234,567')).toBeInTheDocument()
+    expect(screen.getByText('8,901')).toBeInTheDocument()
+    expect(screen.getByText('$1.2345')).toBeInTheDocument()
+  })
+
+  it('renders each table’s empty state when its list is absent', () => {
+    setup({})
+
+    expect(screen.getByText('Trigger activity (30d)')).toBeInTheDocument()
+    expect(screen.getByText('Review candidates')).toBeInTheDocument()
+    expect(screen.getByText('Never attributed')).toBeInTheDocument()
+  })
+})
+
+describe('the shared formatters', () => {
+  it('pctOrDash renders an em dash for null and undefined, not 0%', () => {
+    expect(pctOrDash(null)).toBe('—')
+    expect(pctOrDash(undefined)).toBe('—')
+    expect(pctOrDash(0)).toBe('0.0%')
+  })
+
+  it('pctOrDash scales a 0–1 fraction and honours the digits argument', () => {
+    expect(pctOrDash(0.9673)).toBe('96.7%')
+    expect(pctOrDash(0.9673, 2)).toBe('96.73%')
+  })
+
+  it('fmtLift always carries an explicit sign', () => {
+    expect(fmtLift(0.042)).toBe('+4.2%')
+    expect(fmtLift(0)).toBe('+0.0%')
+  })
+
+  it('fmtLift uses a typographic minus, not a hyphen', () => {
+    // U+2212. It lines up with the + in tabular numerals; a hyphen does not.
+    const out = fmtLift(-0.042)
+    expect(out).toBe('−4.2%')
+    expect(out.startsWith('-')).toBe(false)
+  })
+
+  it('fmtLift renders an em dash for an unknown lift', () => {
+    expect(fmtLift(null)).toBe('—')
+    expect(fmtLift(undefined)).toBe('—')
+  })
+
+  it('fmtWhen renders an em dash for a missing timestamp', () => {
+    expect(fmtWhen(null)).toBe('—')
+    expect(fmtWhen(undefined)).toBe('—')
+    expect(fmtWhen('')).toBe('—')
+  })
+
+  it('fmtWhen renders a real timestamp as a locale string', () => {
+    expect(fmtWhen('2026-09-05T10:00:00Z')).toBe(new Date('2026-09-05T10:00:00Z').toLocaleString())
+  })
+})

--- a/src/frontend-react/src/pages/learning/TriggersTab.test.tsx
+++ b/src/frontend-react/src/pages/learning/TriggersTab.test.tsx
@@ -1,0 +1,204 @@
+/**
+ * TriggersTab — the list of learning-trigger events, and one event's detail.
+ *
+ * The detail drawer's "Flag outcome" is the part that must not be simplified.
+ * It shows TWO lists: what the LLM recommended flagging, and what was actually
+ * flagged after the strong-history guard suppressed some of it. Collapsing
+ * them into one number would hide exactly the disagreement an operator opens
+ * this drawer to find — and "none — all suppressed" is a materially different
+ * outcome from "the LLM recommended nothing", which the same collapsed view
+ * would render identically.
+ */
+import { fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/lib/useFetch', () => ({ useFetch: vi.fn() }))
+
+import { useFetch } from '@/lib/useFetch'
+import TriggersTab from './TriggersTab'
+
+const mockUseFetch = vi.mocked(useFetch)
+afterEach(() => vi.resetAllMocks())
+
+const EVENT = {
+  id: 7, trigger_type: 'trigger_2', created_at: '2026-09-05T10:00:00Z',
+  status: 'succeeded', domain: 'flipkart.com', workflow_id: 'wf-full-id-0123456789abcdef',
+  tokens_in: 1234, tokens_out: 567, latency_ms: 890,
+}
+
+/**
+ * TYPE_FILTERS renders buttons labelled with the same strings the table cells
+ * use ("Feedback conflict" is both a filter and a row value), so every lookup
+ * has to say WHICH it means. This picks the table cell.
+ */
+function rowCell(text: string): HTMLElement {
+  const hit = screen.getAllByText(text).find(el => el.closest('td') !== null)
+  if (!hit) throw new Error(`no table cell with text ${text}`)
+  return hit
+}
+
+/** Route each path to its own payload: the list and the drawer both useFetch. */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function routeFetch(list: any, detail: any = null, opts: { loading?: boolean; error?: string } = {}) {
+  mockUseFetch.mockImplementation((path: string | null) => {
+    if (path?.includes('/triggers/')) {
+      return { data: detail, loading: opts.loading ?? false, error: opts.error ?? '', reload: vi.fn() }
+    }
+    return { data: list, loading: false, error: '', reload: vi.fn() }
+  })
+}
+
+describe('TriggersTab — the list', () => {
+  it('names each trigger by its label and counts the total', () => {
+    routeFetch({ total: 1, triggers: [EVENT] })
+
+    render(<TriggersTab />)
+
+    expect(screen.getByText('1 event')).toBeInTheDocument()
+    expect(rowCell('Feedback conflict')).toBeInTheDocument()
+  })
+
+  it('pluralises the count correctly', () => {
+    routeFetch({ total: 4, triggers: [EVENT, { ...EVENT, id: 8 }] })
+
+    render(<TriggersTab />)
+
+    expect(screen.getByText('4 events')).toBeInTheDocument()
+  })
+
+  it('shows the full workflow id on the row, never a truncation', () => {
+    routeFetch({ total: 1, triggers: [EVENT] })
+
+    render(<TriggersTab />)
+
+    expect(screen.getByText('wf-full-id-0123456789abcdef')).toBeInTheDocument()
+  })
+
+  it('explains an empty list rather than showing a bare blank table', () => {
+    routeFetch({ total: 0, triggers: [] })
+
+    render(<TriggersTab />)
+
+    expect(screen.getByText(/No trigger events recorded yet/)).toBeInTheDocument()
+  })
+
+  it('rebuilds its path from the type and since filters', () => {
+    routeFetch({ total: 0, triggers: [] })
+    render(<TriggersTab />)
+
+    fireEvent.change(screen.getByRole('combobox'), { target: { value: '7d' } })
+
+    expect(mockUseFetch).toHaveBeenCalledWith(expect.stringContaining('since=7d'))
+  })
+
+  it('drops the since parameter entirely for "All time"', () => {
+    // An empty `since` must not be sent as `since=`, which the endpoint would
+    // have to interpret.
+    routeFetch({ total: 0, triggers: [] })
+    render(<TriggersTab />)
+
+    fireEvent.change(screen.getByRole('combobox'), { target: { value: '' } })
+
+    const paths = mockUseFetch.mock.calls.map(c => c[0]).filter(p => typeof p === 'string' && p.includes('/triggers?'))
+    expect(paths.some(p => !String(p).includes('since='))).toBe(true)
+  })
+})
+
+describe('TriggerDrawer — opening one event', () => {
+  function openDrawer(detail: unknown, opts?: { loading?: boolean; error?: string }) {
+    routeFetch({ total: 1, triggers: [EVENT] }, detail, opts)
+    render(<TriggersTab />)
+    fireEvent.click(rowCell('Feedback conflict'))
+  }
+
+  it('titles the drawer with the event id and fetches that event', () => {
+    openDrawer({ trigger: EVENT, hint_texts: {} })
+
+    expect(screen.getByText('Trigger event #7')).toBeInTheDocument()
+    expect(mockUseFetch).toHaveBeenCalledWith('/api/learning/triggers/7')
+  })
+
+  it('shows a loading line, then the error if the read fails', () => {
+    openDrawer(null, { error: 'Org-admin access required' })
+
+    expect(screen.getByText('Org-admin access required')).toBeInTheDocument()
+  })
+
+  it('renders the status, domain and full workflow id', () => {
+    openDrawer({ trigger: EVENT, hint_texts: {} })
+
+    expect(screen.getAllByText('succeeded').length).toBeGreaterThan(0)
+    expect(screen.getAllByText('flipkart.com').length).toBeGreaterThan(0)
+  })
+
+  it('renders the LLM’s reasoning when there is any', () => {
+    openDrawer({ trigger: { ...EVENT, reason: 'two hints contradict each other' }, hint_texts: {} })
+
+    expect(screen.getByText('LLM reasoning')).toBeInTheDocument()
+    expect(screen.getByText('two hints contradict each other')).toBeInTheDocument()
+  })
+
+  it('renders an error message for a failed trigger', () => {
+    openDrawer({ trigger: { ...EVENT, status: 'error', error_message: 'model timed out' }, hint_texts: {} })
+
+    expect(screen.getByText('Error')).toBeInTheDocument()
+    expect(screen.getByText('model timed out')).toBeInTheDocument()
+  })
+})
+
+describe('TriggerDrawer — the flag outcome, recommended vs actual', () => {
+  function openWith(trigger: Record<string, unknown>, hint_texts = {}) {
+    routeFetch({ total: 1, triggers: [EVENT] }, { trigger: { ...EVENT, ...trigger }, hint_texts })
+    render(<TriggersTab />)
+    fireEvent.click(rowCell('Feedback conflict'))
+  }
+
+  it('shows what the LLM recommended and what was actually flagged', () => {
+    openWith({ flagged_hint_ids: [11, 12], actually_flagged_hint_ids: [11] })
+
+    expect(screen.getByText('Flag outcome')).toBeInTheDocument()
+    expect(screen.getByText('11, 12')).toBeInTheDocument()
+    expect(screen.getByText('11')).toBeInTheDocument()
+  })
+
+  it('says explicitly when the guard suppressed EVERY recommendation', () => {
+    // The distinction this whole section exists for: the LLM did recommend
+    // flagging, and the strong-history guard overruled it. Rendering an empty
+    // list here would read as "nothing was recommended".
+    openWith({ flagged_hint_ids: [11, 12], actually_flagged_hint_ids: [] })
+
+    expect(screen.getByText(/none — all suppressed by the strong-history guard/)).toBeInTheDocument()
+  })
+
+  it('omits the whole Flag outcome section when the LLM recommended nothing', () => {
+    // The section is gated on flagged_hint_ids?.length > 0 (TriggersTab.tsx:65),
+    // so its inner `|| '—'` fallback for an empty recommendation list is
+    // unreachable. Pre-existing and harmless - pinned here so the absence is
+    // documented rather than mistaken for a rendering bug.
+    openWith({ flagged_hint_ids: [], actually_flagged_hint_ids: [] })
+
+    expect(screen.queryByText('Flag outcome')).toBeNull()
+    expect(screen.queryByText(/all suppressed/)).toBeNull()
+  })
+
+  it('falls back to the recommended list when the actual list was not recorded', () => {
+    // Older rows predate actually_flagged_hint_ids; they must not render as
+    // "all suppressed", which would be a false accusation against the guard.
+    openWith({ flagged_hint_ids: [11], actually_flagged_hint_ids: undefined })
+
+    expect(screen.queryByText(/all suppressed/)).toBeNull()
+    expect(screen.getAllByText('11').length).toBeGreaterThan(0)
+  })
+
+  it('marks each hint as flagged, suppressed or credited', () => {
+    openWith(
+      { flagged_hint_ids: [11, 12], actually_flagged_hint_ids: [11], used_hint_ids: [12] },
+      { 11: 'first hint text', 12: 'second hint text' },
+    )
+
+    expect(screen.getByText('first hint text')).toBeInTheDocument()
+    expect(screen.getByText('second hint text')).toBeInTheDocument()
+    expect(screen.getByText('flagged')).toBeInTheDocument()
+    expect(screen.getByText('suppressed')).toBeInTheDocument()
+  })
+})

--- a/src/frontend-react/src/pages/metrics/MetricsCharts.test.tsx
+++ b/src/frontend-react/src/pages/metrics/MetricsCharts.test.tsx
@@ -42,14 +42,40 @@ const COST_VARIANTS = [
  * What "this variant survived that dataset" actually has to mean.
  *
  * `select.toHaveValue(key)` proves nothing — the select changes whether or not
- * the chart rendered. These three checks are what catch the real failure modes:
- * a variant that renders NOTHING on data the others handle, and a variant that
+ * the chart rendered. These checks are what catch the real failure modes: a
+ * variant that renders NOTHING on data the others handle, and a variant that
  * lets NaN or Infinity reach an SVG attribute, which recharts does not throw on
  * — it silently draws nothing, so the page looks fine and the chart is empty.
+ *
+ * Two things here are less obvious than they look, both found by diffing an
+ * all-zero multi-metric render against the same render with normalize()'s
+ * `max > 0 ?` guard deleted (the mutation that survived this file before):
+ *
+ * 1. `svg.recharts-surface` is not unique to the chart itself — every
+ *    <Legend> entry is ALSO rendered as its own `<svg class="recharts-surface"
+ *    width="14" height="14">` (a fixed decorative line-glyph, one per series),
+ *    and for every variant that renders a Legend it sits BEFORE the chart's
+ *    own svg in DOM order. A bare `document.querySelector('svg.recharts-surface')`
+ *    was therefore reading a 14×14 legend icon — whose markup never changes
+ *    with the data — for most of the 22 variants. The direct-child
+ *    combinator below is what actually reaches the chart: the legend icons
+ *    are nested inside `.recharts-legend-wrapper`, several levels down, so
+ *    they never match it.
+ * 2. Even pointed at the right node, an outerHTML string search for "NaN"
+ *    would still have missed the bug. recharts never writes that literal for
+ *    a shape whose own coordinates went NaN: d3-shape's line/area generator
+ *    returns `null` instead, and recharts maps that to `d: undefined`, which
+ *    React drops from the DOM rather than rendering as an empty attribute.
+ *    The <path> element survives with everything except its geometry — no
+ *    "NaN" substring anywhere, no missing element to count, just a shape with
+ *    no `d`. That is what the loop at the end checks directly. (Confirmed:
+ *    with the guard removed, the three normalized series — cost/time/llm —
+ *    each lost their `d` outright; only "success", never divided because it
+ *    is already a 0–100 percentage, kept its path.)
  */
 function assertChartIsSane(key: string, rowCount: number) {
   if (rowCount === 0) return          // an empty dataset legitimately draws nothing
-  const svg = document.querySelector('svg.recharts-surface')
+  const svg = document.querySelector<SVGSVGElement>('.recharts-wrapper > svg.recharts-surface')
   if (!svg) {
     // A variant may legitimately decline to draw - but only by SAYING so.
     // A silently blank card is the failure this helper exists to catch, and
@@ -61,6 +87,15 @@ function assertChartIsSane(key: string, rowCount: number) {
   const markup = svg.outerHTML
   expect(markup, `${key} leaked NaN into the SVG`).not.toMatch(/NaN/)
   expect(markup, `${key} leaked Infinity into the SVG`).not.toMatch(/Infinity/)
+
+  // Line, Area (both its stroke and its fill), Bar and Pie all render as a
+  // <path> carrying their computed geometry in `d`. A shape whose inputs went
+  // NaN keeps its element and its class but drops `d` (see above) — so
+  // "the element exists" is not the same claim as "it drew anything".
+  for (const shape of svg.querySelectorAll('path.recharts-curve, path.recharts-rectangle, path.recharts-sector')) {
+    const d = shape.getAttribute('d')
+    expect(d, `${key} drew a "${shape.getAttribute('class')}" with no geometry (d=${JSON.stringify(d)})`).toBeTruthy()
+  }
 }
 
 /** One located element, at the given locator fallback depth. */
@@ -80,13 +115,12 @@ function row(over: Partial<MetricsRow> = {}): MetricsRow {
 
 /** Four datasets that between them cover the shapes that break naive maths. */
 const DATASETS: [string, MetricsRow[]][] = [
-  ['a normal multi-row set', [row(), row({ workflow_id: 'wf-2', url: 'https://amazon.in/x', total_cost: 0.12, success: false })]],
+  ['a normal multi-row set', [row(), row({ workflow_id: 'wf-2', url: 'https://amazon.in/x', total_cost: 0.12 })]],
   ['a single row', [row()]],
   ['an empty set', []],
   ['rows with null urls and zeroed denominators', [
     row({ url: null, total_elements: 0, successful_elements: 0, failed_elements: 0,
-          total_llm_calls: 0, total_cost: 0, execution_time: 0,
-          prompt_tokens: 0, completion_tokens: 0 }),
+          total_llm_calls: 0, total_cost: 0, execution_time: 0 }),
   ]],
 ]
 

--- a/src/frontend-react/src/pages/metrics/MetricsCharts.test.tsx
+++ b/src/frontend-react/src/pages/metrics/MetricsCharts.test.tsx
@@ -1,0 +1,265 @@
+/**
+ * MetricsCharts — the two chart cards, all 22 variants.
+ *
+ * These are ports of the legacy canvas charts, and each variant is its own
+ * branch that reshapes the same rows a different way. The failure mode worth
+ * guarding is not "the chart looks wrong" — it is that one variant throws on a
+ * shape the others tolerate (a null url, a zero denominator, a single row, an
+ * empty set) and takes the whole page down with it. So every variant is driven
+ * against four hostile datasets rather than one happy one.
+ *
+ * recharts measures its container, and jsdom reports zero for everything, so
+ * ResponsiveContainer is replaced with one that hands its child a fixed size.
+ * Without that the charts render nothing and every assertion below would pass
+ * vacuously.
+ */
+import { cloneElement, type ReactElement } from 'react'
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('recharts', async importOriginal => {
+  const actual = await importOriginal<typeof import('recharts')>()
+  return {
+    ...actual,
+    ResponsiveContainer: ({ children }: { children: ReactElement }) =>
+      cloneElement(children, { width: 800, height: 400 }),
+  }
+})
+
+import { PerformanceChartCard, CostChartCard, type MetricsRow } from './MetricsCharts'
+
+const PERFORMANCE_VARIANTS = [
+  'exec-llm', 'cost-trend', 'success-trend', 'multi-metric', 'tokens',
+  'cost-efficiency', 'elements-bar', 'success-elements', 'element-efficiency',
+  'scatter', 'fallback-depth', 'llm-cleaning-rate', 'context-reduction',
+]
+const COST_VARIANTS = [
+  'cost-pie', 'cost-stacked', 'cost-comparison', 'domain-cost', 'llm-split',
+  'llm-histogram', 'workflow-radar', 'domain-performance', 'time-distribution',
+]
+
+/**
+ * What "this variant survived that dataset" actually has to mean.
+ *
+ * `select.toHaveValue(key)` proves nothing — the select changes whether or not
+ * the chart rendered. These three checks are what catch the real failure modes:
+ * a variant that renders NOTHING on data the others handle, and a variant that
+ * lets NaN or Infinity reach an SVG attribute, which recharts does not throw on
+ * — it silently draws nothing, so the page looks fine and the chart is empty.
+ */
+function assertChartIsSane(key: string, rowCount: number) {
+  if (rowCount === 0) return          // an empty dataset legitimately draws nothing
+  const svg = document.querySelector('svg.recharts-surface')
+  if (!svg) {
+    // A variant may legitimately decline to draw - but only by SAYING so.
+    // A silently blank card is the failure this helper exists to catch, and
+    // writing this check is how fallback-depth's empty state was found.
+    const explained = screen.queryByText(/^No .* (data|window)/i)
+    expect(explained, `${key} rendered neither a chart nor an explanation`).not.toBeNull()
+    return
+  }
+  const markup = svg.outerHTML
+  expect(markup, `${key} leaked NaN into the SVG`).not.toMatch(/NaN/)
+  expect(markup, `${key} leaked Infinity into the SVG`).not.toMatch(/Infinity/)
+}
+
+/** One located element, at the given locator fallback depth. */
+const el = (fallback_depth: number) => ({ fallback_depth, success: true })
+
+function row(over: Partial<MetricsRow> = {}): MetricsRow {
+  return {
+    workflow_id: 'wf-1', url: 'https://www.flipkart.com/search', timestamp: '2026-09-01T10:00:00Z',
+    total_llm_calls: 5, total_cost: 0.059, execution_time: 40.5,
+    total_elements: 4, successful_elements: 3, failed_elements: 1,
+    prompt_tokens: 12000, completion_tokens: 900, success: true,
+    browser_use_cost: 0.02, crewai_cost: 0.039,
+    browser_use_llm_calls: 3, crewai_llm_calls: 2,
+    ...over,
+  } as MetricsRow
+}
+
+/** Four datasets that between them cover the shapes that break naive maths. */
+const DATASETS: [string, MetricsRow[]][] = [
+  ['a normal multi-row set', [row(), row({ workflow_id: 'wf-2', url: 'https://amazon.in/x', total_cost: 0.12, success: false })]],
+  ['a single row', [row()]],
+  ['an empty set', []],
+  ['rows with null urls and zeroed denominators', [
+    row({ url: null, total_elements: 0, successful_elements: 0, failed_elements: 0,
+          total_llm_calls: 0, total_cost: 0, execution_time: 0,
+          prompt_tokens: 0, completion_tokens: 0 }),
+  ]],
+]
+
+describe('PerformanceChartCard — every variant against every shape', () => {
+  it.each(DATASETS)('renders all 13 performance variants for %s', (_label, rows) => {
+    render(<PerformanceChartCard rows={rows} />)
+    const select = screen.getByRole('combobox')
+
+    for (const key of PERFORMANCE_VARIANTS) {
+      fireEvent.change(select, { target: { value: key } })
+      assertChartIsSane(key, rows.length)
+    }
+  })
+})
+
+describe('CostChartCard — every variant against every shape', () => {
+  it.each(DATASETS)('renders all 9 cost variants for %s', (_label, rows) => {
+    render(<CostChartCard rows={rows} />)
+    const select = screen.getByRole('combobox')
+
+    for (const key of COST_VARIANTS) {
+      fireEvent.change(select, { target: { value: key } })
+      assertChartIsSane(key, rows.length)
+    }
+  })
+})
+
+describe('MetricsCharts — the cards themselves', () => {
+  it('offers all 13 performance options', () => {
+    render(<PerformanceChartCard rows={[row()]} />)
+
+    expect(screen.getAllByRole('option')).toHaveLength(13)
+    expect(screen.getByRole('option', { name: 'Execution Time & LLM Calls' })).toBeInTheDocument()
+  })
+
+  it('offers all 9 cost options', () => {
+    render(<CostChartCard rows={[row()]} />)
+
+    expect(screen.getAllByRole('option')).toHaveLength(9)
+    expect(screen.getByRole('option', { name: 'Cost Breakdown (Pie)' })).toBeInTheDocument()
+  })
+
+  it('starts each card on its first option', () => {
+    render(<PerformanceChartCard rows={[row()]} />)
+
+    expect(screen.getByRole('combobox')).toHaveValue('exec-llm')
+  })
+
+  it('renders both cards side by side without their selects colliding', () => {
+    // Two cards, two independent selects — changing one must not move the other.
+    render(<><PerformanceChartCard rows={[row()]} /><CostChartCard rows={[row()]} /></>)
+    const [perf, cost] = screen.getAllByRole('combobox')
+
+    fireEvent.change(perf, { target: { value: 'scatter' } })
+
+    expect(perf).toHaveValue('scatter')
+    expect(cost).toHaveValue('cost-pie')
+  })
+})
+
+describe('MetricsCharts — locator strategy distribution', () => {
+  it('explains the absence instead of drawing an empty chart', () => {
+    // element_approach_metrics is absent on most rows (it is written only when
+    // per-element data was captured). A blank card would read as a broken
+    // chart; this says the window has no data.
+    render(<PerformanceChartCard rows={[row()]} />)
+
+    fireEvent.change(screen.getByRole('combobox'), { target: { value: 'fallback-depth' } })
+
+    expect(screen.getByText('No per-element locator data in this window.')).toBeInTheDocument()
+    expect(document.querySelector('svg.recharts-surface')).toBeNull()
+  })
+
+  it('draws the distribution once any row carries per-element data', () => {
+    render(<PerformanceChartCard rows={[
+      row({ element_approach_metrics: [el(0), el(0), el(3)] } as Partial<MetricsRow>),
+      row({ workflow_id: 'wf-2', element_approach_metrics: [el(7)] } as Partial<MetricsRow>),
+    ]} />)
+
+    fireEvent.change(screen.getByRole('combobox'), { target: { value: 'fallback-depth' } })
+
+    expect(screen.queryByText('No per-element locator data in this window.')).toBeNull()
+    assertChartIsSane('fallback-depth', 2)
+  })
+
+  it('counts depths ACROSS rows, not per row', () => {
+    // The window total is what tells you the locator stack is degrading; a
+    // per-row reset would hide a fleet-wide shift to deep fallbacks.
+    render(<PerformanceChartCard rows={[
+      row({ element_approach_metrics: [el(7)] } as Partial<MetricsRow>),
+      row({ workflow_id: 'wf-2', element_approach_metrics: [el(7)] } as Partial<MetricsRow>),
+    ]} />)
+
+    fireEvent.change(screen.getByRole('combobox'), { target: { value: 'fallback-depth' } })
+
+    const labels = Array.from(document.querySelectorAll('.recharts-cartesian-axis-tick-value'))
+      .map(e => e.textContent)
+    expect(labels.some(l => l?.includes('Coordinate'))).toBe(true)
+  })
+})
+
+describe('MetricsCharts — domain grouping (domainOf)', () => {
+  it('groups by hostname with the www stripped', () => {
+    render(<CostChartCard rows={[
+      row({ url: 'https://www.flipkart.com/a' }),
+      row({ workflow_id: 'wf-2', url: 'https://flipkart.com/b' }),
+    ]} />)
+
+    fireEvent.change(screen.getByRole('combobox'), { target: { value: 'domain-cost' } })
+
+    // Both rows collapse to ONE domain: www. and bare are the same site, and
+    // two bars here would double-count a customer's spend.
+    const labels = Array.from(document.querySelectorAll('.recharts-cartesian-axis-tick-value'))
+      .map(el => el.textContent)
+    expect(labels.filter(l => l === 'flipkart.com')).toHaveLength(1)
+    expect(labels).not.toContain('www.flipkart.com')
+  })
+
+  it('labels a null url "unknown" rather than dropping the run', () => {
+    // The backend never fabricates a url. A run whose query named none still
+    // cost money, so it must appear in a cost-by-domain chart.
+    render(<CostChartCard rows={[row({ url: null })]} />)
+
+    fireEvent.change(screen.getByRole('combobox'), { target: { value: 'domain-cost' } })
+
+    const labels = Array.from(document.querySelectorAll('.recharts-cartesian-axis-tick-value'))
+      .map(el => el.textContent)
+    expect(labels).toContain('unknown')
+  })
+
+  it('survives a url that is not parseable at all', () => {
+    // `new URL()` throws on these; the catch falls back to a truncated string.
+    render(<CostChartCard rows={[row({ url: 'not a url at all ::::' })]} />)
+
+    fireEvent.change(screen.getByRole('combobox'), { target: { value: 'domain-cost' } })
+
+    // The catch falls back to a truncated raw string rather than dropping the run.
+    assertChartIsSane('domain-cost', 1)
+  })
+
+  it('survives an empty-string url', () => {
+    render(<CostChartCard rows={[row({ url: '' })]} />)
+
+    fireEvent.change(screen.getByRole('combobox'), { target: { value: 'domain-performance' } })
+
+    const labels = Array.from(document.querySelectorAll('.recharts-cartesian-axis-tick-value'))
+      .map(el => el.textContent)
+    expect(labels).toContain('unknown')
+  })
+})
+
+describe('MetricsCharts — normalize() against an all-zero series', () => {
+  it('does not divide by zero when every value is 0', () => {
+    // normalize() scales each series to its own max. With max 0 it must return
+    // the values untouched rather than producing NaN, which recharts renders
+    // as a blank chart with no error.
+    render(<PerformanceChartCard rows={[
+      row({ total_cost: 0, execution_time: 0, total_llm_calls: 0, total_elements: 0 }),
+      row({ workflow_id: 'wf-2', total_cost: 0, execution_time: 0, total_llm_calls: 0, total_elements: 0 }),
+    ]} />)
+
+    fireEvent.change(screen.getByRole('combobox'), { target: { value: 'multi-metric' } })
+
+    // 0/0 would be NaN, which recharts renders as an empty chart rather than
+    // an error - exactly the silent failure assertChartIsSane exists to catch.
+    assertChartIsSane('multi-metric', 2)
+  })
+
+  it('handles the radar variant on an all-zero row', () => {
+    render(<CostChartCard rows={[row({ total_cost: 0, execution_time: 0, total_llm_calls: 0, total_elements: 0 })]} />)
+
+    fireEvent.change(screen.getByRole('combobox'), { target: { value: 'workflow-radar' } })
+
+    assertChartIsSane('workflow-radar', 1)
+  })
+})

--- a/src/frontend-react/src/test/setup.ts
+++ b/src/frontend-react/src/test/setup.ts
@@ -7,6 +7,24 @@
  */
 import '@testing-library/jest-dom/vitest'
 import { cleanup } from '@testing-library/react'
-import { afterEach } from 'vitest'
+import { afterEach, vi } from 'vitest'
+
+// jsdom implements no matchMedia at all, and reading it throws rather than
+// returning undefined. useIsMobile and ThemeProvider both call it during their
+// first effect, so without this any test that mounts the sidebar or the theme
+// provider dies before its own assertions run. Defaults to "does not match",
+// i.e. desktop width and light mode; a test that cares overrides it.
+if (!window.matchMedia) {
+  window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  }))
+}
 
 afterEach(() => cleanup())

--- a/src/frontend-react/vite.config.ts
+++ b/src/frontend-react/vite.config.ts
@@ -32,12 +32,36 @@ export default defineConfig({
   // Unit tests for the pieces whose bugs are invisible in a type check: the
   // group-state hooks and the folder chip row, plus page components where
   // the wiring itself is the feature (LearningPage.test.tsx — see its own
-  // docstring). Deliberately narrow — still no browser suite, no coverage
-  // gate.
+  // docstring). No browser suite.
   test: {
     environment: 'jsdom',
     setupFiles: ['./src/test/setup.ts'],
     globals: false,
     css: false,
+    coverage: {
+      provider: 'v8',
+      // lcov is what SonarQube reads (sonar.javascript.lcov.reportPaths);
+      // text is for the terminal; json-summary lets a script assert on totals
+      // without re-parsing lcov.
+      reporter: ['text', 'lcov', 'json-summary'],
+      reportsDirectory: './coverage',
+      include: ['src/**/*.{ts,tsx}'],
+      exclude: [
+        // Vendored shadcn/ui. Not our code: it arrives generated, is not
+        // edited here, and testing it would measure the upstream project.
+        // Excluded from COVERAGE only — sonar still analyses it for defects.
+        'src/components/ui/**',
+        // Bootstrap and generated/ambient type surfaces: no branches to cover.
+        'src/main.tsx',
+        'src/vite-env.d.ts',
+        'src/**/*.d.ts',
+        'src/test/**',
+        'src/**/*.test.{ts,tsx}',
+      ],
+      // The gate. Set at the level the suite actually reaches so a regression
+      // fails CI rather than quietly eroding; raise it when coverage rises,
+      // never lower it to make a red run green.
+      thresholds: { lines: 80, functions: 80, branches: 80, statements: 80 },
+    },
   },
 })

--- a/src/frontend-react/vite.config.ts
+++ b/src/frontend-react/vite.config.ts
@@ -1,7 +1,7 @@
 /// <reference types="vitest/config" />
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
-import path from 'path'
+import path from 'node:path'
 
 export default defineConfig({
   plugins: [react()],

--- a/tests/test_api/test_feedback_can_retract.py
+++ b/tests/test_api/test_feedback_can_retract.py
@@ -8,11 +8,14 @@ may act on a hint they wrote — list_hints/get_hint stay gated on
 is_dashboard_viewer (a deliberate non-change; widening those would open a
 cross-user visibility surface the permission design relies on not existing).
 
-The three columns the predicate needs (org_id, created_by_user_id, is_active)
-travel from the engine to this handler only. They must never reach the
-response body, so one test pins the exact key set of a correction item — an
-explicit projection built field-by-field, not the row dict with keys
-deleted, so a column added to that SELECT later cannot leak silently.
+Two of the columns the predicate needs (org_id, created_by_user_id) travel
+from the engine to this handler only and must never reach the response
+body. A third, is_active, also travels that path, but it now reaches the
+client too, as active — the caller already reads the hint's own text, and
+the backend already discloses the same state in the hint_inactive message.
+One test pins the exact key set of a correction item — an explicit
+projection built field-by-field, not the row dict with keys deleted, so a
+column added to that SELECT later cannot leak silently.
 
 can_retract is an OFFER of an action, not just a permission check.
 hint_mutation_verdict answers who may act on a hint; it says nothing about
@@ -140,12 +143,26 @@ class TestCanRetract:
         assert body["corrections"][0]["can_retract"] is True
 
     def test_the_raw_permission_columns_never_reach_the_client(self):
-        """org_id, created_by_user_id and is_active feed the can_retract
-        computation but are not part of the client's contract."""
+        """org_id and created_by_user_id feed the can_retract computation but
+        are not part of the client's contract. is_active feeds the same
+        computation and now also reaches the client, as active."""
         body = _get([_row(author_id=_AUTHOR["user_id"])], caller=_AUTHOR)
 
         assert set(body["corrections"][0].keys()) == {
-            "hint_id", "feedback_text", "recorded_at", "can_retract"}
+            "hint_id", "feedback_text", "recorded_at", "active", "can_retract"}
+
+    def test_active_mirrors_is_active_for_the_client(self):
+        """active is a direct mirror of is_active, computed independently of
+        hint_mutation_verdict — unlike can_retract, which ANDs the two
+        together."""
+        inactive = _get(
+            [_row(author_id=_AUTHOR["user_id"], is_active=0)], caller=_AUTHOR)
+        assert inactive["corrections"][0]["active"] is False
+        assert inactive["corrections"][0]["can_retract"] is False
+
+        active = _get(
+            [_row(author_id=_AUTHOR["user_id"], is_active=1)], caller=_AUTHOR)
+        assert active["corrections"][0]["active"] is True
 
     def test_a_token_less_caller_is_offered_nothing(self):
         """Minor 9. AUTH_ENFORCED off resolves an anonymous request to None,
@@ -282,6 +299,8 @@ class TestCanRetractReflectsHintState:
         before = self._get_as(client, app, _AUTHOR)
         assert before["corrections"][0]["can_retract"] is True, (
             "sanity: the seeded hint starts active and the author may act on it")
+        assert before["corrections"][0]["active"] is True, (
+            "sanity: same fact, from the field a client actually reads")
 
         app.dependency_overrides[require_user] = lambda: _AUTHOR
         retract_resp = client.post(
@@ -298,13 +317,17 @@ class TestCanRetractReflectsHintState:
         assert item["can_retract"] is False, (
             "a retracted hint must not still offer Retract to its own "
             "author on the next page load — this is the defect being fixed")
+        assert item["active"] is False, (
+            "the reload proves active flips too, not just can_retract — end "
+            "to end against real Postgres, not the mocked projection above")
         assert item["feedback_text"] == "wait for the spinner", (
             "the row must still be RETURNED — get_corrections_for_run stays "
             "unfiltered on is_active, so a retracted hint is still the "
             "user's own recorded words, not hidden")
         assert set(item.keys()) == {
-            "hint_id", "feedback_text", "recorded_at", "can_retract"}, (
-            "is_active must not have joined the response body")
+            "hint_id", "feedback_text", "recorded_at", "active", "can_retract"}, (
+            "active joined the response body; org_id and created_by_user_id "
+            "still must not")
 
         # Property of the HINT's state, not the caller's tier: an org admin
         # and a platform admin, who would otherwise pass

--- a/tests/test_build_manifests.py
+++ b/tests/test_build_manifests.py
@@ -57,6 +57,21 @@ def _libdoc_version(library: str) -> str:
     return json.loads(path.read_text(encoding="utf-8"))["version"]
 
 
+def _run_shell(steps: list[dict]) -> str:
+    """Join steps' `run:` bodies, dropping shell-comment lines first.
+
+    This repo's comments are checkable claims: a `#`-commented command is not
+    an invocation, so it must not satisfy an "X runs" assertion just because
+    the text is present. A `run: |` block's own `#` lines land in `run:` and
+    would otherwise read as a real command; a YAML `#` comment above a step
+    never reaches `run:` at all, so this only ever strips the former.
+    """
+    return "\n".join(
+        line for s in steps for line in s.get("run", "").splitlines()
+        if not line.strip().startswith("#")
+    )
+
+
 def test_playwright_pin_matches_between_bench_venv_and_shipped_image():
     """The bench must resolve locators on the engine the image ships."""
     bench = _pin(_read("requirements-bus.txt"), "playwright", "requirements-bus.txt")
@@ -129,7 +144,7 @@ def test_the_publish_gate_job_exists_and_runs_the_suite():
         f"build-images.yml has no '{GATE_JOB}' job — nothing stops a red suite "
         "from publishing images")
     steps = wf["jobs"][GATE_JOB].get("steps", [])
-    run_text = "\n".join(s.get("run", "") for s in steps)
+    run_text = _run_shell(steps)
     assert "pytest" in run_text, f"the '{GATE_JOB}' job does not run pytest"
 
 
@@ -173,7 +188,7 @@ def test_the_frontend_publish_gate_exists_and_runs_the_suite():
         f"build-images.yml has no '{FRONTEND_GATE_JOB}' job — nothing runs the "
         "frontend suite before its image is published")
     steps = wf["jobs"][FRONTEND_GATE_JOB].get("steps", [])
-    run_text = "\n".join(s.get("run", "") for s in steps)
+    run_text = _run_shell(steps)
     assert FRONTEND_COVERAGE_SCRIPT in run_text, (
         f"the '{FRONTEND_GATE_JOB}' job does not run '{FRONTEND_COVERAGE_SCRIPT}' — "
         "vitest only evaluates vite.config.ts's coverage thresholds under "
@@ -200,6 +215,11 @@ def test_the_shared_coverage_script_actually_measures_coverage():
         f"src/frontend-react/package.json's '{script_name}' script no longer "
         "runs vitest with --coverage, so vite.config.ts's thresholds would "
         "silently stop being evaluated in both CI lanes")
+    assert "vitest" in scripts[script_name], (
+        f"src/frontend-react/package.json's '{script_name}' script does not "
+        "invoke vitest at all - '--coverage' could belong to any other "
+        "command (e.g. 'echo --coverage'), so its presence alone does not "
+        "prove coverage is measured")
 
 
 def test_the_frontend_image_waits_for_the_frontend_suite():
@@ -216,8 +236,8 @@ def test_the_frontend_gate_checks_out_without_persisting_the_token():
     """actions/checkout writes GITHUB_TOKEN into .git/config unless told not to.
 
     This job then runs code the pull request itself authored - `npm ci` executes
-    lifecycle scripts from the PR's package.json, and `npm test` runs its test
-    files - so anything the PR wants can read that token off disk. No step in
+    lifecycle scripts from the PR's package.json, and `npm run test:coverage`
+    runs its test files - so anything the PR wants can read that token off disk. No step in
     the job needs git authentication afterwards. check-browser-service-release.yml
     already sets this for the same reason.
     """
@@ -398,13 +418,13 @@ def test_the_sonar_workflow_produces_the_lcov_before_it_scans():
     wf = yaml.safe_load(SONAR_WORKFLOW.read_text(encoding="utf-8"))
     steps = wf["jobs"]["sonarqube"]["steps"]
     names = [s.get("name") or s.get("uses", "") for s in steps]
-    runs = "\n".join(s.get("run", "") for s in steps)
+    runs = _run_shell(steps)
     assert FRONTEND_COVERAGE_SCRIPT in runs, (
         "sonarqube.yml never generates the frontend lcov it tells Sonar to read")
     scan = next(i for i, s in enumerate(steps)
                 if "sonarqube-scan-action" in s.get("uses", ""))
     cov = next((i for i, s in enumerate(steps)
-                if FRONTEND_COVERAGE_SCRIPT in s.get("run", "")), None)
+                if FRONTEND_COVERAGE_SCRIPT in _run_shell([s])), None)
     assert cov is not None, (
         f"no step in sonarqube.yml runs '{FRONTEND_COVERAGE_SCRIPT}' — the lcov "
         "SonarQube reads would never be produced")
@@ -423,7 +443,7 @@ def test_the_sonar_workflow_rewrites_lcov_paths_to_repo_root():
     """
     steps = __import__("yaml").safe_load(
         SONAR_WORKFLOW.read_text(encoding="utf-8"))["jobs"]["sonarqube"]["steps"]
-    runs = chr(10).join(s.get("run", "") for s in steps)
+    runs = _run_shell(steps)
     assert "SF:src/frontend-react/src/" in runs, (
         "sonarqube.yml does not rewrite the lcov paths to repo-root-relative - "
         "Sonar will silently report src/frontend-react as 0% covered")

--- a/tests/test_build_manifests.py
+++ b/tests/test_build_manifests.py
@@ -208,3 +208,95 @@ def test_the_frontend_gate_runs_the_same_node_major_as_the_image_build():
     assert all(v.split(".")[0] == image_major for v in versions), (
         f"'{FRONTEND_GATE_JOB}' runs Node {versions} but Dockerfile.frontend "
         f"builds on node:{image_major}")
+
+
+# ---------------------------------------------------------------------------
+# SonarQube's view of the frontend.
+#
+# src/frontend-react was excluded from Sonar analysis entirely while it had no
+# test harness. It has one now, so the exclusion came off and lcov is wired in.
+# Both halves are silent when broken, which is why they are guarded here:
+#
+#   - Sonar does NOT fail when an lcov path is missing. It reports the whole SPA
+#     as 0% covered, which fails the new-code gate on every frontend PR for a
+#     reason that looks nothing like the cause.
+#   - Re-adding src/frontend-react to sonar.exclusions would make the analysis
+#     pass by not looking, which is how this started.
+# ---------------------------------------------------------------------------
+
+SONAR_PROPS = REPO_ROOT / "sonar-project.properties"
+SONAR_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "sonarqube.yml"
+
+
+def _sonar_props() -> dict[str, str]:
+    out: dict[str, str] = {}
+    for line in SONAR_PROPS.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, _, value = line.partition("=")
+        out[key.strip()] = value.strip()
+    return out
+
+
+def test_the_frontend_is_not_excluded_from_sonar_analysis():
+    excl = _sonar_props().get("sonar.exclusions", "")
+    offenders = [
+        p for p in excl.split(",")
+        if p.strip().startswith("src/frontend-react")
+        and not p.strip().startswith(("src/frontend-react/dist", "src/frontend-react/coverage"))
+    ]
+    assert not offenders, (
+        f"sonar.exclusions hides frontend SOURCE from analysis: {offenders}. "
+        "Build output and coverage output may be excluded; source may not.")
+
+
+def test_sonar_reads_the_frontend_lcov():
+    props = _sonar_props()
+    assert props.get("sonar.javascript.lcov.reportPaths") == "src/frontend-react/coverage/lcov.info", (
+        "sonar.javascript.lcov.reportPaths is missing or wrong — Sonar would "
+        "silently report the SPA as 0% covered rather than failing")
+
+
+def test_vendored_shadcn_is_excluded_from_coverage_but_not_from_analysis():
+    props = _sonar_props()
+    cov_excl = props.get("sonar.coverage.exclusions", "")
+    assert "src/frontend-react/src/components/ui/**" in cov_excl, (
+        "vendored shadcn/ui must be excluded from COVERAGE (it is generated and "
+        "never edited here) — but it must stay in analysis, since it ships")
+
+
+def test_the_sonar_workflow_produces_the_lcov_before_it_scans():
+    import yaml
+    wf = yaml.safe_load(SONAR_WORKFLOW.read_text(encoding="utf-8"))
+    steps = wf["jobs"]["sonarqube"]["steps"]
+    names = [s.get("name") or s.get("uses", "") for s in steps]
+    runs = "\n".join(s.get("run", "") for s in steps)
+    assert "vitest run --coverage" in runs, (
+        "sonarqube.yml never generates the frontend lcov it tells Sonar to read")
+    scan = next(i for i, s in enumerate(steps)
+                if "sonarqube-scan-action" in s.get("uses", ""))
+    cov = next(i for i, s in enumerate(steps)
+               if "vitest run --coverage" in s.get("run", ""))
+    assert cov < scan, (
+        f"the frontend coverage step (index {cov}) must run BEFORE the scan "
+        f"(index {scan}), or the lcov does not exist when Sonar reads it")
+    assert names, "sonarqube job has no steps"
+
+
+def test_the_sonar_workflow_rewrites_lcov_paths_to_repo_root():
+    """vitest writes lcov paths relative to ITS OWN root, so every record reads
+    `SF:src/App.tsx`. Sonar resolves those against the repo root, where `src/`
+    is the PYTHON backend - measured 2026-09-05, all 41 records unresolvable
+    and the SPA reported as 0% covered, with no error from Sonar. The rewrite
+    is what makes the lcov usable, and it is one `sed` away from being lost.
+    """
+    steps = __import__("yaml").safe_load(
+        SONAR_WORKFLOW.read_text(encoding="utf-8"))["jobs"]["sonarqube"]["steps"]
+    runs = chr(10).join(s.get("run", "") for s in steps)
+    assert "SF:src/frontend-react/src/" in runs, (
+        "sonarqube.yml does not rewrite the lcov paths to repo-root-relative - "
+        "Sonar will silently report src/frontend-react as 0% covered")
+    assert "exit 1" in runs, (
+        "the lcov rewrite is not verified in CI; a partial rewrite would pass "
+        "silently and produce a wrong coverage number rather than a failure")

--- a/tests/test_build_manifests.py
+++ b/tests/test_build_manifests.py
@@ -243,10 +243,50 @@ def test_the_coverage_script_guards_against_an_empty_coverage_map():
         (REPO_ROOT / "src" / "frontend-react" / "package.json").read_text(encoding="utf-8"))
     script_name = FRONTEND_COVERAGE_SCRIPT.split(" ")[-1]
     scripts = package_json.get("scripts", {})
-    assert "assert-coverage-not-empty.mjs" in scripts.get(script_name, ""), (
-        f"src/frontend-react/package.json's '{script_name}' script no longer "
-        "invokes assert-coverage-not-empty.mjs - a collapsed coverage map "
-        "would once again exit 0 in both CI lanes")
+    # Chained with `&&` specifically, not `;` and not `|| true`: `;` would run
+    # the checker even after vitest itself failed (masking a real test
+    # failure as a coverage pass/fail), and `|| true` would restore exit 0
+    # after the checker caught a collapsed map. Only `&&` makes the checker's
+    # exit code the script's exit code.
+    assert "&& node scripts/assert-coverage-not-empty.mjs" in scripts.get(script_name, ""), (
+        f"src/frontend-react/package.json's '{script_name}' script does not "
+        "chain assert-coverage-not-empty.mjs with `&&` - a `;` would run the "
+        "checker even when vitest already failed, and `|| true` would swallow "
+        "the checker's own failure, so a collapsed coverage map would once "
+        "again exit 0 in both CI lanes")
+
+
+# The floor the two CI lanes enforce - the value must never be lowered to make
+# a red run green (matches vite.config.ts's own comment on `thresholds`).
+FRONTEND_COVERAGE_THRESHOLD_FLOOR = 80
+
+
+def test_the_coverage_thresholds_are_not_silently_gutted():
+    """`--coverage` MEASURES coverage; vite.config.ts's `thresholds` is the only
+    thing that GATES it. Nothing in this file otherwise reads vite.config.ts,
+    so a threshold silently zeroed, lowered or deleted would leave every test
+    above green while both CI lanes pass on collapsed coverage.
+    """
+    vite_config = _read("src/frontend-react/vite.config.ts")
+    match = re.search(r"thresholds:\s*\{([^}]*)\}", vite_config)
+    assert match, (
+        "src/frontend-react/vite.config.ts has no `thresholds` block under "
+        "coverage - without it, `--coverage` measures and reports but gates "
+        "nothing, so both CI lanes go green on collapsed coverage")
+
+    thresholds_body = match.group(1)
+    for metric in ("lines", "functions", "branches", "statements"):
+        metric_match = re.search(rf"\b{metric}\s*:\s*(\d+)", thresholds_body)
+        assert metric_match, (
+            f"vite.config.ts's `thresholds` has no `{metric}` metric - without "
+            "it, that metric is never gated and both CI lanes go green on "
+            "collapsed coverage for it")
+        value = int(metric_match.group(1))
+        assert value >= FRONTEND_COVERAGE_THRESHOLD_FLOOR, (
+            f"vite.config.ts's `thresholds.{metric}` is {value}, below the "
+            f"floor of {FRONTEND_COVERAGE_THRESHOLD_FLOOR} - lowering it "
+            "weakens the only real gate on frontend coverage and both CI "
+            "lanes would go green on a regression")
 
 
 def test_the_frontend_image_waits_for_the_frontend_suite():

--- a/tests/test_build_manifests.py
+++ b/tests/test_build_manifests.py
@@ -164,10 +164,12 @@ def test_every_image_build_waits_for_the_suite(job):
 # The FRONTEND publish gate.
 #
 # Until test-frontend existed, no workflow ran a single frontend test. Both
-# pytest lanes are backend-only, and sonar-project.properties excludes
-# src/frontend-react outright, so the only thing standing between a broken
-# React change and a published frontend image was `tsc -b` inside
-# Dockerfile.frontend. That catches a type error and nothing else.
+# pytest lanes are backend-only, and sonar-project.properties excluded
+# src/frontend-react outright at the time, so the only thing standing between a
+# broken React change and a published frontend image was `tsc -b` inside
+# Dockerfile.frontend. That catches a type error and nothing else. That
+# exclusion is gone now, and test_the_frontend_is_not_excluded_from_sonar_analysis
+# below is what keeps it gone.
 #
 # Guarded for the same reason as the backend gate above: a `needs:` line and a
 # test command are exactly what gets dropped while making a job faster.

--- a/tests/test_build_manifests.py
+++ b/tests/test_build_manifests.py
@@ -187,6 +187,25 @@ def test_the_frontend_image_waits_for_the_frontend_suite():
         "publish an image built from React code the frontend suite rejected")
 
 
+def test_the_frontend_gate_checks_out_without_persisting_the_token():
+    """actions/checkout writes GITHUB_TOKEN into .git/config unless told not to.
+
+    This job then runs code the pull request itself authored - `npm ci` executes
+    lifecycle scripts from the PR's package.json, and `npm test` runs its test
+    files - so anything the PR wants can read that token off disk. No step in
+    the job needs git authentication afterwards. check-browser-service-release.yml
+    already sets this for the same reason.
+    """
+    steps = _build_images_workflow()["jobs"][FRONTEND_GATE_JOB].get("steps", [])
+    checkouts = [s for s in steps if s.get("uses", "").startswith("actions/checkout")]
+    assert checkouts, f"'{FRONTEND_GATE_JOB}' has no checkout step"
+    for s in checkouts:
+        assert s.get("with", {}).get("persist-credentials") is False, (
+            f"'{FRONTEND_GATE_JOB}' checks out with credential persistence on, "
+            "then runs pull-request-authored npm scripts and tests that can read "
+            "the token out of .git/config")
+
+
 def test_the_frontend_gate_runs_the_same_node_major_as_the_image_build():
     # A suite that passes on a different Node major than the image builds on is
     # not a gate on the thing being shipped. Dockerfile.frontend's build stage

--- a/tests/test_build_manifests.py
+++ b/tests/test_build_manifests.py
@@ -275,8 +275,21 @@ def test_the_coverage_thresholds_are_not_silently_gutted():
         "nothing, so both CI lanes go green on collapsed coverage")
 
     thresholds_body = match.group(1)
+    # This repo's habit when changing a number is to leave the previous
+    # value behind in a `//` comment, e.g.:
+    #   // was lines: 80, functions: 80, branches: 80, statements: 80
+    #   lines: 0, functions: 0, branches: 0, statements: 0,
+    # A bare substring search finds the commented-out 80 before the real 0.
+    # Strip `//` comments per physical line first, then split on commas so
+    # each metric's declaration starts its own line - re.M anchors the
+    # search to that start, so a metric can only match its own live value,
+    # never a substring surviving in a comment or inside another metric's
+    # entry.
+    code_only = "\n".join(
+        line.split("//", 1)[0] for line in thresholds_body.splitlines())
+    declarations = "\n".join(code_only.split(","))
     for metric in ("lines", "functions", "branches", "statements"):
-        metric_match = re.search(rf"\b{metric}\s*:\s*(\d+)", thresholds_body)
+        metric_match = re.search(rf"^\s*{metric}\s*:\s*(\d+)", declarations, re.MULTILINE)
         assert metric_match, (
             f"vite.config.ts's `thresholds` has no `{metric}` metric - without "
             "it, that metric is never gated and both CI lanes go green on "

--- a/tests/test_build_manifests.py
+++ b/tests/test_build_manifests.py
@@ -143,3 +143,68 @@ def test_every_image_build_waits_for_the_suite(job):
     assert GATE_JOB in needs, (
         f"'{job}' does not depend on '{GATE_JOB}' — it can publish an image "
         "built from code the suite rejected")
+
+
+# ---------------------------------------------------------------------------
+# The FRONTEND publish gate.
+#
+# Until test-frontend existed, no workflow ran a single frontend test. Both
+# pytest lanes are backend-only, and sonar-project.properties excludes
+# src/frontend-react outright, so the only thing standing between a broken
+# React change and a published frontend image was `tsc -b` inside
+# Dockerfile.frontend. That catches a type error and nothing else.
+#
+# Guarded for the same reason as the backend gate above: a `needs:` line and a
+# test command are exactly what gets dropped while making a job faster.
+# ---------------------------------------------------------------------------
+
+FRONTEND_GATE_JOB = "test-frontend"
+
+
+def test_the_frontend_publish_gate_exists_and_runs_the_suite():
+    wf = _build_images_workflow()
+    assert FRONTEND_GATE_JOB in wf["jobs"], (
+        f"build-images.yml has no '{FRONTEND_GATE_JOB}' job — nothing runs the "
+        "frontend suite before its image is published")
+    steps = wf["jobs"][FRONTEND_GATE_JOB].get("steps", [])
+    run_text = "\n".join(s.get("run", "") for s in steps)
+    # `npm test` is package.json's `vitest run`; accept either spelling so the
+    # job may call vitest directly without silently losing the gate.
+    assert "npm test" in run_text or "vitest" in run_text, (
+        f"the '{FRONTEND_GATE_JOB}' job does not run the frontend suite")
+    assert "tsc" in run_text, (
+        f"the '{FRONTEND_GATE_JOB}' job does not typecheck — tsc is the only "
+        "check that covers the TSX the suite does not reach")
+
+
+def test_the_frontend_image_waits_for_the_frontend_suite():
+    wf = _build_images_workflow()
+    needs = wf["jobs"]["build-frontend"].get("needs", [])
+    if isinstance(needs, str):
+        needs = [needs]
+    assert FRONTEND_GATE_JOB in needs, (
+        f"'build-frontend' does not depend on '{FRONTEND_GATE_JOB}' — it can "
+        "publish an image built from React code the frontend suite rejected")
+
+
+def test_the_frontend_gate_runs_the_same_node_major_as_the_image_build():
+    # A suite that passes on a different Node major than the image builds on is
+    # not a gate on the thing being shipped. Dockerfile.frontend's build stage
+    # is the authority.
+    import re
+    wf = _build_images_workflow()
+    dockerfile = (REPO_ROOT / "Dockerfile.frontend").read_text(encoding="utf-8")
+    m = re.search(r"^FROM\s+node:(\d+)", dockerfile, re.MULTILINE)
+    assert m, "Dockerfile.frontend has no `FROM node:<major>` build stage"
+    image_major = m.group(1)
+
+    steps = wf["jobs"][FRONTEND_GATE_JOB].get("steps", [])
+    versions = [
+        str(s["with"]["node-version"])
+        for s in steps
+        if s.get("uses", "").startswith("actions/setup-node") and "node-version" in s.get("with", {})
+    ]
+    assert versions, f"'{FRONTEND_GATE_JOB}' does not pin a Node version"
+    assert all(v.split(".")[0] == image_major for v in versions), (
+        f"'{FRONTEND_GATE_JOB}' runs Node {versions} but Dockerfile.frontend "
+        f"builds on node:{image_major}")

--- a/tests/test_build_manifests.py
+++ b/tests/test_build_manifests.py
@@ -160,6 +160,12 @@ def test_every_image_build_waits_for_the_suite(job):
 
 FRONTEND_GATE_JOB = "test-frontend"
 
+# The shared coverage invocation both CI lanes must call. vite.config.ts's
+# coverage thresholds are only evaluated when vitest runs with `--coverage` -
+# a bare `npm test` (or `vitest run`) exits 0 without checking them at all, so
+# "the suite ran" is not proof the thresholds were enforced.
+FRONTEND_COVERAGE_SCRIPT = "npm run test:coverage"
+
 
 def test_the_frontend_publish_gate_exists_and_runs_the_suite():
     wf = _build_images_workflow()
@@ -168,13 +174,32 @@ def test_the_frontend_publish_gate_exists_and_runs_the_suite():
         "frontend suite before its image is published")
     steps = wf["jobs"][FRONTEND_GATE_JOB].get("steps", [])
     run_text = "\n".join(s.get("run", "") for s in steps)
-    # `npm test` is package.json's `vitest run`; accept either spelling so the
-    # job may call vitest directly without silently losing the gate.
-    assert "npm test" in run_text or "vitest" in run_text, (
-        f"the '{FRONTEND_GATE_JOB}' job does not run the frontend suite")
+    assert FRONTEND_COVERAGE_SCRIPT in run_text, (
+        f"the '{FRONTEND_GATE_JOB}' job does not run '{FRONTEND_COVERAGE_SCRIPT}' — "
+        "vitest only evaluates vite.config.ts's coverage thresholds under "
+        "--coverage, so without it this job publishes images on collapsed "
+        "coverage")
     assert "tsc" in run_text, (
         f"the '{FRONTEND_GATE_JOB}' job does not typecheck — tsc is the only "
         "check that covers the TSX the suite does not reach")
+
+
+def test_the_shared_coverage_script_actually_measures_coverage():
+    # Both workflows above call FRONTEND_COVERAGE_SCRIPT by name and trust it to
+    # run vitest with --coverage. Without this test, both lanes could be pointed
+    # at a script that silently stopped measuring coverage and nothing here
+    # would notice.
+    package_json = json.loads(
+        (REPO_ROOT / "src" / "frontend-react" / "package.json").read_text(encoding="utf-8"))
+    script_name = FRONTEND_COVERAGE_SCRIPT.split(" ")[-1]
+    scripts = package_json.get("scripts", {})
+    assert script_name in scripts, (
+        f"src/frontend-react/package.json has no '{script_name}' script — "
+        f"'{FRONTEND_COVERAGE_SCRIPT}' would fail in CI")
+    assert "--coverage" in scripts[script_name], (
+        f"src/frontend-react/package.json's '{script_name}' script no longer "
+        "runs vitest with --coverage, so vite.config.ts's thresholds would "
+        "silently stop being evaluated in both CI lanes")
 
 
 def test_the_frontend_image_waits_for_the_frontend_suite():
@@ -374,12 +399,15 @@ def test_the_sonar_workflow_produces_the_lcov_before_it_scans():
     steps = wf["jobs"]["sonarqube"]["steps"]
     names = [s.get("name") or s.get("uses", "") for s in steps]
     runs = "\n".join(s.get("run", "") for s in steps)
-    assert "vitest run --coverage" in runs, (
+    assert FRONTEND_COVERAGE_SCRIPT in runs, (
         "sonarqube.yml never generates the frontend lcov it tells Sonar to read")
     scan = next(i for i, s in enumerate(steps)
                 if "sonarqube-scan-action" in s.get("uses", ""))
-    cov = next(i for i, s in enumerate(steps)
-               if "vitest run --coverage" in s.get("run", ""))
+    cov = next((i for i, s in enumerate(steps)
+                if FRONTEND_COVERAGE_SCRIPT in s.get("run", "")), None)
+    assert cov is not None, (
+        f"no step in sonarqube.yml runs '{FRONTEND_COVERAGE_SCRIPT}' — the lcov "
+        "SonarQube reads would never be produced")
     assert cov < scan, (
         f"the frontend coverage step (index {cov}) must run BEFORE the scan "
         f"(index {scan}), or the lcov does not exist when Sonar reads it")

--- a/tests/test_build_manifests.py
+++ b/tests/test_build_manifests.py
@@ -222,6 +222,33 @@ def test_the_shared_coverage_script_actually_measures_coverage():
         "prove coverage is measured")
 
 
+# A run with an empty coverage map still exits 0: vitest reports
+# "All files | 0 | 0 | 0 | 0" and every threshold trivially "passes" against
+# zero measured files. The checker script closes that gap; this test makes
+# sure the script keeps existing and stays wired into test:coverage, since
+# both are silent failure modes (a missing/renamed file, or a script edited
+# back to the bare `vitest run --coverage` form) that no other test here would
+# catch.
+COVERAGE_EMPTY_MAP_CHECKER = "src/frontend-react/scripts/assert-coverage-not-empty.mjs"
+
+
+def test_the_coverage_script_guards_against_an_empty_coverage_map():
+    checker_path = REPO_ROOT / COVERAGE_EMPTY_MAP_CHECKER
+    assert checker_path.exists(), (
+        f"{COVERAGE_EMPTY_MAP_CHECKER} is missing - nothing would fail a "
+        "test:coverage run whose coverage.include matches no file, even "
+        "though vitest itself exits 0 on an empty coverage map")
+
+    package_json = json.loads(
+        (REPO_ROOT / "src" / "frontend-react" / "package.json").read_text(encoding="utf-8"))
+    script_name = FRONTEND_COVERAGE_SCRIPT.split(" ")[-1]
+    scripts = package_json.get("scripts", {})
+    assert "assert-coverage-not-empty.mjs" in scripts.get(script_name, ""), (
+        f"src/frontend-react/package.json's '{script_name}' script no longer "
+        "invokes assert-coverage-not-empty.mjs - a collapsed coverage map "
+        "would once again exit 0 in both CI lanes")
+
+
 def test_the_frontend_image_waits_for_the_frontend_suite():
     wf = _build_images_workflow()
     needs = wf["jobs"]["build-frontend"].get("needs", [])

--- a/tests/test_build_manifests.py
+++ b/tests/test_build_manifests.py
@@ -285,6 +285,89 @@ def test_vendored_shadcn_is_excluded_from_coverage_but_not_from_analysis():
         "never edited here) — but it must stay in analysis, since it ships")
 
 
+def _ant_match(path: str, pattern: str) -> bool:
+    """Approximate Sonar's ant path matching well enough for the patterns here.
+
+    `**` spans directories and `*` does not, but every pattern this repo uses is
+    either `<dir>/**` or `**/*.<ext>`, for which collapsing both to ".*" gives
+    the same answer.
+    """
+    import re
+    rx = re.escape(pattern).replace(r"\*\*", ".*").replace(r"\*", ".*")
+    return re.fullmatch(rx, path) is not None
+
+
+def _sonar_scope(path: str) -> str:
+    """Which scope Sonar puts `path` in: 'test', 'source', or 'dropped'.
+
+    sonar.tests sets where test code is looked for; sonar.test.inclusions then
+    NARROWS that set. A file under sonar.tests that matches no inclusion is not
+    a test - and if it is not under sonar.sources either, it leaves the analysis
+    entirely.
+    """
+    props = _sonar_props()
+    csv = lambda k: [v.strip() for v in props.get(k, "").split(",") if v.strip()]
+
+    under = lambda roots: any(path == r or path.startswith(r.rstrip("/") + "/") for r in roots)
+    test_incl = csv("sonar.test.inclusions")
+    matches_test_incl = any(_ant_match(path, p) for p in test_incl)
+    if under(csv("sonar.tests")):
+        if not test_incl or matches_test_incl:
+            if not any(_ant_match(path, p) for p in csv("sonar.test.exclusions")):
+                return "test"
+    # A file matching sonar.test.inclusions is never indexed as source, whether
+    # or not a sonar.tests root reaches it - so an inclusion without a matching
+    # root removes the file from the analysis instead of reclassifying it.
+    # Confirmed on PR #100: app-header.test.tsx and tests/test_build_manifests.py
+    # were both changed by the PR and neither is indexed, while GeneratePage.tsx
+    # and useFetch.ts from the same diff are both indexed as FIL.
+    if under(csv("sonar.sources")) and not matches_test_incl:
+        if not any(_ant_match(path, p) for p in csv("sonar.exclusions")):
+            return "source"
+    return "dropped"
+
+
+def test_the_python_suite_is_still_in_sonars_test_scope():
+    """Adding sonar.test.inclusions for the frontend silently emptied it.
+
+    sonar.test.inclusions narrows sonar.tests, so `**/*.test.ts,**/*.test.tsx`
+    matched no Python file and dropped the entire tests/ tree out of the
+    analysis. Measured on PR #100: SonarCloud indexed 0 unit-test files against
+    the PR while the main branch indexed 187, and Sonar reported nothing wrong.
+    """
+    for path in ("tests/test_build_manifests.py", "tests/test_api/test_feedback_can_retract.py"):
+        assert (REPO_ROOT / path).exists(), f"{path} moved; pick another real test file"
+        assert _sonar_scope(path) == "test", (
+            f"{path} is not in Sonar's test scope - the Python suite is being "
+            "analysed as though it did not exist")
+
+
+def test_the_frontend_suite_is_in_sonars_test_scope():
+    """A test.inclusions pattern with no sonar.tests root behind it deletes files.
+
+    `**/*.test.tsx` matched every frontend test and took them out of the source
+    scope, but nothing put them into the test scope, so 37 files and ~7,300
+    lines simply left the analysis. Measured on PR #100: app-header.test.tsx is
+    in the diff and is not indexed at all, while GeneratePage.tsx and
+    useFetch.ts from the same diff are indexed as FIL.
+    """
+    path = "src/frontend-react/src/components/app-header.test.tsx"
+    assert (REPO_ROOT / path).exists(), f"{path} moved; pick another real test file"
+    assert _sonar_scope(path) == "test", (
+        f"{path} is not in Sonar's test scope - the frontend suite is either "
+        "graded as production code or dropped from the analysis entirely")
+
+
+def test_frontend_production_code_is_still_analysed_as_source():
+    # The counterweight: whatever pulls the test files out must not take the
+    # pages with them. This is the file carrying most of the PR's Sonar issues.
+    path = "src/frontend-react/src/pages/GeneratePage.tsx"
+    assert (REPO_ROOT / path).exists(), f"{path} moved; pick another real page"
+    assert _sonar_scope(path) == "source", (
+        f"{path} left the source scope - the SPA would stop being analysed, "
+        "which is exactly the exclusion this branch removed")
+
+
 def test_the_sonar_workflow_produces_the_lcov_before_it_scans():
     import yaml
     wf = yaml.safe_load(SONAR_WORKFLOW.read_text(encoding="utf-8"))


### PR DESCRIPTION
## What was wrong

`GET /api/feedback/{run_id}` sent no lifecycle state. A correction whose hint had since
been switched off — by an org admin, by auto-disable, or by an LLM review — rendered in the
feedback panel exactly like a live one: the user's own words, no marker, and the sentence
*"You already sent this for this run — it won't be counted again."*

The backend already knew better. `get_run_corrections` selects `is_active` to gate
`can_retract`, and the resend path's own `hint_inactive` outcome says the hint is
*"currently switched off"*. The panel just never saw the bit.

Second gap: that panel lives only on the Generate page. Open the same run in History a day
later and there was nothing at all about feedback — no answer to *"did my correction
register?"*

## What this does

- **`active` on the payload.** `get_run_corrections` forwards the `is_active` it already
  selects. `org_id` and `created_by_user_id` stay server-only — they were never content.
- **A `— switched off` marker in the panel**, in strict precedence: the client-only
  retracted marker (this session's own click, which knows *who*) beats `active === false`
  (everything else that can flip the bit, which the client can't attribute), which beats
  nothing. The branch is `active === false`, never `!active`, so a missing field — an older
  backend, or the learning-disabled response — renders exactly as it does today.
- **`RecordedCorrections.tsx`**, a read-only presentational component: heading, quoted
  text, switched-off marker. No Retract button, no per-row error, no props to configure a
  control, because the drawer offers no action on these rows. The Generate panel keeps its
  own list markup (it still owns Retract, the retract error and the client-only retracted
  marker) but imports the component module's two exported strings instead of a second
  hand-typed copy — that shared import is the anti-drift mechanism between the surfaces.
- **The History drawer** now fetches `GET /api/feedback/{run_id}` alongside the run detail.
  On a re-run, the list is prefixed with the original run's full, never-truncated id,
  matching the header's existing treatment.

## A 403 here is expected, and renders nothing

`GET /api/history/{run_id}` passes `is_grouped=true`, so a colleague's shared run opens in
the drawer. `GET /api/feedback/{run_id}` deliberately does not — publishing a test never
publishes the corrections filed against it. So the feedback read 403s on exactly the runs
the history read allows. The drawer renders nothing in that case, same as for an empty
list: silence claims nothing.

That is why the staleness guard folds in **`error`** as well as `loading`. `useFetch` never
clears `data` in its catch branch, and `loading` settles back to `false` once the failed
attempt lands — so a guard on `loading` alone closes the window while a newly-selected
row's fetch is in flight, but reopens it once that fetch fails, leaving the *previous*
run's correction text (and a "filed against the original run" notice that may not even be
true) rendering under the new row. Unlike the in-flight window, that one does not
self-correct. The commit history has the red/green for it.

The last commit closes the matching window on the other side: `d`, the run-detail fetch's
own freshness signal, now governs the corrections derivation too, so the single render
between `selected` changing and `useFetch`'s effect firing shows nothing rather than the
previous run's text.

## Tests

`3,991 passed, 9 skipped` on the CI-equivalent invocation both workflows use
(`pytest tests/ --ignore=tests/test_integration`), and `687 passed` / 37 files on the
frontend suite. The backend figure was `3,977` before the coverage-gate commits below
added their guards.

Locally the same command reports 12 additional failures, all in `tests/test_clients/`.
That directory is gitignored (`.gitignore:83`) and untracked — `git ls-files
tests/test_clients/` is empty — so CI never checks it out. It fails here only because
`clients/inextrix/` does not exist on this machine.

One further caveat, stated rather than buried: a full local run *including* integration
saw `test_live_crew.py::TestLiveLLMCrewOnline::test_llm_monitor_is_per_workflow` fail once.
It passes in isolation and passes with its whole file (11/11). It makes a real LLM call and
asserts `total_responses >= 1`, so a transient is the likely cause, but I could not
reproduce it and am not claiming a diagnosis. Both CI lanes ignore `tests/test_integration`,
and this branch touches neither `agents.py` nor `crew.py`, where monitor sharing lives.

The drawer tests were checked for vacuity, not just for green: every pre-existing drawer
test was an absence-assertion, and mutating the corrections derivation to a hardcoded `[]`
— which disables this feature entirely — left 136/136 passing. Two presence-asserting tests
were added, mutation-verified red, then restored green.

## Verified live

Through rebuilt `-local` images and a real browser: submit → `active: true`; retract →
`active: false`; resend → `outcome: hint_inactive`; History drawer rendering
`"…" — switched off`. Probe rows were deleted afterwards and the learning store verified
back to pre-state (36 hints, 0 evidence, 30 audit).

Note for reviewers: the running Docker stack was rebuilt from this branch, so `nlrf-fastapi`
and `nlrf-frontend` are currently on `feat/feedback-visibility`, not `develop`.

## Also on this branch

**The `useFetch` staleness fix** (`9b9836a`). It never cleared `data` in its catch
branch. Keeping it is right when the failure was a refetch of the *same* path — the last
good view of one screen under a banner, which six call sites render on purpose. It was
wrong when the data belonged to a *different* path, because then it is another request's
answer. Three sites were reachable and wrong: LearningPage's hints table, LearningPage's
runs table (which also kept showing the previous filter's "N runs" count), and
TriggersTab's list. Each builds its path from a filter that changes while mounted and
renders `{error && …}` and `{data && …}` as siblings, not as an early return.

Four candidate implementations were measured, not argued. Committed React states on a
filter change, recorded via an effect with no dep array:

| | filter change → success | filter change → failure | same-path `reload()` fails |
|---|---|---|---|
| current | `ROWS(122)→ROWS(48)` | `ROWS(122)+ERR` ← the defect | `ROWS(122)+ERR` |
| **scoped (shipped)** | `ROWS(122)→ROWS(48)` | `ERR-ONLY` | `ROWS(122)+ERR` |
| reset-on-path-change | `BLANK→LOADING→ROWS(48)` | `ERR-ONLY` | `ROWS(122)+ERR` |
| clear-on-every-error | `ROWS(122)→ROWS(48)` | `ERR-ONLY` | `ERR-ONLY` |

All three fixes close the defect. Reset-on-path-change blanks the table on every
*successful* filter change and every debounced keystroke, defeating the
`{loading && !data && …}` guard that LearningPage:367 and TriggersTab:218 wrote for
exactly that purpose. Clear-on-every-error wipes the table when a same-path `reload()`
fails — which is LearningPage's `act()` after every unflag/retract/reactivate. Only the
scoped form is correct in all three columns. TanStack Query's `keepPreviousData` solves
this by scoping its cache to the query key, the same idea; adopting it for one hook is
not proportionate.

The other 13 call sites are unreachable or already guarded: ten have a constant path,
`LearningPage.tsx:538` early-returns on error, and this branch's own two drawer fetches
gate on `d`/`loading`/`error`. The three that look like the same shape (`HintDrawer`,
`RunDrawer`, the trigger drawer) each mount behind `{id != null && …}` inside a Sheet
whose `SheetContent` always renders a full-viewport `SheetOverlay`, with no
`modal={false}` anywhere — so their id can only go A → null → B, which unmounts.

`useFetch` had **no test file** while being called from 16 places, which is why this
survived. It has one now — 16 tests. Exactly the three cross-path-failure tests were
red before the change; the six pinning existing behaviour were green throughout. Those
nine were the count at `9b9836a`; `760b561` then added seven more — the StrictMode,
path-through-null and teardown cases the first pass reasoned about but never ran.

**The unopenable re-run-of id gets its copy control back** (`637222a`). The id rule is
unconditional — full *and* click-to-copy. The drawer's re-run-of line satisfied it only
on the accessible branch, where the id is a button because it navigates. The
inaccessible branch drops the link correctly (it would 404) but dropped the copy with
it. That is the case where copying earns the most: the only thing left to do with an id
you cannot open is hand it to someone who can. `setup()` in `HistoryPage.test.tsx`
hardcoded the run-detail payload, so no test could reach either re-run branch; it takes
a third parameter now. Pre-existing defect, not introduced here.

## The frontend coverage gate actually gates now

Review of this branch found the coverage thresholds it introduced were enforced nowhere
that mattered, in three separate layers. Each was reproduced before it was fixed.

**The publish gate never evaluated them.** `test-frontend` — the job `build-frontend`
lists in `needs:` — ran `npm test`, which is `vitest run` with no `--coverage`, so vitest
skipped threshold evaluation entirely. Only `sonarqube.yml` ran the coverage form, and
that is a separate workflow with independent triggers and no `needs` link: it *races*
`build-images.yml` on a push rather than gating it. Measured, with thresholds temporarily
set to 99: `npm test` exit 0, `npx vitest run --coverage` exit 1. So coverage could
collapse and `-develop` images would still publish — the same race
`tests/test_build_manifests.py` already documents for the backend gate.

Both lanes now call one shared `test:coverage` npm script, so the two cannot drift.

**An empty coverage map passed.** With `coverage.include` edited to match no file,
`vitest run --coverage` printed `All files | 0 | 0 | 0 | 0`, wrote a summary with zero
file entries and `"pct":"Unknown"`, and **exited 0**. `scripts/assert-coverage-not-empty.mjs`
is chained onto `test:coverage` and fails that case, using the `json-summary` reporter
that `vite.config.ts` already emitted for exactly this purpose.

**The threshold values themselves were unguarded.** Zeroing them to `0/0/0/0` left every
guard test green — the guards proved coverage was *measured*, never that it was *gated*.
A guard now asserts all four metrics stay at 80 or above.

Each guard was verified by mutation, red then green: reverting either lane to a
non-coverage invocation; commenting the command out inside a `run: |` block (the guards
now strip shell comments before matching, so a `#`-ed command no longer satisfies them);
swapping `&&` for `;`; renaming or unchaining the checker; zeroing, lowering or deleting
the thresholds; and pointing `coverage.include` at nothing.

`sonar.coverage.exclusions` now also scopes `src/frontend-react/scripts/**` — CI tooling
that runs *after* the test run, so it can never carry coverage — on the same principle as
`main.tsx` already in that list. It stays inside `sonar.sources`, so it is still analysed
for defects.

## Known follow-ups, still not in this branch

- **The 403 path is unit-tested and gate-read, but never driven in a browser** — it needs
  a second account and a run published into a shared folder.
- **"What did the system learn from me"** — correction → hint → injected → helped/failed
  → retired. All recorded, all admin-only today. Parked deliberately: exposing
  `conflict_flagged` means telling a user an LLM overruled them, and the counters are
  *event* counters, so "helped 12 times" could be one query re-run twelve times.
  `hint_evidence` diversity counts are the honest figure.

## One thing not to conclude from this

`hint_evidence` had 0 rows before this work, so the "Already recorded" card has never
rendered for a real correction. That is a reason to watch the feature after merge, not
evidence that anything is fine. Nothing in the live database is customer traffic — it is
all the owner's own testing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - History details now display corrections recorded for a run.
  - Corrections indicate when they have been switched off.
  - Inaccessible original run IDs can still be copied for reference.

- **Bug Fixes**
  - Feedback controls and duplicate-submission messages now accurately reflect correction status.
  - Resubmitting switched-off feedback now explains that it will not reactivate the correction.
  - Prevented stale results from appearing when loading different or failed requests.
  - Learning decisions now handle canceled prompts correctly and trim notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
